### PR TITLE
Improved TrustChain crawler

### DIFF
--- a/ipv8/attestation/identity/community.py
+++ b/ipv8/attestation/identity/community.py
@@ -27,15 +27,15 @@ class IdentityCommunity(TrustChainCommunity):
         """
         self.known_attestation_hashes[hash] = (name, time(), public_key)
 
-    def should_sign(self, payload):
-        _, transaction = decode(payload.transaction)
+    def should_sign(self, block):
+        transaction = block.transaction
         requested_keys = set(transaction.keys())
         if requested_keys != {"hash", "name", "date"}:
             return False
         hash = transaction['hash']
         if hash not in self.known_attestation_hashes:
             return False
-        if payload.public_key != self.known_attestation_hashes[hash][2]:
+        if block.public_key != self.known_attestation_hashes[hash][2]:
             return False
         # Refuse to sign blocks older than 5 minutes
         if time() > self.known_attestation_hashes[hash][1] + 300:

--- a/ipv8/attestation/trustchain/block.py
+++ b/ipv8/attestation/trustchain/block.py
@@ -60,6 +60,20 @@ class TrustChainBlock(object):
                     payload.link_public_key, payload.link_sequence_number, payload.previous_hash,
                     payload.signature, time.time()], serializer)
 
+    @classmethod
+    def from_pair_payload(cls, payload, serializer):
+        """
+        Create two half blocks from a block pair message, according to a given payload and serializer.
+        Used to construct two blocks when receiving a block pair from the network.
+        """
+        block1 = cls([payload.transaction1, payload.public_key1, payload.sequence_number1,
+                      payload.link_public_key1, payload.link_sequence_number1, payload.previous_hash1,
+                      payload.signature1, time.time()], serializer)
+        block2 = cls([payload.transaction2, payload.public_key2, payload.sequence_number2,
+                      payload.link_public_key2, payload.link_sequence_number2, payload.previous_hash2,
+                      payload.signature2, time.time()], serializer)
+        return block1, block2
+
     def __str__(self):
         # This makes debugging and logging easier
         return "Block {0} from ...{1}:{2} links ...{3}:{4} for {5}".format(

--- a/ipv8/attestation/trustchain/block.py
+++ b/ipv8/attestation/trustchain/block.py
@@ -1,5 +1,7 @@
 from hashlib import sha256
 
+import time
+
 from ...keyvault.crypto import ECCrypto
 from ...messaging.deprecated.encoding import decode, encode
 from ...messaging.serialization import Serializer
@@ -48,6 +50,16 @@ class TrustChainBlock(object):
                 self.signature = str(self.signature)
         self.serializer = serializer
 
+    @classmethod
+    def from_payload(cls, payload, serializer):
+        """
+        Create a block according to a given payload and serializer.
+        This method can be used when receiving a block from the network.
+        """
+        return cls([payload.transaction, payload.public_key, payload.sequence_number,
+                    payload.link_public_key, payload.link_sequence_number, payload.previous_hash,
+                    payload.signature, time.time()], serializer)
+
     def __str__(self):
         # This makes debugging and logging easier
         return "Block {0} from ...{1}:{2} links ...{3}:{4} for {5}".format(
@@ -69,6 +81,13 @@ class TrustChainBlock(object):
     @property
     def hash(self):
         return sha256(self.pack()).digest()
+
+    @property
+    def hash_number(self):
+        """
+        Return the hash of this block as a number (used as crawl ID).
+        """
+        return int(self.hash.encode('hex'), 16) % 100000000L
 
     def pack(self, signature=True):
         """

--- a/ipv8/attestation/trustchain/caches.py
+++ b/ipv8/attestation/trustchain/caches.py
@@ -1,0 +1,36 @@
+import logging
+import sys
+
+from ipv8.requestcache import NumberCache
+
+
+class CrawlRequestCache(NumberCache):
+    """
+    This request cache keeps track of outstanding crawl requests.
+    """
+    CRAWL_TIMEOUT = 5.0
+
+    def __init__(self, community, crawl_id, crawl_deferred):
+        super(CrawlRequestCache, self).__init__(community.request_cache, u"crawl", crawl_id)
+        self.logger = logging.getLogger(self.__class__.__name__)
+        self.community = community
+        self.crawl_deferred = crawl_deferred
+        self.received_half_blocks = []
+        self.total_half_blocks_expected = sys.maxint
+
+    @property
+    def timeout_delay(self):
+        return CrawlRequestCache.CRAWL_TIMEOUT
+
+    def received_block(self, block, total_count):
+        self.received_half_blocks.append(block)
+        self.total_half_blocks_expected = total_count
+
+        if len(self.received_half_blocks) >= self.total_half_blocks_expected:
+            self.community.request_cache.pop(u"crawl", self.number)
+            self.crawl_deferred.callback(self.received_half_blocks)
+
+    def on_timeout(self):
+        self._logger.info("Timeout for crawl with id %d", self.number)
+        self.community.request_cache.pop(u"crawl", self.number)
+        self.crawl_deferred.callback(self.received_half_blocks)

--- a/ipv8/attestation/trustchain/payload.py
+++ b/ipv8/attestation/trustchain/payload.py
@@ -72,6 +72,42 @@ class HalfBlockPayload(Payload):
         return HalfBlockPayload(*args)
 
 
+class HalfBlockBroadcastPayload(HalfBlockPayload):
+    """
+    Payload for a message that contains a half block and a TTL field for broadcasts.
+    """
+
+    format_list = ['74s', 'I', '74s', 'I', '32s', '64s', 'varlenI', 'I']
+
+    def __init__(self, public_key, sequence_number, link_public_key, link_sequence_number, previous_hash,
+                 signature, transaction, ttl):
+        super(HalfBlockBroadcastPayload, self).__init__(public_key, sequence_number, link_public_key,
+                                                        link_sequence_number, previous_hash, signature, transaction)
+        self.ttl = ttl
+
+    @classmethod
+    def from_half_block(cls, block, ttl):
+        return HalfBlockBroadcastPayload(
+            block.public_key,
+            block.sequence_number,
+            block.link_public_key,
+            block.link_sequence_number,
+            block.previous_hash,
+            block.signature,
+            block.transaction,
+            ttl
+        )
+
+    def to_pack_list(self):
+        data = super(HalfBlockBroadcastPayload, self).to_pack_list()
+        data.append(('I', self.ttl))
+        return data
+
+    @classmethod
+    def from_unpack_list(cls, *args):
+        return HalfBlockBroadcastPayload(*args)
+
+
 class CrawlResponsePayload(Payload):
     """
     Payload for the response to a crawl request.
@@ -194,3 +230,50 @@ class HalfBlockPairPayload(Payload):
     @classmethod
     def from_unpack_list(cls, *args):
         return HalfBlockPairPayload(*args)
+
+
+class HalfBlockPairBroadcastPayload(HalfBlockPairPayload):
+    """
+    Payload for a broadcast message that ships two half blocks
+    """
+
+    format_list = ['74s', 'I', '74s', 'I', '32s', '64s', 'varlenI'] * 2 + ['I']
+
+    def __init__(self, public_key1, sequence_number1, link_public_key1, link_sequence_number1, previous_hash1,
+                 signature1, transaction1, public_key2, sequence_number2, link_public_key2, link_sequence_number2,
+                 previous_hash2, signature2, transaction2, ttl):
+        super(HalfBlockPairBroadcastPayload, self).__init__(public_key1, sequence_number1, link_public_key1,
+                                                            link_sequence_number1, previous_hash1, signature1,
+                                                            transaction1, public_key2, sequence_number2,
+                                                            link_public_key2, link_sequence_number2, previous_hash2,
+                                                            signature2, transaction2)
+        self.ttl = ttl
+
+    @classmethod
+    def from_half_blocks(cls, block1, block2, ttl):
+        return HalfBlockPairBroadcastPayload(
+            block1.public_key,
+            block1.sequence_number,
+            block1.link_public_key,
+            block1.link_sequence_number,
+            block1.previous_hash,
+            block1.signature,
+            block1.transaction,
+            block2.public_key,
+            block2.sequence_number,
+            block2.link_public_key,
+            block2.link_sequence_number,
+            block2.previous_hash,
+            block2.signature,
+            block2.transaction,
+            ttl
+        )
+
+    def to_pack_list(self):
+        data = super(HalfBlockPairBroadcastPayload, self).to_pack_list()
+        data.append(('I', self.ttl))
+        return data
+
+    @classmethod
+    def from_unpack_list(cls, *args):
+        return HalfBlockPairBroadcastPayload(*args)

--- a/ipv8/attestation/trustchain/payload.py
+++ b/ipv8/attestation/trustchain/payload.py
@@ -45,7 +45,7 @@ class HalfBlockPayload(Payload):
         self.transaction = transaction
 
     @classmethod
-    def from_block(cls, block):
+    def from_half_block(cls, block):
         return HalfBlockPayload(
             block.public_key,
             block.sequence_number,
@@ -125,3 +125,72 @@ class CrawlResponsePayload(Payload):
     @classmethod
     def from_unpack_list(cls, *args):
         return CrawlResponsePayload(*args)
+
+
+class HalfBlockPairPayload(Payload):
+    """
+    Payload for message that ships two half blocks
+    """
+
+    format_list = ['74s', 'I', '74s', 'I', '32s', '64s', 'varlenI'] * 2
+
+    def __init__(self, public_key1, sequence_number1, link_public_key1, link_sequence_number1, previous_hash1,
+                 signature1, transaction1, public_key2, sequence_number2, link_public_key2, link_sequence_number2,
+                 previous_hash2, signature2, transaction2):
+        super(HalfBlockPairPayload, self).__init__()
+        self.public_key1 = public_key1
+        self.sequence_number1 = sequence_number1
+        self.link_public_key1 = link_public_key1
+        self.link_sequence_number1 = link_sequence_number1
+        self.previous_hash1 = previous_hash1
+        self.signature1 = signature1
+        self.transaction1 = transaction1
+
+        self.public_key2 = public_key2
+        self.sequence_number2 = sequence_number2
+        self.link_public_key2 = link_public_key2
+        self.link_sequence_number2 = link_sequence_number2
+        self.previous_hash2 = previous_hash2
+        self.signature2 = signature2
+        self.transaction2 = transaction2
+
+    @classmethod
+    def from_half_blocks(cls, block1, block2):
+        return HalfBlockPairPayload(
+            block1.public_key,
+            block1.sequence_number,
+            block1.link_public_key,
+            block1.link_sequence_number,
+            block1.previous_hash,
+            block1.signature,
+            block1.transaction,
+            block2.public_key,
+            block2.sequence_number,
+            block2.link_public_key,
+            block2.link_sequence_number,
+            block2.previous_hash,
+            block2.signature,
+            block2.transaction
+        )
+
+    def to_pack_list(self):
+        data = [('74s', self.public_key1),
+                ('I', self.sequence_number1),
+                ('74s', self.link_public_key1),
+                ('I', self.link_sequence_number1),
+                ('32s', self.previous_hash1),
+                ('64s', self.signature1),
+                ('varlenI', encode(self.transaction1)),
+                ('74s', self.public_key2),
+                ('I', self.sequence_number2),
+                ('74s', self.link_public_key2),
+                ('I', self.link_sequence_number2),
+                ('32s', self.previous_hash2),
+                ('64s', self.signature2),
+                ('varlenI', encode(self.transaction2))]
+
+        return data
+
+    @classmethod
+    def from_unpack_list(cls, *args):
+        return HalfBlockPairPayload(*args)

--- a/ipv8/attestation/trustchain/payload.py
+++ b/ipv8/attestation/trustchain/payload.py
@@ -9,20 +9,21 @@ class CrawlRequestPayload(Payload):
 
     format_list = ['74s', 'l', 'I']
 
-    def __init__(self, requested_sequence_number):
+    def __init__(self, requested_sequence_number, crawl_id):
         super(CrawlRequestPayload, self).__init__()
         self.requested_sequence_number = requested_sequence_number
+        self.crawl_id = crawl_id
 
     def to_pack_list(self):
         data = [('74s', '0'*74),
                 ('l', self.requested_sequence_number),
-                ('I', 10)]
+                ('I', self.crawl_id)]
 
         return data
 
     @classmethod
-    def from_unpack_list(cls, public_key, sequence_number, limit):
-        return CrawlRequestPayload(sequence_number)
+    def from_unpack_list(cls, public_key, sequence_number, crawl_id):
+        return CrawlRequestPayload(sequence_number, crawl_id)
 
 
 class HalfBlockPayload(Payload):
@@ -33,7 +34,7 @@ class HalfBlockPayload(Payload):
     format_list = ['74s', 'I', '74s', 'I', '32s', '64s', 'varlenI']
 
     def __init__(self, public_key, sequence_number, link_public_key, link_sequence_number, previous_hash,
-                         signature, transaction):
+                 signature, transaction):
         super(HalfBlockPayload, self).__init__()
         self.public_key = public_key
         self.sequence_number = sequence_number
@@ -69,3 +70,58 @@ class HalfBlockPayload(Payload):
     @classmethod
     def from_unpack_list(cls, *args):
         return HalfBlockPayload(*args)
+
+
+class CrawlResponsePayload(Payload):
+    """
+    Payload for the response to a crawl request.
+    """
+
+    format_list = ['74s', 'I', '74s', 'I', '32s', '64s', 'varlenI', 'I', 'I', 'I']
+
+    def __init__(self, public_key, sequence_number, link_public_key, link_sequence_number, previous_hash, signature,
+                 transaction, crawl_id, cur_count, total_count):
+        super(CrawlResponsePayload, self).__init__()
+        self.public_key = public_key
+        self.sequence_number = sequence_number
+        self.link_public_key = link_public_key
+        self.link_sequence_number = link_sequence_number
+        self.previous_hash = previous_hash
+        self.signature = signature
+        self.transaction = transaction
+        self.crawl_id = crawl_id
+        self.cur_count = cur_count
+        self.total_count = total_count
+
+    @classmethod
+    def from_crawl(cls, block, crawl_id, cur_count, total_count):
+        return CrawlResponsePayload(
+            block.public_key,
+            block.sequence_number,
+            block.link_public_key,
+            block.link_sequence_number,
+            block.previous_hash,
+            block.signature,
+            block.transaction,
+            crawl_id,
+            cur_count,
+            total_count,
+        )
+
+    def to_pack_list(self):
+        data = [('74s', self.public_key),
+                ('I', self.sequence_number),
+                ('74s', self.link_public_key),
+                ('I', self.link_sequence_number),
+                ('32s', self.previous_hash),
+                ('64s', self.signature),
+                ('varlenI', encode(self.transaction)),
+                ('I', self.crawl_id),
+                ('I', self.cur_count),
+                ('I', self.total_count)]
+
+        return data
+
+    @classmethod
+    def from_unpack_list(cls, *args):
+        return CrawlResponsePayload(*args)

--- a/test/attestation/trustchain/test_community.py
+++ b/test/attestation/trustchain/test_community.py
@@ -246,3 +246,44 @@ class TestTrustChainCommunity(TestBase):
 
         self.assertTrue(self.nodes[1].overlay.persistence.get_latest(block1.public_key))
         self.assertTrue(self.nodes[1].overlay.persistence.get_latest(block2.public_key))
+
+    @twisted_wrapper
+    def test_broadcast_half_block(self):
+        """
+        Test broadcasting a half block
+        """
+        yield self.introduce_nodes()
+
+        # Let node 3 discover node 2.
+        node3 = self.create_node()
+        self.nodes[1].network.add_verified_peer(node3.my_peer)
+        self.nodes[1].discovery.take_step()
+
+        block = TestBlock()
+        self.nodes[0].overlay.send_block(block)
+
+        yield self.deliver_messages()
+
+        self.assertTrue(node3.overlay.relayed_broadcasts)
+
+    @twisted_wrapper
+    def test_broadcast_half_block_pair(self):
+        """
+        Test broadcasting a half block pair
+        """
+        yield self.introduce_nodes()
+
+        # Let node 3 discover node 2.
+        node3 = self.create_node()
+        self.nodes[1].network.add_verified_peer(node3.my_peer)
+        self.nodes[1].discovery.take_step()
+
+        block1 = TestBlock()
+        block2 = TestBlock()
+        self.nodes[0].overlay.send_block_pair(block1, block2)
+
+        yield self.deliver_messages()
+
+        for node_nr in [0, 1]:
+            self.assertIsNotNone(self.nodes[node_nr].overlay.persistence.get_latest(block1.public_key))
+            self.assertIsNotNone(self.nodes[node_nr].overlay.persistence.get_latest(block2.public_key))

--- a/test/attestation/trustchain/test_community.py
+++ b/test/attestation/trustchain/test_community.py
@@ -1,4 +1,5 @@
 from ipv8.attestation.trustchain.community import TrustChainCommunity, UNKNOWN_SEQ
+from test.attestation.trustchain.test_block import TestBlock
 from test.base import TestBase
 from test.mocking.ipv8 import MockIPv8
 from test.util import twisted_wrapper
@@ -229,3 +230,19 @@ class TestTrustChainCommunity(TestBase):
             # His second block -> my second block
             self.assertIsNotNone(self.nodes[node_nr].overlay.persistence.get(his_pubkey, 2))
             self.assertEqual(self.nodes[node_nr].overlay.persistence.get(his_pubkey, 2).link_sequence_number, 2)
+
+    @twisted_wrapper
+    def test_send_block_pair(self):
+        """
+        Test sending and receiving a pair of blocks from one to another peer.
+        """
+        yield self.introduce_nodes()
+
+        block1 = TestBlock()
+        block2 = TestBlock()
+        self.nodes[0].overlay.send_block_pair(block1, block2, self.nodes[0].network.verified_peers[0])
+
+        yield self.deliver_messages()
+
+        self.assertTrue(self.nodes[1].overlay.persistence.get_latest(block1.public_key))
+        self.assertTrue(self.nodes[1].overlay.persistence.get_latest(block2.public_key))


### PR DESCRIPTION
Added a dedicated message for a crawler response and each crawl now has an identifier. In addition, we also keep track of outstanding crawl requests in a request cache.

Also added block pair messages and added support for broadcasts of blocks.