### PR TITLE
Fixed pending attestation request from previous id on clear

### DIFF
--- a/ipv8/REST/attestation_endpoint.py
+++ b/ipv8/REST/attestation_endpoint.py
@@ -104,6 +104,7 @@ class AttestationEndpoint(resource.Resource):
             self.identity_overlay.persistence.commit()
             self.attestation_overlay.database.execute('DELETE FROM %s' % self.attestation_overlay.database.db_name)
             self.attestation_overlay.database.commit()
+            self.attestation_requests.clear()
         return ""
 
     def render_POST(self, request):


### PR DESCRIPTION
This fixes leftover attestation requests from before the id wipe.