### PR TITLE
READY: Supercharged Trustchain database queries by adding indices to columns

### DIFF
--- a/ipv8/attestation/trustchain/database.py
+++ b/ipv8/attestation/trustchain/database.py
@@ -147,6 +147,11 @@ class TrustChainDB(Database):
 
         CREATE TABLE option(key TEXT PRIMARY KEY, value BLOB);
         INSERT INTO option(key, value) VALUES('database_version', '%s');
+
+        CREATE INDEX pub_key_ind ON blocks (public_key);
+        CREATE INDEX link_pub_key_ind ON blocks (link_public_key);
+        CREATE INDEX seq_num_ind ON blocks (sequence_number);
+        CREATE INDEX link_seq_num_ind ON blocks (link_sequence_number);
         """ % str(self.LATEST_DB_VERSION)
 
     def get_upgrade_script(self, current_version):


### PR DESCRIPTION
After my experiment didn't work as expected, I ran a profiler and found out that the validation method of Trustchain blocks is _very_ expensive (often taking 100+ ms). The main reason for this behavior is the duration of database lookups, which is performed often when validating a block (i.e. fetching previous blocks or linked blocks).

A regular lookup in a sqlite database takes `O(n)` time where n is the number of rows in the database. Considering `SELECT` queries that span multiple columns (for instance, when fetching the linked block), this becomes expensive. By adding indices to the relevant, we are able to improve query speeds, to `O(log n)`. By doing so, it gives the expected results in my experiments and significantly reduced CPU usage, at the cost of some storage. This also makes it feasible in my experiments to broadcast a block one hop away after it is being constructed.

TLDR: reduced duration of sqlite database duration by an order of magnitude.