### PR TITLE
Endpoint stresstest properly exits

### DIFF
--- a/stresstest/endpoint_stresstest.py
+++ b/stresstest/endpoint_stresstest.py
@@ -3,6 +3,7 @@ from os import makedirs, path, rename
 from random import randint
 from shutil import rmtree
 from subprocess import call
+from sys import exit as _exit
 from time import sleep, time
 
 from twisted.internet import reactor
@@ -218,3 +219,9 @@ if retcode > 0:
             print "Significant slowdown in %s" % errmap[i]
 else:
     print "Stresstest found no significant slowdown"
+
+# This should be the last block of code in the file
+if retcode > 0:
+    _exit(1)
+else:
+    _exit(0)

--- a/stresstest/endpoint_stresstest_plot.R
+++ b/stresstest/endpoint_stresstest_plot.R
@@ -77,7 +77,7 @@ data_diff_b <- diff(b$count)
 speeds_a <- mapply(function(x, y) x/y, data_diff_a, time_diff_a)
 speeds_b <- mapply(function(x, y) x/y, data_diff_b, time_diff_b)
 # A positive value would be a speed-up, which we are fine with
-if (t.test(speeds_a, speeds_b)[['statistic']][['t']]  <= -31.82) {
+if (t.test(speeds_a, speeds_b)[['statistic']][['t']]  <= -13) {
 return(bitwOr(bitwShiftL(errors, 1), 1))
 }
 return(bitwShiftL(errors, 1))


### PR DESCRIPTION
As `bbq` is faster than my laptop, it requires a stricter variance to check for slowdown.