### PR TITLE
Do not load IPv8 until the plugin is started

### DIFF
--- a/ipv8_service.py
+++ b/ipv8_service.py
@@ -3,6 +3,7 @@ from os.path import isfile
 import sys
 from threading import RLock
 
+from twisted.internet import reactor
 from twisted.internet.defer import DeferredList, inlineCallbacks, maybeDeferred
 from twisted.internet.task import LoopingCall
 
@@ -125,7 +126,6 @@ class IPv8(object):
 
 
 if __name__ == '__main__':
-    from twisted.internet import reactor
     from twisted.plugins.ipv8_plugin import Options, service_maker
 
     options = Options()

--- a/twisted/plugins/ipv8_plugin.py
+++ b/twisted/plugins/ipv8_plugin.py
@@ -31,7 +31,7 @@ class IPV8ServiceMaker(object):
         """
         Initialize the variables of the IPV8ServiceMaker and the logger.
         """
-        self.ipv8 = IPv8(get_default_configuration())
+        self.ipv8 = None
         self.restapi = None
         self._stopping = False
 
@@ -39,6 +39,8 @@ class IPV8ServiceMaker(object):
         """
         Main method to startup IPv8.
         """
+        self.ipv8 = IPv8(get_default_configuration())
+
         def signal_handler(sig, _):
             msg("Received shut down signal %s" % sig)
             if not self._stopping:


### PR DESCRIPTION
This causes an IPv8 instance to be loaded every time the module is imported.