### PR TITLE
Refactored TrustChain so it's a single ledger now

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,4 +70,4 @@ IPv8 can be used as a library or as a service. It is easiest to start off with t
 This file will load the IPv8 stack for *signed messaging*, *anonymous messaging*, *attribute attestation*, *public service discovery*, *peer discovery* and *peer keep-alive*.
 You can start creating your first network overlay by following [the overlay creation tutorial](doc/overlay_tutorial.md).
 
-Additional documentation is also available for the [TrustChain](doc/trustchain.md) and [anonymization](doc/anonymization.md) provided in IPv8.
+Additional documentation is also available for the [TrustChain](doc/trustchain.md) and [anonymous overlay](doc/anonymization.md) provided in IPv8.

--- a/doc/trustchain.md
+++ b/doc/trustchain.md
@@ -1,18 +1,58 @@
-This document entails the implementation of TrustChain in IPv8.
-The implementation is provided in 4 files:
+This document entails a high-level overview of the implementation of TrustChain in IPv8.
+TrustChain is a scalable, tamper-proof and distributed ledger, built for secure accounting.
+For more information about TrustChain itself, we refer to our [IETF internet standard](https://tools.ietf.org/html/draft-pouwelse-trustchain-01).
+Additional information can be found [in our published scientific article](https://www.sciencedirect.com/science/article/pii/S0167739X17318988).
 
- - `block.py`: data structure of a block in the Blockchain
- - `community.py`: the ipv8 overlay providing higher order TrustChain logic
- - `database.py`: wrapper to query and update the database
- - `payload.py`: message format and datastructures for communication
- 
-## Payload
+The TrustChain implementation is provided in 4 files:
 
-The TrustChain uses 2 messages to communicate between peers: a `CrawlRequest` and a `HalfBlock` message.
+ - `block.py`: this file defines the data structure of a block in the TrustChain ledger
+ - `community.py`: the ipv8 overlay providing higher order TrustChain logic (i.e. handling incoming blocks and exploring other blocks in the network)
+ - `database.py`: wrapper to query and update the database with known TrustChain blocks
+ - `payload.py`: defines the message format and data structures for communication between peers
 
-The `CrawlRequest` request message is sent when one peer wishes to receive blocks from another peer.
-A `CrawlRequest` takes a sequence number as an argument.
-This sequence number specifies from which sequence number forward, blocks will be sent back (up to 100 blocks in response).
+The logic present in each file is now briefly explained.
+
+## block.py
+The `block.py` file contains the definition of a TrustChain half block (in the `TrustChainBlock` class).
+Note that each valid transaction contains exactly two blocks, signed by both involved parties.
+Each block in TrustChain contains the following properties:
+
+| Property | Type | Description |
+| --- | --- | --- |
+| _type_ | string | The type of the block. Can be any arbitrary string. |
+| _transaction_ | dictionary | The transaction that this block describes. |
+| _public_key_ | string | The public key in binary format of the block creator. |
+| _link_public_key_ | string | The public key of the transaction counterparty. |
+| _sequence_number_ | integer | The sequence number of the block. The sequence number of the genesis block is 1. |
+| _link_sequence_number_ | integer | The sequence number of the linked block. |
+| _previous_hash_ | string | The SHA256 hash of the previous block in the chain. |
+| _signature_ | string | The signature of the block. |
+| _timestamp_ | integer | The epoch timestamp defining when this block is created (with milliseconds precision). |
+
+
+The attributes within the `TrustChainBlock` class have a high overlap with those in a `HalfBlockPayload`.
+
+### Block Validation
+Each incoming block and new block created are verified for correctness.
+These checks are performed by the `validate` method inside the `TrustChainBlock` class.
+Discovered blocks that are invalid are ignored and not added to the database.
+The validation method also aims to detect fraudulent operations performed by users, such as a double-spend attack.
+
+## payload.py
+
+TrustChain defines six different messages types, used to request signatures in blocks and exchange knowledge of existing blocks.
+We now describe the functionality of each message:
+
+| Name | Description |
+| --- | --- |
+| _CrawlRequestPayload_ | This message describes a crawl request for another user. It contains the public key of the receiver of the crawl request, the index of the block(s) being requested and a random identifier. |
+| _CrawlResponsePayload_ | Response to a _CrawlRequest_ message. Contains a TrustChain block, the crawl identifier, the total amount of blocks being sent during the crawl, and the index of this block during the crawl. |
+| _HalfBlockPayload_ | Contains a single half block. |
+| _HalfBlockBroadcastPayload_ | Contains a single half block and a TTL value. |
+| _HalfBlockPairPayload_ | Contains a pair of half blocks. |
+| _HalfBlockPairBroadcastPayload_ | Contains a pair of half blocks and a TTL value. |
+
+The sequence number in the _CrawlRequestPayload_ specifies from which sequence number forward, blocks will be sent back (up to 100 blocks in response).
 Alternatively, the sequence number can also be negative.
 A negative sequence number implies the offset from the last block.
 For example, when peer **A** performs a crawl request from a peer **B** with 8 blocks (numbered 1 through 8):
@@ -26,53 +66,49 @@ For example, when peer **A** performs a crawl request from a peer **B** with 8 b
 | CrawlRequest(-5) | 4, 5, 6, 7, 8 |
 | CrawlRequest(9) |  |
 
-The `HalfBlock` message is used to share a block.
-It is sent when a transaction is being made or upon a `CrawlRequest`.
+The `HalfBlockPayload` class is used to share a block.
+It is sent when a transaction is being made.
 Upon receipt, the TrustChain logic will determine if the block is valid and/or other blocks need to be crawled to validate the received block.
-The `HalfBlock` message has the following attributes:
-
- - *public_key*: the key of the block owner
- - *sequence_number*: the sequence number of the block in the chain of the owner
- - *link_public_key*: the public key of the party with which the owner transacted
- - *link_sequence_number*: the sequence number of the block in the chain of the other party\*
- - *previous_hash*: the hash of the previous block in the owners chain
- - *signature*: the cryptographic signature of this block, using *public_key*
- - *transaction*: the binary blob containing the data portion of this block
 
 \* NOTE: The *link_sequence_number* of the party requesting the transaction be signed is always 0.
 The blocks are only linked by sequence number through the second "half" of the block.
-Therefore, you should always use `get_linked()` of `database.py` to retrieve a block's other half.
+Therefore, you should always use `get_linked()` defined in `database.py` to retrieve a block's other half.
 
-## Block
-The block class has a high overlap with the `HalfBlock` message.
-The `TrustChainBlock` however, provides methods for validating (`validate()`), signing (`sign()`) and hashing (`hash`) blocks.
+## database.py
+The `database.py` file defines the TrustChain database class.
+This database class is responsible for (1) storing and (2) querying blocks in the database, of both the owner and crawled third parties.
+One can either access this data structure as a linked list, or by index reference (sequence number).
 
-## Database
-The database class is responsible for (1) storing and (2) querying blocks in the databsae, of both the owner and crawled third parties.
-One can either access this datastructure as a linked list, or by index reference (sequence number).
-
-For linked list type usage use:
- - `get_latest()` to get the last block for some peer
- - `get_latest_blocks()` to get the tail of the chain for some peer
- - `get_block_after()` to get the next block in a chain
- - `get_block_before()` to get the previous block in a chain
- - `get_linked()` to get the linked block from another chain (if available)
+Various methods are defined to fetch information from the TrustChain database in a structured manner:
+ - `contains(block)` to check whether a specific block is stored in the database.
+ - `get_latest(public_key, block_type=None)` to get the last block for a specific peer with a public key.
+ - `get_latest_blocks(public_key, limit=25)` to get the tail of the chain for some peer.
+ - `get_block_after(block, block_type=None)` to get the next block in a chain, after a specified block.
+ - `get_block_before(block, block_type=None)` to get the previous block in a chain, before a specified block.
+ - `get_lowest_sequence_number_unknown(public_key)` to get the lowest sequence number of the block we do not have (yet).
+ - `get_linked()` to get the linked block from another chain (if available).
+ - `get_all_blocks()` to get all blocks stored in the database.
+ - `get_block_with_hash(hash)` to get the block with a specific hash (if available).
+ - `get_blocks_with_type(self, block_type, public_key=None)` to get all blocks with a specific type and optionally with a public key.
 
 For indexed usage, one can use:
- - `get()` to get a specific block for a specific peer and manually read the `TrustChainBlock`
+ - `get(public_key, sequence_number)` to get a specific block for a specific peer and manually read the `TrustChainBlock`.
  
 As previously mentioned, do bear in mind that the *link_sequence_number* will always be 0 for the transactor and non-zero for the transactee.
-As such, *link_sequence_number* should never be used to perform a subsequent `get()`: `get_linked()` should be used instead.
+As such, *link_sequence_number* should never be used to perform a subsequent `get`: the `get_linked` method should be used instead.
 
-## Community
-The `TrustChainCommunity` class provides the higher order TrustChain logic.
-In particular, it maintains a database object (`persistence`) and decides when to send `CrawlRequest` and `HalfBlock` messages to other peers.
-This class implements the behavior as specified in the [Payload](#payload) section.
-Additionally, this class also provides the interface for creating blocks: `sign_block()` and `should_sign()`.
+## community.py
+The `community.py` file defines the higher order TrustChain logic, in particular, in the `TrustChainCommunity` class.
+This class maintains a database object (`persistence`) and decides when to send messages to other peers.
+Additionally, this class also provides the method for creating blocks: `sign_block()`.
+Invoking this method with the correct parameters should sent a half block to a counterparty for signing.
+This method returns a `Deferred` object which fires when the counterparty has created their half block and has sent it back to us.
+Developers can interact with the chain by defining listeners, which can trigger specific actions on receiving blocks.
 
-**The `should_sign()` method should be defined in a subclass of `TrustChainCommunity` to define the buisiness logic for when to sign a block of another party.**
+### Listeners
+To manage creation and update procedure of TrustChain blocks with a specific type, one should define and create a `BlockListener` object.
+Each `BlockListener` class should define the following two methods:
+- `should_sign(block)`: returns whether the block should be signed or not.
+- `received_block(block)`: invoked when the TrustChain community receives a block that matches with the block type that the listener listens to.
 
-The `sign_block()` method is responsible for initiating a two-party signing of a block with another peer and is the main access point for block creation.
-
-In short: use `sign_block()` to create blocks and use `should_sign()` to accept or reject blocks based on the transaction value.
-Note that `should_sign()` does not have to validate the correctness of the chain (which is checked by the `TrustChainCommunity` class), only of the *transaction* content of the block.
+To add a listener to the TrustChain community, one should use the `add_listener` method, which takes a `BlockListener` object and a list of block types that this listener listens to.

--- a/ipv8/attestation/identity/community.py
+++ b/ipv8/attestation/identity/community.py
@@ -1,14 +1,12 @@
 from time import time
 
-from ...deprecated.payload import IntroductionResponsePayload
-from ...messaging.deprecated.encoding import decode
+from ...attestation.trustchain.community import TrustChainCommunity
+from ...attestation.trustchain.listener import BlockListener
 from ...peer import Peer
-from ..trustchain.community import TrustChainCommunity
 
 
-class IdentityCommunity(TrustChainCommunity):
+class IdentityCommunity(TrustChainCommunity, BlockListener):
 
-    DB_NAME = 'identity'
     master_peer = Peer(("3081a7301006072a8648ce3d020106052b810400270381920004009ad2a2e35c328a3e92019873820d70b53b" +
                         "82a752490febbce8bbbe2531a06a165121b8068e674236f26055a59b12c2139445f14dd86c4c3c9598e8c999" +
                         "109f184556dac595f69001b5b16d2c14fe5f641f1a25227152df1989f0c8fb71a107ec55e8e67f464391491c" +
@@ -16,6 +14,8 @@ class IdentityCommunity(TrustChainCommunity):
 
     def __init__(self, *args, **kwargs):
         super(IdentityCommunity, self).__init__(*args, **kwargs)
+
+        self.add_listener(self, ['id_metadata'])
 
         # Dict of hash -> (attribute_name, date, public_key)
         self.known_attestation_hashes = {}
@@ -25,6 +25,9 @@ class IdentityCommunity(TrustChainCommunity):
         We know about this hash+peer combination. Thus we can handle sign requests for it.
         """
         self.known_attestation_hashes[hash] = (name, time(), public_key)
+
+    def received_block(self, block):
+        pass
 
     def should_sign(self, block):
         transaction = block.transaction
@@ -52,8 +55,9 @@ class IdentityCommunity(TrustChainCommunity):
         """
         self.sign_block(peer,
                         public_key=peer.public_key.key_to_bin(),
+                        block_type="id_metadata",
                         transaction={
-                                "hash": hash,
-                                "name": name,
-                                "date": time()
-                            })
+                            "hash": hash,
+                            "name": name,
+                            "date": time()
+                        })

--- a/ipv8/attestation/trustchain/block.py
+++ b/ipv8/attestation/trustchain/block.py
@@ -423,7 +423,7 @@ class TrustChainBlock(object):
         :return: generator to iterate over all properties of this block
         """
         for key, value in self.__dict__.iteritems():
-            if key == 'key' or key == 'serializer':
+            if key == 'key' or key == 'serializer' or key == 'crypto':
                 continue
             if isinstance(value, basestring) and key != "insert_time" and key != "type":
                 yield key, value.encode("hex")

--- a/ipv8/attestation/trustchain/block.py
+++ b/ipv8/attestation/trustchain/block.py
@@ -24,6 +24,7 @@ class TrustChainBlock(object):
         super(TrustChainBlock, self).__init__()
         if data is None:
             # data
+            self.type = 'unknown'
             self.transaction = {}
             # identity
             self.public_key = EMPTY_PK
@@ -38,10 +39,11 @@ class TrustChainBlock(object):
             # debug stuff
             self.insert_time = None
         else:
-            _, self.transaction = decode(str(data[0]))
-            (self.public_key, self.sequence_number, self.link_public_key, self.link_sequence_number, self.previous_hash,
-             self.signature, self.timestamp, self.insert_time) = (data[1], data[2], data[3], data[4], data[5],
-                                                                  data[6], data[7], data[8])
+            _, self.transaction = decode(str(data[1]))
+            (self.type, self.public_key, self.sequence_number, self.link_public_key, self.link_sequence_number,
+             self.previous_hash, self.signature, self.timestamp, self.insert_time) = (data[0], data[2], data[3],
+                                                                                      data[4], data[5], data[6],
+                                                                                      data[7], data[8], data[9])
             if isinstance(self.public_key, buffer):
                 self.public_key = str(self.public_key)
             if isinstance(self.link_public_key, buffer):
@@ -59,7 +61,7 @@ class TrustChainBlock(object):
         Create a block according to a given payload and serializer.
         This method can be used when receiving a block from the network.
         """
-        return cls([payload.transaction, payload.public_key, payload.sequence_number,
+        return cls([payload.type, payload.transaction, payload.public_key, payload.sequence_number,
                     payload.link_public_key, payload.link_sequence_number, payload.previous_hash,
                     payload.signature, payload.timestamp, time.time()], serializer)
 
@@ -69,23 +71,24 @@ class TrustChainBlock(object):
         Create two half blocks from a block pair message, according to a given payload and serializer.
         Used to construct two blocks when receiving a block pair from the network.
         """
-        block1 = cls([payload.transaction1, payload.public_key1, payload.sequence_number1,
+        block1 = cls([payload.type1, payload.transaction1, payload.public_key1, payload.sequence_number1,
                       payload.link_public_key1, payload.link_sequence_number1, payload.previous_hash1,
                       payload.signature1, payload.timestamp1, time.time()], serializer)
-        block2 = cls([payload.transaction2, payload.public_key2, payload.sequence_number2,
+        block2 = cls([payload.type2, payload.transaction2, payload.public_key2, payload.sequence_number2,
                       payload.link_public_key2, payload.link_sequence_number2, payload.previous_hash2,
                       payload.signature2, payload.timestamp2, time.time()], serializer)
         return block1, block2
 
     def __str__(self):
         # This makes debugging and logging easier
-        return "Block {0} from ...{1}:{2} links ...{3}:{4} for {5}".format(
+        return "Block {0} from ...{1}:{2} links ...{3}:{4} for {5} type {6}".format(
             self.hash.encode("hex")[-8:],
             self.public_key.encode("hex")[-8:],
             self.sequence_number,
             self.link_public_key.encode("hex")[-8:],
             self.link_sequence_number,
-            self.transaction)
+            self.transaction,
+            self.type)
 
     def __hash__(self):
         return self.hash
@@ -125,7 +128,8 @@ class TrustChainBlock(object):
         :return: the buffer the data was packed into
         """
         args = [self.public_key, self.sequence_number, self.link_public_key, self.link_sequence_number,
-                self.previous_hash, self.signature if signature else EMPTY_SIG, self.transaction, self.timestamp]
+                self.previous_hash, self.signature if signature else EMPTY_SIG, self.type, self.transaction,
+                self.timestamp]
         return self.serializer.pack_multiple(HalfBlockPayload(*args).to_pack_list())
 
     def validate_transaction(self, database):
@@ -372,11 +376,12 @@ class TrustChainBlock(object):
         self.signature = self.crypto.create_signature(key, self.pack(signature=False))
 
     @classmethod
-    def create(cls, transaction, database, public_key, link=None, link_pk=None):
+    def create(cls, block_type, transaction, database, public_key, link=None, link_pk=None):
         """
         Create an empty next block.
-        :param database: the database to use as information source
+        :param block_type: the type of the block to be constructed
         :param transaction: the transaction to use in this block
+        :param database: the database to use as information source
         :param public_key: the public key to use for this block
         :param link: optionally create the block as a linked block to this block
         :param link_pk: the public key of the counterparty in this transaction
@@ -385,10 +390,12 @@ class TrustChainBlock(object):
         blk = database.get_latest(public_key)
         ret = cls()
         if link:
+            ret.type = link.type
             ret.transaction = link.transaction
             ret.link_public_key = link.public_key
             ret.link_sequence_number = link.sequence_number
         else:
+            ret.type = block_type
             ret.transaction = transaction
             ret.link_public_key = link_pk
             ret.link_sequence_number = UNKNOWN_SEQ
@@ -406,9 +413,9 @@ class TrustChainBlock(object):
         Prepare a tuple to use for inserting into the database
         :return: A database insertable tuple
         """
-        return (buffer(encode(self.transaction)), buffer(self.public_key), self.sequence_number,
-                buffer(self.link_public_key), self.link_sequence_number, buffer(self.previous_hash),
-                buffer(self.signature), self.timestamp, buffer(self.hash))
+        return (self.type, buffer(encode(self.transaction)), buffer(self.public_key),
+                self.sequence_number, buffer(self.link_public_key), self.link_sequence_number,
+                buffer(self.previous_hash), buffer(self.signature), self.timestamp, buffer(self.hash))
 
     def __iter__(self):
         """
@@ -418,7 +425,7 @@ class TrustChainBlock(object):
         for key, value in self.__dict__.iteritems():
             if key == 'key' or key == 'serializer':
                 continue
-            if isinstance(value, basestring) and key != "insert_time":
+            if isinstance(value, basestring) and key != "insert_time" and key != "type":
                 yield key, value.encode("hex")
             else:
                 yield key, value

--- a/ipv8/attestation/trustchain/community.py
+++ b/ipv8/attestation/trustchain/community.py
@@ -43,10 +43,10 @@ class TrustChainCommunity(Community):
     DB_NAME = 'trustchain'
     BROADCAST_FANOUT = 10
     version = '\x02'
-    master_peer = Peer(("3081a7301006072a8648ce3d020106052b81040027038192000403428b0fa33d3ed62dd39852481f535e2161714" +
-                        "4a95e682ad5733b9a739b27051dc6ad1da743a463821fc8d3d1849191d5fb84fab1f3fe3ad44fb2b83f07d0c78a" +
-                        "13b7ad1d311063069f49070cad7dc15620996cdd625c1abcdbfabf750727f1dec706f6f16cb28ce6946fdf39887" +
-                        "a84fc457a5f9edc660adbe0a72ea5219f9578dd6432de825c167e80987ca4c6a2bf").decode("HEX"))
+    master_peer = Peer(("3081a7301006072a8648ce3d020106052b810400270381920004057a1c4c4f8422b328209d99724bd30cf08d1f81"
+                        "a2961b003affd2964f92c457572f2f79de0968c42698e2d1cfb371dd71b275332a0a4c19f35f16166272baae8e23"
+                        "0bba377cc5c40643b83206088075559ec2f13a090e8786d04d84802268bef12e52983978da360589a2b7e293ce4f"
+                        "16d02f37da2c3256f4703b9623d3750f7af437befebc8935c0f0726f58c1c1e9").decode("HEX"))
 
     def __init__(self, *args, **kwargs):
         working_directory = kwargs.pop('working_directory', '')

--- a/ipv8/attestation/trustchain/community.py
+++ b/ipv8/attestation/trustchain/community.py
@@ -39,18 +39,26 @@ class TrustChainCommunity(Community):
     """
     Community for reputation based on TrustChain tamper proof interaction history.
     """
+    TESTNET_PEER = Peer(("3081a7301006072a8648ce3d020106052b810400270381920004017aa18185c6c8a3741aed970f5476d50932980"
+                         "66670c6557f9d2519a77c2abe293f9438444fdb73d9e36d0b43a4a254f96c563c0da7915def980270d88da4079e"
+                         "83a6039ce97f2205528c69087f88a6d6f35d83b93b3fb8a360260114729d4cfb5acc4b190e067695b4ae5e240a3"
+                         "939a1f45520e87a459ed0f358bf5e66371a748daa041997da69cab227596948bffd").decode("HEX"))
+    MAINNET_PEER = Peer(("3081a7301006072a8648ce3d020106052b810400270381920004057a1c4c4f8422b328209d99724bd30cf08d1f8"
+                         "1a2961b003affd2964f92c457572f2f79de0968c42698e2d1cfb371dd71b275332a0a4c19f35f16166272baae8e"
+                         "230bba377cc5c40643b83206088075559ec2f13a090e8786d04d84802268bef12e52983978da360589a2b7e293c"
+                         "e4f16d02f37da2c3256f4703b9623d3750f7af437befebc8935c0f0726f58c1c1e9").decode("HEX"))
+
     DB_CLASS = TrustChainDB
     DB_NAME = 'trustchain'
     BROADCAST_FANOUT = 10
     version = '\x02'
-    master_peer = Peer(("3081a7301006072a8648ce3d020106052b810400270381920004057a1c4c4f8422b328209d99724bd30cf08d1f81"
-                        "a2961b003affd2964f92c457572f2f79de0968c42698e2d1cfb371dd71b275332a0a4c19f35f16166272baae8e23"
-                        "0bba377cc5c40643b83206088075559ec2f13a090e8786d04d84802268bef12e52983978da360589a2b7e293ce4f"
-                        "16d02f37da2c3256f4703b9623d3750f7af437befebc8935c0f0726f58c1c1e9").decode("HEX"))
+    master_peer = None  # Determined at runtime
 
     def __init__(self, *args, **kwargs):
         working_directory = kwargs.pop('working_directory', '')
         db_name = kwargs.pop('db_name', self.DB_NAME)
+        self.testnet = kwargs.pop('testnet', False)
+        TrustChainCommunity.master_peer = self.TESTNET_PEER if self.testnet else self.MAINNET_PEER
         super(TrustChainCommunity, self).__init__(*args, **kwargs)
         self.request_cache = RequestCache()
         self.logger = logging.getLogger(self.__class__.__name__)

--- a/ipv8/attestation/trustchain/database.py
+++ b/ipv8/attestation/trustchain/database.py
@@ -41,7 +41,7 @@ class TrustChainDB(Database):
         """
         self.execute(
             u"INSERT INTO blocks (tx, public_key, sequence_number, link_public_key,"
-            u"link_sequence_number, previous_hash, signature, block_hash) VALUES(?,?,?,?,?,?,?,?)",
+            u"link_sequence_number, previous_hash, signature, block_timestamp, block_hash) VALUES(?,?,?,?,?,?,?,?,?)",
             block.pack_db_insert())
         self.commit()
 
@@ -55,7 +55,8 @@ class TrustChainDB(Database):
         """
         self.execute(
             u"DELETE FROM blocks WHERE tx = ? AND public_key = ? AND sequence_number = ? AND link_public_key = ? AND "
-            u"link_sequence_number = ? AND previous_hash = ? AND signature = ? AND block_hash = ?",
+            u"link_sequence_number = ? AND previous_hash = ? AND signature = ? AND block_timestamp = ? " \
+            u"AND block_hash = ?",
             block.pack_db_insert())
         self.commit()
 
@@ -147,7 +148,7 @@ class TrustChainDB(Database):
         Return the first part of a generic sql select query.
         """
         _columns = u"tx, public_key, sequence_number, link_public_key, link_sequence_number, " \
-                   u"previous_hash, signature, insert_time"
+                   u"previous_hash, signature, block_timestamp, insert_time"
         return u"SELECT " + _columns + u" FROM blocks "
 
     def get_schema(self):
@@ -163,7 +164,7 @@ class TrustChainDB(Database):
          link_sequence_number INTEGER NOT NULL,
          previous_hash	      TEXT NOT NULL,
          signature		      TEXT NOT NULL,
-
+         block_timestamp      BIGINT NOT NULL,
          insert_time          TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
          block_hash	          TEXT NOT NULL,
 

--- a/ipv8/attestation/trustchain/listener.py
+++ b/ipv8/attestation/trustchain/listener.py
@@ -1,0 +1,28 @@
+import abc
+
+from .block import TrustChainBlock
+
+
+class BlockListener(object):
+    """
+    This class defines a listener for TrustChain blocks with a specific type.
+    """
+
+    __metaclass__ = abc.ABCMeta
+
+    BLOCK_CLASS = TrustChainBlock
+
+    @abc.abstractmethod
+    def should_sign(self, block):
+        """
+        Method to indicate whether this listener wants a specific block signed or not.
+        """
+        pass
+
+    @abc.abstractmethod
+    def received_block(self, block):
+        """
+        This method is called when a listener receives a block that matches the BLOCK_CLASS.
+        :return:
+        """
+        pass

--- a/ipv8/attestation/trustchain/payload.py
+++ b/ipv8/attestation/trustchain/payload.py
@@ -31,10 +31,10 @@ class HalfBlockPayload(Payload):
     Payload for message that ships a half block
     """
 
-    format_list = ['74s', 'I', '74s', 'I', '32s', '64s', 'varlenI', 'Q']
+    format_list = ['74s', 'I', '74s', 'I', '32s', '64s', 'varlenI', 'varlenI', 'Q']
 
     def __init__(self, public_key, sequence_number, link_public_key, link_sequence_number, previous_hash,
-                 signature, transaction, timestamp):
+                 signature, block_type, transaction, timestamp):
         super(HalfBlockPayload, self).__init__()
         self.public_key = public_key
         self.sequence_number = sequence_number
@@ -42,6 +42,7 @@ class HalfBlockPayload(Payload):
         self.link_sequence_number = link_sequence_number
         self.previous_hash = previous_hash
         self.signature = signature
+        self.type = block_type
         self.transaction = transaction
         self.timestamp = timestamp
 
@@ -54,6 +55,7 @@ class HalfBlockPayload(Payload):
             block.link_sequence_number,
             block.previous_hash,
             block.signature,
+            block.type,
             block.transaction,
             block.timestamp
         )
@@ -65,6 +67,7 @@ class HalfBlockPayload(Payload):
                 ('I', self.link_sequence_number),
                 ('32s', self.previous_hash),
                 ('64s', self.signature),
+                ('varlenI', str(self.type)),
                 ('varlenI', encode(self.transaction)),
                 ('Q', self.timestamp)]
 
@@ -80,13 +83,13 @@ class HalfBlockBroadcastPayload(HalfBlockPayload):
     Payload for a message that contains a half block and a TTL field for broadcasts.
     """
 
-    format_list = ['74s', 'I', '74s', 'I', '32s', '64s', 'varlenI', 'Q', 'I']
+    format_list = ['74s', 'I', '74s', 'I', '32s', '64s', 'varlenI', 'varlenI', 'Q', 'I']
 
     def __init__(self, public_key, sequence_number, link_public_key, link_sequence_number, previous_hash,
-                 signature, transaction, timestamp, ttl):
+                 signature, block_type, transaction, timestamp, ttl):
         super(HalfBlockBroadcastPayload, self).__init__(public_key, sequence_number, link_public_key,
                                                         link_sequence_number, previous_hash, signature,
-                                                        transaction, timestamp)
+                                                        block_type, transaction, timestamp)
         self.ttl = ttl
 
     @classmethod
@@ -98,6 +101,7 @@ class HalfBlockBroadcastPayload(HalfBlockPayload):
             block.link_sequence_number,
             block.previous_hash,
             block.signature,
+            block.type,
             block.transaction,
             block.timestamp,
             ttl
@@ -118,10 +122,10 @@ class CrawlResponsePayload(Payload):
     Payload for the response to a crawl request.
     """
 
-    format_list = ['74s', 'I', '74s', 'I', '32s', '64s', 'varlenI', 'Q', 'I', 'I', 'I']
+    format_list = ['74s', 'I', '74s', 'I', '32s', '64s', 'varlenI', 'varlenI', 'Q', 'I', 'I', 'I']
 
     def __init__(self, public_key, sequence_number, link_public_key, link_sequence_number, previous_hash, signature,
-                 transaction, timestamp, crawl_id, cur_count, total_count):
+                 block_type, transaction, timestamp, crawl_id, cur_count, total_count):
         super(CrawlResponsePayload, self).__init__()
         self.public_key = public_key
         self.sequence_number = sequence_number
@@ -129,6 +133,7 @@ class CrawlResponsePayload(Payload):
         self.link_sequence_number = link_sequence_number
         self.previous_hash = previous_hash
         self.signature = signature
+        self.type = block_type
         self.transaction = transaction
         self.timestamp = timestamp
         self.crawl_id = crawl_id
@@ -144,6 +149,7 @@ class CrawlResponsePayload(Payload):
             block.link_sequence_number,
             block.previous_hash,
             block.signature,
+            block.type,
             block.transaction,
             block.timestamp,
             crawl_id,
@@ -158,6 +164,7 @@ class CrawlResponsePayload(Payload):
                 ('I', self.link_sequence_number),
                 ('32s', self.previous_hash),
                 ('64s', self.signature),
+                ('varlenI', str(self.type)),
                 ('varlenI', encode(self.transaction)),
                 ('Q', self.timestamp),
                 ('I', self.crawl_id),
@@ -176,11 +183,11 @@ class HalfBlockPairPayload(Payload):
     Payload for message that ships two half blocks
     """
 
-    format_list = ['74s', 'I', '74s', 'I', '32s', '64s', 'varlenI', 'Q'] * 2
+    format_list = ['74s', 'I', '74s', 'I', '32s', '64s', 'varlenI', 'varlenI', 'Q'] * 2
 
     def __init__(self, public_key1, sequence_number1, link_public_key1, link_sequence_number1, previous_hash1,
-                 signature1, transaction1, timestamp1, public_key2, sequence_number2, link_public_key2,
-                 link_sequence_number2, previous_hash2, signature2, transaction2, timestamp2):
+                 signature1, block_type1, transaction1, timestamp1, public_key2, sequence_number2, link_public_key2,
+                 link_sequence_number2, previous_hash2, signature2, block_type2, transaction2, timestamp2):
         super(HalfBlockPairPayload, self).__init__()
         self.public_key1 = public_key1
         self.sequence_number1 = sequence_number1
@@ -188,6 +195,7 @@ class HalfBlockPairPayload(Payload):
         self.link_sequence_number1 = link_sequence_number1
         self.previous_hash1 = previous_hash1
         self.signature1 = signature1
+        self.type1 = block_type1
         self.transaction1 = transaction1
         self.timestamp1 = timestamp1
 
@@ -197,6 +205,7 @@ class HalfBlockPairPayload(Payload):
         self.link_sequence_number2 = link_sequence_number2
         self.previous_hash2 = previous_hash2
         self.signature2 = signature2
+        self.type2 = block_type2
         self.transaction2 = transaction2
         self.timestamp2 = timestamp2
 
@@ -209,6 +218,7 @@ class HalfBlockPairPayload(Payload):
             block1.link_sequence_number,
             block1.previous_hash,
             block1.signature,
+            block1.type,
             block1.transaction,
             block1.timestamp,
             block2.public_key,
@@ -217,6 +227,7 @@ class HalfBlockPairPayload(Payload):
             block2.link_sequence_number,
             block2.previous_hash,
             block2.signature,
+            block2.type,
             block2.transaction,
             block2.timestamp
         )
@@ -228,6 +239,7 @@ class HalfBlockPairPayload(Payload):
                 ('I', self.link_sequence_number1),
                 ('32s', self.previous_hash1),
                 ('64s', self.signature1),
+                ('varlenI', str(self.type1)),
                 ('varlenI', encode(self.transaction1)),
                 ('Q', self.timestamp1),
                 ('74s', self.public_key2),
@@ -236,6 +248,7 @@ class HalfBlockPairPayload(Payload):
                 ('I', self.link_sequence_number2),
                 ('32s', self.previous_hash2),
                 ('64s', self.signature2),
+                ('varlenI', str(self.type2)),
                 ('varlenI', encode(self.transaction2)),
                 ('Q', self.timestamp2)]
 
@@ -251,16 +264,17 @@ class HalfBlockPairBroadcastPayload(HalfBlockPairPayload):
     Payload for a broadcast message that ships two half blocks
     """
 
-    format_list = ['74s', 'I', '74s', 'I', '32s', '64s', 'varlenI', 'Q'] * 2 + ['I']
+    format_list = ['74s', 'I', '74s', 'I', '32s', '64s', 'varlenI', 'varlenI', 'Q'] * 2 + ['I']
 
     def __init__(self, public_key1, sequence_number1, link_public_key1, link_sequence_number1, previous_hash1,
-                 signature1, transaction1, timestamp1, public_key2, sequence_number2, link_public_key2,
-                 link_sequence_number2, previous_hash2, signature2, transaction2, timestamp2, ttl):
+                 signature1, block_type1, transaction1, timestamp1, public_key2, sequence_number2, link_public_key2,
+                 link_sequence_number2, previous_hash2, signature2, block_type2, transaction2, timestamp2, ttl):
         super(HalfBlockPairBroadcastPayload, self).__init__(public_key1, sequence_number1, link_public_key1,
                                                             link_sequence_number1, previous_hash1, signature1,
-                                                            transaction1, timestamp1, public_key2, sequence_number2,
-                                                            link_public_key2, link_sequence_number2, previous_hash2,
-                                                            signature2, transaction2, timestamp2)
+                                                            block_type1, transaction1, timestamp1, public_key2,
+                                                            sequence_number2, link_public_key2, link_sequence_number2,
+                                                            previous_hash2, signature2, block_type2, transaction2,
+                                                            timestamp2)
         self.ttl = ttl
 
     @classmethod
@@ -272,6 +286,7 @@ class HalfBlockPairBroadcastPayload(HalfBlockPairPayload):
             block1.link_sequence_number,
             block1.previous_hash,
             block1.signature,
+            block1.type,
             block1.transaction,
             block1.timestamp,
             block2.public_key,
@@ -280,6 +295,7 @@ class HalfBlockPairBroadcastPayload(HalfBlockPairPayload):
             block2.link_sequence_number,
             block2.previous_hash,
             block2.signature,
+            block2.type,
             block2.transaction,
             block2.timestamp,
             ttl

--- a/ipv8/attestation/trustchain/payload.py
+++ b/ipv8/attestation/trustchain/payload.py
@@ -31,10 +31,10 @@ class HalfBlockPayload(Payload):
     Payload for message that ships a half block
     """
 
-    format_list = ['74s', 'I', '74s', 'I', '32s', '64s', 'varlenI']
+    format_list = ['74s', 'I', '74s', 'I', '32s', '64s', 'varlenI', 'Q']
 
     def __init__(self, public_key, sequence_number, link_public_key, link_sequence_number, previous_hash,
-                 signature, transaction):
+                 signature, transaction, timestamp):
         super(HalfBlockPayload, self).__init__()
         self.public_key = public_key
         self.sequence_number = sequence_number
@@ -43,6 +43,7 @@ class HalfBlockPayload(Payload):
         self.previous_hash = previous_hash
         self.signature = signature
         self.transaction = transaction
+        self.timestamp = timestamp
 
     @classmethod
     def from_half_block(cls, block):
@@ -53,7 +54,8 @@ class HalfBlockPayload(Payload):
             block.link_sequence_number,
             block.previous_hash,
             block.signature,
-            block.transaction
+            block.transaction,
+            block.timestamp
         )
 
     def to_pack_list(self):
@@ -63,7 +65,8 @@ class HalfBlockPayload(Payload):
                 ('I', self.link_sequence_number),
                 ('32s', self.previous_hash),
                 ('64s', self.signature),
-                ('varlenI', encode(self.transaction))]
+                ('varlenI', encode(self.transaction)),
+                ('Q', self.timestamp)]
 
         return data
 
@@ -77,12 +80,13 @@ class HalfBlockBroadcastPayload(HalfBlockPayload):
     Payload for a message that contains a half block and a TTL field for broadcasts.
     """
 
-    format_list = ['74s', 'I', '74s', 'I', '32s', '64s', 'varlenI', 'I']
+    format_list = ['74s', 'I', '74s', 'I', '32s', '64s', 'varlenI', 'Q', 'I']
 
     def __init__(self, public_key, sequence_number, link_public_key, link_sequence_number, previous_hash,
-                 signature, transaction, ttl):
+                 signature, transaction, timestamp, ttl):
         super(HalfBlockBroadcastPayload, self).__init__(public_key, sequence_number, link_public_key,
-                                                        link_sequence_number, previous_hash, signature, transaction)
+                                                        link_sequence_number, previous_hash, signature,
+                                                        transaction, timestamp)
         self.ttl = ttl
 
     @classmethod
@@ -95,6 +99,7 @@ class HalfBlockBroadcastPayload(HalfBlockPayload):
             block.previous_hash,
             block.signature,
             block.transaction,
+            block.timestamp,
             ttl
         )
 
@@ -113,10 +118,10 @@ class CrawlResponsePayload(Payload):
     Payload for the response to a crawl request.
     """
 
-    format_list = ['74s', 'I', '74s', 'I', '32s', '64s', 'varlenI', 'I', 'I', 'I']
+    format_list = ['74s', 'I', '74s', 'I', '32s', '64s', 'varlenI', 'Q', 'I', 'I', 'I']
 
     def __init__(self, public_key, sequence_number, link_public_key, link_sequence_number, previous_hash, signature,
-                 transaction, crawl_id, cur_count, total_count):
+                 transaction, timestamp, crawl_id, cur_count, total_count):
         super(CrawlResponsePayload, self).__init__()
         self.public_key = public_key
         self.sequence_number = sequence_number
@@ -125,6 +130,7 @@ class CrawlResponsePayload(Payload):
         self.previous_hash = previous_hash
         self.signature = signature
         self.transaction = transaction
+        self.timestamp = timestamp
         self.crawl_id = crawl_id
         self.cur_count = cur_count
         self.total_count = total_count
@@ -139,6 +145,7 @@ class CrawlResponsePayload(Payload):
             block.previous_hash,
             block.signature,
             block.transaction,
+            block.timestamp,
             crawl_id,
             cur_count,
             total_count,
@@ -152,6 +159,7 @@ class CrawlResponsePayload(Payload):
                 ('32s', self.previous_hash),
                 ('64s', self.signature),
                 ('varlenI', encode(self.transaction)),
+                ('Q', self.timestamp),
                 ('I', self.crawl_id),
                 ('I', self.cur_count),
                 ('I', self.total_count)]
@@ -168,11 +176,11 @@ class HalfBlockPairPayload(Payload):
     Payload for message that ships two half blocks
     """
 
-    format_list = ['74s', 'I', '74s', 'I', '32s', '64s', 'varlenI'] * 2
+    format_list = ['74s', 'I', '74s', 'I', '32s', '64s', 'varlenI', 'Q'] * 2
 
     def __init__(self, public_key1, sequence_number1, link_public_key1, link_sequence_number1, previous_hash1,
-                 signature1, transaction1, public_key2, sequence_number2, link_public_key2, link_sequence_number2,
-                 previous_hash2, signature2, transaction2):
+                 signature1, transaction1, timestamp1, public_key2, sequence_number2, link_public_key2,
+                 link_sequence_number2, previous_hash2, signature2, transaction2, timestamp2):
         super(HalfBlockPairPayload, self).__init__()
         self.public_key1 = public_key1
         self.sequence_number1 = sequence_number1
@@ -181,6 +189,7 @@ class HalfBlockPairPayload(Payload):
         self.previous_hash1 = previous_hash1
         self.signature1 = signature1
         self.transaction1 = transaction1
+        self.timestamp1 = timestamp1
 
         self.public_key2 = public_key2
         self.sequence_number2 = sequence_number2
@@ -189,6 +198,7 @@ class HalfBlockPairPayload(Payload):
         self.previous_hash2 = previous_hash2
         self.signature2 = signature2
         self.transaction2 = transaction2
+        self.timestamp2 = timestamp2
 
     @classmethod
     def from_half_blocks(cls, block1, block2):
@@ -200,13 +210,15 @@ class HalfBlockPairPayload(Payload):
             block1.previous_hash,
             block1.signature,
             block1.transaction,
+            block1.timestamp,
             block2.public_key,
             block2.sequence_number,
             block2.link_public_key,
             block2.link_sequence_number,
             block2.previous_hash,
             block2.signature,
-            block2.transaction
+            block2.transaction,
+            block2.timestamp
         )
 
     def to_pack_list(self):
@@ -217,13 +229,15 @@ class HalfBlockPairPayload(Payload):
                 ('32s', self.previous_hash1),
                 ('64s', self.signature1),
                 ('varlenI', encode(self.transaction1)),
+                ('Q', self.timestamp1),
                 ('74s', self.public_key2),
                 ('I', self.sequence_number2),
                 ('74s', self.link_public_key2),
                 ('I', self.link_sequence_number2),
                 ('32s', self.previous_hash2),
                 ('64s', self.signature2),
-                ('varlenI', encode(self.transaction2))]
+                ('varlenI', encode(self.transaction2)),
+                ('Q', self.timestamp2)]
 
         return data
 
@@ -237,16 +251,16 @@ class HalfBlockPairBroadcastPayload(HalfBlockPairPayload):
     Payload for a broadcast message that ships two half blocks
     """
 
-    format_list = ['74s', 'I', '74s', 'I', '32s', '64s', 'varlenI'] * 2 + ['I']
+    format_list = ['74s', 'I', '74s', 'I', '32s', '64s', 'varlenI', 'Q'] * 2 + ['I']
 
     def __init__(self, public_key1, sequence_number1, link_public_key1, link_sequence_number1, previous_hash1,
-                 signature1, transaction1, public_key2, sequence_number2, link_public_key2, link_sequence_number2,
-                 previous_hash2, signature2, transaction2, ttl):
+                 signature1, transaction1, timestamp1, public_key2, sequence_number2, link_public_key2,
+                 link_sequence_number2, previous_hash2, signature2, transaction2, timestamp2, ttl):
         super(HalfBlockPairBroadcastPayload, self).__init__(public_key1, sequence_number1, link_public_key1,
                                                             link_sequence_number1, previous_hash1, signature1,
-                                                            transaction1, public_key2, sequence_number2,
+                                                            transaction1, timestamp1, public_key2, sequence_number2,
                                                             link_public_key2, link_sequence_number2, previous_hash2,
-                                                            signature2, transaction2)
+                                                            signature2, transaction2, timestamp2)
         self.ttl = ttl
 
     @classmethod
@@ -259,6 +273,7 @@ class HalfBlockPairBroadcastPayload(HalfBlockPairPayload):
             block1.previous_hash,
             block1.signature,
             block1.transaction,
+            block1.timestamp,
             block2.public_key,
             block2.sequence_number,
             block2.link_public_key,
@@ -266,6 +281,7 @@ class HalfBlockPairBroadcastPayload(HalfBlockPairPayload):
             block2.previous_hash,
             block2.signature,
             block2.transaction,
+            block2.timestamp,
             ttl
         )
 

--- a/ipv8/test/attestation/trustchain/test_block.py
+++ b/ipv8/test/attestation/trustchain/test_block.py
@@ -23,7 +23,7 @@ class TestBlock(TrustChainBlock):
         if previous:
             self.key = previous.key
             TrustChainBlock.__init__(self, (encode(transaction), previous.public_key, previous.sequence_number + 1,
-                                            other, 0, previous.hash, 0, 0))
+                                            other, 0, previous.hash, 0, 0, 0))
         else:
             if key:
                 self.key = key
@@ -32,7 +32,7 @@ class TestBlock(TrustChainBlock):
 
             TrustChainBlock.__init__(self, (
                 encode(transaction), self.key.pub().key_to_bin(), random.randint(50, 100), other, 0,
-                sha256(str(random.randint(0, 100000))).digest(), 0, 0))
+                sha256(str(random.randint(0, 100000))).digest(), 0, 0, 0))
         self.sign(self.key)
 
         self.transaction_validation_result = (ValidationResult.valid, [])
@@ -95,8 +95,9 @@ class TestTrustChainBlock(unittest.TestCase):
         Test the empty hash of a block
         """
         block = TrustChainBlock()
-        self.assertEqual(block.hash, '\x1f\x1bp\x90\xe3>\x83\xf6\xcd\xafd\xd9\xee\xfb"&|<ZLsyB:Z\r'
-                                     '<\xc5\xb0\x97\xa3\xaf')
+        block.timestamp = 0  # To make the hash the same between runs
+        self.assertEqual(block.hash, '\x12s\xdd\xd9\xb0`^(b\xaby\xaf\xf8\x12\x10L\xfd\x91\x94\xa0i\xcc\xb2'
+                                     ' \xa9\\\xe0\x8b6\t$7')
 
     def test_sign(self):
         """

--- a/ipv8/test/attestation/trustchain/test_community.py
+++ b/ipv8/test/attestation/trustchain/test_community.py
@@ -277,8 +277,6 @@ class TestTrustChainCommunity(TestBase):
         signed2 = self.nodes[0].overlay.sign_block(self.nodes[0].network.verified_peers[0], public_key=his_pubkey,
                                                    block_type='test', transaction={})
 
-        yield self.deliver_messages()
-
         yield signed1
         yield signed2
 

--- a/ipv8/test/attestation/trustchain/test_community.py
+++ b/ipv8/test/attestation/trustchain/test_community.py
@@ -1,9 +1,22 @@
 from ....attestation.trustchain.caches import CrawlRequestCache
 from ....attestation.trustchain.community import TrustChainCommunity, UNKNOWN_SEQ
+from ....attestation.trustchain.listener import BlockListener
 from ...attestation.trustchain.test_block import TestBlock
 from ...base import TestBase
 from ...mocking.ipv8 import MockIPv8
 from ...util import twisted_wrapper
+
+
+class TestBlockListener(BlockListener):
+    """
+    This block listener simply signs all blocks it receives.
+    """
+
+    def should_sign(self, block):
+        return True
+
+    def received_block(self, block):
+        pass
 
 
 class TestTrustChainCommunity(TestBase):
@@ -11,6 +24,9 @@ class TestTrustChainCommunity(TestBase):
     def setUp(self):
         super(TestTrustChainCommunity, self).setUp()
         self.initialize(TrustChainCommunity, 2)
+
+        for node in self.nodes:
+            node.overlay.add_listener(TestBlockListener(), ['test'])
 
     def create_node(self):
         return MockIPv8(u"curve25519", TrustChainCommunity, working_directory=u":memory:")
@@ -27,7 +43,7 @@ class TestTrustChainCommunity(TestBase):
         my_pubkey = self.nodes[0].my_peer.public_key.key_to_bin()
         his_pubkey = self.nodes[0].network.verified_peers[0].public_key.key_to_bin()
         self.nodes[0].overlay.sign_block(self.nodes[0].network.verified_peers[0], public_key=his_pubkey,
-                                         transaction={})
+                                         block_type='test', transaction={})
 
         yield self.deliver_messages()
 
@@ -44,7 +60,7 @@ class TestTrustChainCommunity(TestBase):
 
         his_pubkey = self.nodes[0].network.verified_peers[0].public_key.key_to_bin()
         yield self.nodes[0].overlay.sign_block(self.nodes[0].network.verified_peers[0], public_key=his_pubkey,
-                                               transaction={})
+                                               block_type='test', transaction={})
 
         for node_nr in [0, 1]:
             self.assertIsNotNone(self.nodes[node_nr].overlay.persistence.get(his_pubkey, 1))
@@ -60,7 +76,7 @@ class TestTrustChainCommunity(TestBase):
         my_pubkey = self.nodes[0].my_peer.public_key.key_to_bin()
         his_pubkey = self.nodes[0].network.verified_peers[0].public_key.key_to_bin()
         self.nodes[0].overlay.sign_block(self.nodes[0].network.verified_peers[0], public_key=his_pubkey,
-                                         transaction={})
+                                         block_type='test', transaction={})
 
         yield self.deliver_messages()
 
@@ -88,7 +104,7 @@ class TestTrustChainCommunity(TestBase):
         my_pubkey = self.nodes[0].my_peer.public_key.key_to_bin()
         his_pubkey = self.nodes[0].network.verified_peers[0].public_key.key_to_bin()
         self.nodes[0].overlay.sign_block(self.nodes[0].network.verified_peers[0], public_key=his_pubkey,
-                                         transaction={})
+                                         block_type='test', transaction={})
 
         yield self.deliver_messages()
 
@@ -116,7 +132,7 @@ class TestTrustChainCommunity(TestBase):
         my_pubkey = self.nodes[0].my_peer.public_key.key_to_bin()
         his_pubkey = self.nodes[0].network.verified_peers[0].public_key.key_to_bin()
         self.nodes[0].overlay.sign_block(self.nodes[0].network.verified_peers[0], public_key=his_pubkey,
-                                         transaction={})
+                                         block_type='test', transaction={})
 
         yield self.deliver_messages()
 
@@ -154,7 +170,7 @@ class TestTrustChainCommunity(TestBase):
         my_pubkey = self.nodes[0].my_peer.public_key.key_to_bin()
         his_pubkey = self.nodes[0].network.verified_peers[0].public_key.key_to_bin()
         self.nodes[0].overlay.sign_block(self.nodes[0].network.verified_peers[0], public_key=his_pubkey,
-                                         transaction={})
+                                         block_type='test', transaction={})
 
         yield self.deliver_messages()
         self.assertIsNone(self.nodes[1].overlay.persistence.get(my_pubkey, 1))
@@ -178,7 +194,7 @@ class TestTrustChainCommunity(TestBase):
         his_pubkey = self.nodes[0].network.verified_peers[0].public_key.key_to_bin()
         for _ in xrange(0, 3):
             self.nodes[0].overlay.sign_block(self.nodes[0].network.verified_peers[0], public_key=his_pubkey,
-                                             transaction={})
+                                             block_type='test', transaction={})
 
         yield self.deliver_messages()
 
@@ -199,7 +215,7 @@ class TestTrustChainCommunity(TestBase):
 
         his_pubkey = self.nodes[0].network.verified_peers[0].public_key.key_to_bin()
         yield self.nodes[0].overlay.sign_block(self.nodes[0].network.verified_peers[0], public_key=his_pubkey,
-                                               transaction={})
+                                               block_type='test', transaction={})
 
         self.add_node_to_experiment(self.create_node())
 
@@ -219,9 +235,9 @@ class TestTrustChainCommunity(TestBase):
 
         his_pubkey = self.nodes[0].network.verified_peers[0].public_key.key_to_bin()
         self.nodes[0].overlay.sign_block(self.nodes[0].network.verified_peers[0], public_key=his_pubkey,
-                                         transaction={})
+                                         block_type='test', transaction={})
         self.nodes[0].overlay.sign_block(self.nodes[0].network.verified_peers[0], public_key=his_pubkey,
-                                         transaction={})
+                                         block_type='test', transaction={})
 
         yield self.deliver_messages()
 
@@ -253,13 +269,13 @@ class TestTrustChainCommunity(TestBase):
         his_pubkey = self.nodes[0].network.verified_peers[0].public_key.key_to_bin()
         self.nodes[0].endpoint.close()
         signed1 = self.nodes[0].overlay.sign_block(self.nodes[0].network.verified_peers[0], public_key=his_pubkey,
-                                                   transaction={})
+                                                   block_type='test', transaction={})
 
         yield self.deliver_messages()
 
         self.nodes[0].endpoint.open()
         signed2 = self.nodes[0].overlay.sign_block(self.nodes[0].network.verified_peers[0], public_key=his_pubkey,
-                                                   transaction={})
+                                                   block_type='test', transaction={})
 
         yield self.deliver_messages()
 
@@ -348,6 +364,7 @@ class TestTrustChainCommunity(TestBase):
             node 1 and 3.
         """
         node3 = self.create_node()
+        node3.overlay.add_listener(TestBlockListener(), ['test'])
         node3.my_peer.address = node3.endpoint.wan_address
         self.nodes.append(node3)
         # Disable broadcasting to others on signing (we don't want to test that here)
@@ -358,7 +375,7 @@ class TestTrustChainCommunity(TestBase):
         his_pubkey = self.nodes[0].network.verified_peers[0].public_key.key_to_bin()
         node3_pubkey = self.nodes[2].overlay.my_peer.public_key.key_to_bin()
         yield self.nodes[0].overlay.sign_block(self.nodes[0].network.verified_peers[0], public_key=his_pubkey,
-                                               transaction={})
+                                               block_type='test', transaction={})
 
         # Perform the first crawl with all nodes
         yield self.introduce_nodes()
@@ -369,7 +386,8 @@ class TestTrustChainCommunity(TestBase):
                              UNKNOWN_SEQ)
 
         # Perform a transaction between node 1 and 3
-        yield self.nodes[0].overlay.sign_block(node3.my_peer, public_key=node3_pubkey, transaction={})
+        yield self.nodes[0].overlay.sign_block(node3.my_peer, public_key=node3_pubkey,
+                                               block_type='test', transaction={})
 
         # Perform the second crawl with all nodes
         yield self.introduce_nodes()
@@ -402,7 +420,7 @@ class TestTrustChainCommunity(TestBase):
         my_pubkey = self.nodes[0].overlay.my_peer.public_key.key_to_bin()
         his_pubkey = self.nodes[0].network.verified_peers[0].public_key.key_to_bin()
         yield self.nodes[0].overlay.sign_block(self.nodes[0].network.verified_peers[0], public_key=his_pubkey,
-                                               transaction={})
+                                               block_type='test', transaction={})
 
         yield self.deliver_messages()
 
@@ -418,7 +436,7 @@ class TestTrustChainCommunity(TestBase):
         yield self.introduce_nodes()
 
         my_pubkey = self.nodes[0].overlay.my_peer.public_key.key_to_bin()
-        yield self.nodes[0].overlay.self_sign_block(transaction={})
+        yield self.nodes[0].overlay.self_sign_block(block_type='test', transaction={})
 
         yield self.deliver_messages()
 

--- a/ipv8/test/mocking/ipv8.py
+++ b/ipv8/test/mocking/ipv8.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+from ...attestation.trustchain.community import TrustChainCommunity
 from ...keyvault.crypto import ECCrypto
 from ...peer import Peer
 from ...peerdiscovery.network import Network
@@ -9,11 +10,18 @@ from .discovery import MockWalk
 
 class MockIPv8(object):
 
-    def __init__(self, crypto_curve, overlay_class, *args, **kwargs):
+    def __init__(self, crypto_curve, overlay_class, create_trustchain=False, *args, **kwargs):
         self.endpoint = AutoMockEndpoint()
         self.endpoint.open()
         self.network = Network()
         self.my_peer = Peer(ECCrypto().generate_key(crypto_curve), self.endpoint.wan_address)
+
+        # Load a TrustChain community if specified
+        self.trustchain = None
+        if create_trustchain:
+            self.trustchain = TrustChainCommunity(self.my_peer, self.endpoint, self.network,
+                                                  working_directory=u":memory:")
+            kwargs.update({'trustchain': self.trustchain})
         self.overlay = overlay_class(self.my_peer, self.endpoint, self.network, *args, **kwargs)
         self.overlay._use_main_thread = False
         self.discovery = MockWalk(self.overlay)
@@ -24,3 +32,5 @@ class MockIPv8(object):
     def unload(self):
         self.endpoint.close()
         self.overlay.unload()
+        if self.trustchain:
+            self.trustchain.unload()


### PR DESCRIPTION
In this PR, I refactored the TrustChain overlay so it's a generic ledger that is reusable across several domains. The most important change is that each transaction now should have a type (i.e. `ask`, `tribler_bandwidth`, `attestation` etc). This transaction type is also stored in the database as a separate column for easy lookups. For instance, this allows us to get all blocks with an `attestation` transaction.

In addition, I also added a timestamp to each TrustChain record. These changes are included in this PR since it also breaks backward compatibility so I guess it's ok to combine it with the other breaking change (merging all chains together).