### PR TITLE
Improved crawling in the TrustChain community

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,6 @@ twisted/plugins/dropin.cache
 
 # sqlite folder
 sqlite/
+
+# macOS DS_Store files
+**.DS_Store

--- a/ipv8/attestation/trustchain/caches.py
+++ b/ipv8/attestation/trustchain/caches.py
@@ -1,6 +1,7 @@
 import logging
 import sys
 
+from twisted.internet import reactor
 from twisted.python.failure import Failure
 
 from ...requestcache import NumberCache
@@ -56,7 +57,7 @@ class CrawlRequestCache(NumberCache):
 
         if len(self.received_half_blocks) >= self.total_half_blocks_expected:
             self.community.request_cache.pop(u"crawl", self.number)
-            self.crawl_deferred.callback(self.received_half_blocks)
+            reactor.callFromThread(self.crawl_deferred.callback, self.received_half_blocks)
 
     def on_timeout(self):
         self._logger.info("Timeout for crawl with id %d", self.number)

--- a/ipv8/attestation/trustchain/caches.py
+++ b/ipv8/attestation/trustchain/caches.py
@@ -55,7 +55,10 @@ class CrawlRequestCache(NumberCache):
         self.received_half_blocks.append(block)
         self.total_half_blocks_expected = total_count
 
-        if len(self.received_half_blocks) >= self.total_half_blocks_expected:
+        if self.total_half_blocks_expected == 0:
+            self.community.request_cache.pop(u"crawl", self.number)
+            reactor.callFromThread(self.crawl_deferred.callback, [])
+        elif len(self.received_half_blocks) >= self.total_half_blocks_expected:
             self.community.request_cache.pop(u"crawl", self.number)
             reactor.callFromThread(self.crawl_deferred.callback, self.received_half_blocks)
 

--- a/ipv8/attestation/trustchain/community.py
+++ b/ipv8/attestation/trustchain/community.py
@@ -314,6 +314,13 @@ class TrustChainCommunity(Community):
         blocks = self.persistence.crawl(self.my_peer.public_key.key_to_bin(), sq)
         total_count = len(blocks)
 
+        if total_count == 0:
+            # If there are no blocks to send, send a dummy block back with an empty transaction.
+            # This is to inform the requester that he can't expect any blocks.
+            block = self.BLOCK_CLASS.create({}, self.persistence, self.my_peer.public_key.key_to_bin(),
+                                            link_pk=EMPTY_PK)
+            self.send_crawl_response(block, payload.crawl_id, 0, 0, peer)
+
         for ind in xrange(len(blocks)):
             self.send_crawl_response(blocks[ind], payload.crawl_id, ind + 1, total_count, peer)
         self.logger.info("Sent %d blocks", total_count)

--- a/ipv8/attestation/trustchain/community.py
+++ b/ipv8/attestation/trustchain/community.py
@@ -331,11 +331,11 @@ class TrustChainCommunity(Community):
     @synchronized
     def received_crawl_response(self, source_address, data):
         dist, payload = self._ez_unpack_noauth(CrawlResponsePayload, data)
+        self.received_half_block(source_address, data[:-12])  # We cut off a few bytes to make it a BlockPayload
 
-        cache = self.request_cache.get(u"crawl", payload.crawl_id)
         block = TrustChainBlock.from_payload(payload, self.serializer)
+        cache = self.request_cache.get(u"crawl", payload.crawl_id)
         cache.received_block(block, payload.total_count)
-        self.received_half_block(source_address, data[:-12])  # We cut off the last three bytes to make it a BlockPayload
 
     def unload(self):
         self.logger.debug("Unloading the TrustChain Community.")

--- a/ipv8/messaging/serialization.py
+++ b/ipv8/messaging/serialization.py
@@ -119,6 +119,7 @@ class Serializer(object):
             'B': DefaultStruct(">B", True),
             'BBH': DefaultStruct(">BBH"),
             'BH': DefaultStruct(">BH"),
+            'c': DefaultStruct(">c", True),
             'f': DefaultStruct(">f", True),
             'H': DefaultStruct(">H", True),
             'HH': DefaultStruct(">HH"),

--- a/test/attestation/trustchain/test_community.py
+++ b/test/attestation/trustchain/test_community.py
@@ -137,11 +137,9 @@ class TestTrustChainCommunity(TestBase):
         yield self.introduce_nodes()
 
         my_pubkey = self.nodes[0].my_peer.public_key.key_to_bin()
-        self.nodes[1].overlay.send_crawl_request(self.nodes[0].my_peer, my_pubkey, 1)
+        response = yield self.nodes[1].overlay.send_crawl_request(self.nodes[0].my_peer, my_pubkey, 1)
 
-        yield self.deliver_messages()
-
-        self.assertIsNone(self.nodes[1].overlay.persistence.get(my_pubkey, 0))
+        self.assertFalse(response)
 
     @twisted_wrapper
     def test_crawl_negative_index(self):

--- a/test/attestation/trustchain/test_community.py
+++ b/test/attestation/trustchain/test_community.py
@@ -182,9 +182,7 @@ class TestTrustChainCommunity(TestBase):
         self.add_node_to_experiment(self.create_node())
 
         my_pubkey = self.nodes[0].my_peer.public_key.key_to_bin()
-        self.nodes[2].overlay.send_crawl_request(self.nodes[0].my_peer, my_pubkey, -1)
-
-        yield self.deliver_messages()
+        yield self.nodes[2].overlay.send_crawl_request(self.nodes[0].my_peer, my_pubkey, -1)
 
         # Check whether we have both blocks now
         self.assertEqual(self.nodes[2].overlay.persistence.get(my_pubkey, 1).link_sequence_number, UNKNOWN_SEQ)


### PR DESCRIPTION
In this PR, I improve the crawling mechanism in TrustChain. The most important change is that I send a dummy block back when receiving a crawl request and when there are no blocks to send to the request initiator. This avoids that the initiator should wait until the crawl request cache times out.

I've also added a test for crawling block pairs.