### PR TITLE
Added support for smaller prime generation

### DIFF
--- a/ipv8/attestation/wallet/primitives/cryptosystem/boneh.py
+++ b/ipv8/attestation/wallet/primitives/cryptosystem/boneh.py
@@ -86,18 +86,23 @@ def get_good_wp(n, p=None):
     return p, wp
 
 
-def generate_primes(key_size=512):
+def generate_primes(key_size=128):
     """
-    Generate some primes. Key size in bits (minimum 512).
+    Generate some primes. Key size in bits.
     """
-    from cryptography.hazmat.backends import default_backend
-    from cryptography.hazmat.primitives.asymmetric import rsa
-    private_key = rsa.generate_private_key(public_exponent=65537,key_size=key_size,backend=default_backend())
-    private_numbers = private_key.private_numbers()
-    return min(private_numbers.p, private_numbers.q), max(private_numbers.p, private_numbers.q)
+    if key_size >= 512:
+        from cryptography.hazmat.backends import default_backend
+        from cryptography.hazmat.primitives.asymmetric import rsa
+        private_key = rsa.generate_private_key(public_exponent=65537, key_size=key_size, backend=default_backend())
+        private_numbers = private_key.private_numbers()
+        p, q = private_numbers.p, private_numbers.q
+    else:
+        import gensafeprime
+        p, q = gensafeprime.generate(key_size), gensafeprime.generate(key_size)
+    return min(p, q), max(p, q)
 
 
-def generate_keypair(key_size=512):
+def generate_keypair(key_size=128):
     """
     Generate a keypair for a certain prime bit space.
     """

--- a/ipv8/test/attestation/wallet/primitives/cryptosystem/test_boneh.py
+++ b/ipv8/test/attestation/wallet/primitives/cryptosystem/test_boneh.py
@@ -96,3 +96,16 @@ class TestBoneh(unittest.TestCase):
         PK = TestBoneh.private_key.public_key()
 
         self.assertIsNone(decode(TestBoneh.private_key, [0], encode(PK, 1)))
+
+    def test_generate_keypair(self):
+        """
+        Check if we can create a new keypair.
+        """
+        PK, SK = generate_keypair(32)
+
+        self.assertEqual(PK.p, SK.p)
+        self.assertEqual(PK.g, SK.g)
+        self.assertEqual(PK.h, SK.h)
+        self.assertEqual(decode(SK, [0, 1, 2], encode(PK, 0)), 0)
+        self.assertEqual(decode(SK, [0, 1, 2], encode(PK, 1)), 1)
+        self.assertEqual(decode(SK, [0, 1, 2], encode(PK, 2)), 2)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ netifaces
 networkx
 Twisted
 pyOpenSSL
+gensafeprime


### PR DESCRIPTION
Fixes #106 

This sets the default prime size to 128 bit, this leads to 256 bit EC keys (which is still 4 times larger than the curve25519 keys we use for TrustChain).

And we only use this for a 2 bit message space 🤓 