### PR TITLE
Increased timeout of crawl request cache

### DIFF
--- a/ipv8/attestation/trustchain/caches.py
+++ b/ipv8/attestation/trustchain/caches.py
@@ -37,7 +37,7 @@ class CrawlRequestCache(NumberCache):
     """
     This request cache keeps track of outstanding crawl requests.
     """
-    CRAWL_TIMEOUT = 5.0
+    CRAWL_TIMEOUT = 20.0
 
     def __init__(self, community, crawl_id, crawl_deferred):
         super(CrawlRequestCache, self).__init__(community.request_cache, u"crawl", crawl_id)

--- a/ipv8/attestation/trustchain/community.py
+++ b/ipv8/attestation/trustchain/community.py
@@ -342,7 +342,8 @@ class TrustChainCommunity(Community):
 
         block = TrustChainBlock.from_payload(payload, self.serializer)
         cache = self.request_cache.get(u"crawl", payload.crawl_id)
-        cache.received_block(block, payload.total_count)
+        if cache:
+            cache.received_block(block, payload.total_count)
 
     def unload(self):
         self.logger.debug("Unloading the TrustChain Community.")


### PR DESCRIPTION
Also added a check to see whether the cache still exists when a crawl response is received (the timeout could have been triggered already which removes this cache).