### PR TITLE
Fixed negative number of circuits needed

### DIFF
--- a/ipv8/messaging/anonymization/community.py
+++ b/ipv8/messaging/anonymization/community.py
@@ -207,7 +207,7 @@ class TunnelCommunity(Community):
 
     def do_circuits(self):
         for circuit_length, num_circuits in self.circuits_needed.items():
-            num_to_build = num_circuits - len(self.data_circuits(circuit_length))
+            num_to_build = max(0, num_circuits - len(self.data_circuits(circuit_length)))
             self.logger.info("want %d data circuits of length %d", num_to_build, circuit_length)
             for _ in range(num_to_build):
                 if not self.create_circuit(circuit_length):


### PR DESCRIPTION
This issue occurs when we have more circuits than we actually need, which can happen just after removing a download. The logging statement would then report that we need a negative amount of circuits, which is slightly confusing.