### PR TITLE
Fixed introduce_nodes test method

### DIFF
--- a/ipv8/test/attestation/trustchain/test_community.py
+++ b/ipv8/test/attestation/trustchain/test_community.py
@@ -349,6 +349,10 @@ class TestTrustChainCommunity(TestBase):
         node3 = self.create_node()
         node3.my_peer.address = node3.endpoint.wan_address
         self.nodes.append(node3)
+        # Disable broadcasting to others on signing (we don't want to test that here)
+        for node in self.nodes:
+            node.overlay.broadcast_block = False
+
         my_pubkey = self.nodes[0].my_peer.public_key.key_to_bin()
         his_pubkey = self.nodes[0].network.verified_peers[0].public_key.key_to_bin()
         node3_pubkey = self.nodes[2].overlay.my_peer.public_key.key_to_bin()

--- a/ipv8/test/base.py
+++ b/ipv8/test/base.py
@@ -132,8 +132,10 @@ class TestBase(unittest.TestCase):
     @inlineCallbacks
     def introduce_nodes(self):
         for node in self.nodes:
-            node.discovery.take_step()
-        yield self.sleep()
+            for other in self.nodes:
+                if other != node:
+                    node.overlay.walk_to(other.endpoint.wan_address)
+        yield self.deliver_messages()
 
     def temporary_directory(self):
         d = os.path.join("temp", self.__class__.__name__ + str(int(time.time())))


### PR DESCRIPTION
Fixes #135

Instead of sleeping a fixed amount of time, we deliver messages. This apparently was causing the (slower) test machine to rarely fail.

I also had to fix a test which depended on the old implementation (involving racing the block broadcasting).