### PR TITLE
Added support for newer versions of cryptography

### DIFF
--- a/ipv8/keyvault/__init__.py
+++ b/ipv8/keyvault/__init__.py
@@ -1,0 +1,25 @@
+def _should_use_new_crypto_version():
+    """
+    Checks if this python-cryptography supports the new signing and verifying methods.
+
+    As of version 1.5.x cryptography has the `sign` and `verify` methods.
+    As of version 2.x, the `signer` and `verifier` methods have been deprecated.
+
+    :return: whether we should use the new signing/verifying methods
+    :rtype: bool
+    """
+    import cryptography
+    from distutils.version import LooseVersion
+    try:
+        cryptography_version = LooseVersion(cryptography.__version__)
+        return cryptography_version >= LooseVersion('1.5')
+    except (AttributeError, UnicodeEncodeError):
+        # Empty strings raise AttributeError
+        # Illegal unicode characters raise UnicodeEncodeError
+        return False
+
+
+NEW_CRYPTOGRAPHY_SIGN_VERSION = _should_use_new_crypto_version()
+
+
+__all__ = ['NEW_CRYPTOGRAPHY_SIGN_VERSION']

--- a/ipv8/keyvault/private/m2crypto.py
+++ b/ipv8/keyvault/private/m2crypto.py
@@ -5,6 +5,7 @@ from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives.asymmetric.utils import decode_dss_signature
 
+from .. import NEW_CRYPTOGRAPHY_SIGN_VERSION
 from ...keyvault.public.m2crypto import M2CryptoPK
 from ...keyvault.keys import PrivateKey
 
@@ -67,9 +68,12 @@ class M2CryptoSK(PrivateKey, M2CryptoPK):
         :param msg: the message to sign
         """
         # Create the pyca signature
-        signer = self.ec.signer(ec.ECDSA(hashes.SHA1()))
-        signer.update(msg)
-        signature = signer.finalize()
+        if NEW_CRYPTOGRAPHY_SIGN_VERSION:
+            signature = self.ec.sign(msg, ec.ECDSA(hashes.SHA1()))
+        else:
+            signer = self.ec.signer(ec.ECDSA(hashes.SHA1()))
+            signer.update(msg)
+            signature = signer.finalize()
         # Decode the DSS r and s variables from the pyca signature
         # We are going to turn these longs into (binary) string format
         r, s = decode_dss_signature(signature)

--- a/ipv8/keyvault/public/m2crypto.py
+++ b/ipv8/keyvault/public/m2crypto.py
@@ -7,6 +7,7 @@ from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives.asymmetric.utils import encode_dss_signature
 
+from .. import NEW_CRYPTOGRAPHY_SIGN_VERSION
 from ...keyvault.keys import PublicKey
 
 
@@ -81,7 +82,10 @@ class M2CryptoPK(PublicKey):
         s = int(hexlify(s), 16)
         # verify
         try:
-            self.ec.verifier(encode_dss_signature(r, s), ec.ECDSA(hashes.SHA1()))
+            if NEW_CRYPTOGRAPHY_SIGN_VERSION:
+                self.ec.verify(encode_dss_signature(r, s), msg, ec.ECDSA(hashes.SHA1()))
+            else:
+                self.ec.verifier(encode_dss_signature(r, s), ec.ECDSA(hashes.SHA1()))
             return True
         except InvalidSignature:
             return False


### PR DESCRIPTION
Newer versions of python cryptography give a deprecation warning when you use the old `verifier()` and `signer()` methods.

This PR also allows for older cryptography versions to still function (although you probably shouldn't run those).

P.S. For anyone seeing the `InvalidSignature` for the first time: https://cryptography.io/en/latest/changelog/#v1-9