### PR TITLE
Fixed AutoMockEndpoint picking illegal addresses

### DIFF
--- a/ipv8/test/mocking/community.py
+++ b/ipv8/test/mocking/community.py
@@ -17,6 +17,8 @@ class MockCommunity(DiscoveryCommunity):
         super(MockCommunity, self).__init__(peer, endpoint, network)
         # workaround for race conditions in deliver_messages
         self._use_main_thread = False
+        self.my_estimated_lan = endpoint.lan_address
+        self.my_estimated_wan = endpoint.wan_address
 
     def bootstrap(self):
         super(MockCommunity, self).bootstrap()

--- a/ipv8/test/mocking/endpoint.py
+++ b/ipv8/test/mocking/endpoint.py
@@ -46,10 +46,17 @@ class MockEndpoint(Endpoint):
         self._open = False
 
 
+class AddressTester(EndpointListener):
+
+    def on_packet(self, packet):
+        pass
+
+
 class AutoMockEndpoint(MockEndpoint):
 
     def __init__(self):
         super(AutoMockEndpoint, self).__init__(self._generate_unique_address(), self._generate_unique_address())
+        self._port = 0
 
     def _generate_address(self):
         b0 = random.randint(0, 255)
@@ -60,10 +67,18 @@ class AutoMockEndpoint(MockEndpoint):
 
         return ('%d.%d.%d.%d' % (b0, b1, b2, b3), port)
 
+    def _is_lan(self, address):
+        """
+        Avoid false positives for the actual machine's lan.
+        """
+        self._port = address[1]
+        address_tester = AddressTester(self)
+        return address_tester.address_is_lan(address[0])
+
     def _generate_unique_address(self):
         address = self._generate_address()
 
-        while address in internet:
+        while address in internet or self._is_lan(address):
             address = self._generate_address()
 
         return address


### PR DESCRIPTION
Fixes  #192

This PR fixes two obscure errors in the tests, both having to do with address resolution:

 1. Sometimes a Community will not have had any chance to estimate its own wan address and will therefore try to use the machine's estimated lan address. This can throw off the tests which assume a stable ip.
 2. The generated addresses by `AutoMockEndpoint` may be flagged (false positive) as lan addresses as the actual machine's address is not part of the fake internet layer provided by the mocked endpoints.