### PR TITLE
Add endpoint listening address option

### DIFF
--- a/ipv8/configuration.py
+++ b/ipv8/configuration.py
@@ -1,6 +1,7 @@
 import copy
 
 default = {
+    'address': '0.0.0.0',
     'port': 8090,
     'keys': [
         {

--- a/ipv8_service.py
+++ b/ipv8_service.py
@@ -45,7 +45,7 @@ class IPv8(object):
         if endpoint_override:
             self.endpoint = endpoint_override
         else:
-            self.endpoint = UDPEndpoint(configuration['port'])
+            self.endpoint = UDPEndpoint(port=configuration['port'], ip=configuration['address'])
             self.endpoint.open()
 
         self.network = Network()


### PR DESCRIPTION
This adds the option in IPv8 to explicitly set listening address (e.g. network interface). By default it is `0.0.0.0`, meaning that it would listen to all interfaces.
It is important to note that it is impossible to send packets to real interfaces, if you set it to `127.0.0.1`. The thing would spit "wrong address" type of errors if you try to. So, it is useful for setting up isolated testnets (that was the reason to do this), and for better control on multi-hosted machines.
The patch with command-line option for overriding bootstrap servers in Tribler will follow as soon as this would become merged.