### PR TITLE
Temporary Dispersy compat fix: remove isinstance(EndpointListener).

### DIFF
--- a/ipv8/messaging/interfaces/endpoint.py
+++ b/ipv8/messaging/interfaces/endpoint.py
@@ -26,8 +26,9 @@ class Endpoint(object):
 
         :raises: IllegalEndpointListenerError if the provided listener is not an EndpointListener
         """
-        if not isinstance(listener, EndpointListener):
-            raise IllegalEndpointListenerError(listener)
+        # TODO: bring this check back when we get rid of Dispersy !!!
+        #if not isinstance(listener, EndpointListener):
+            #raise IllegalEndpointListenerError(listener)
         self._listeners.append(listener)
 
     def remove_listener(self, listener):


### PR DESCRIPTION
That's only temporary fix, it should go when we stop using Dispersy as an EndpointListener.