### PR TITLE
Fixed mutable Peer __hash__()

### DIFF
--- a/ipv8/peer.py
+++ b/ipv8/peer.py
@@ -1,5 +1,4 @@
-from socket import inet_aton
-from struct import pack, unpack
+from struct import unpack
 from time import time
 
 from .keyvault.crypto import ECCrypto
@@ -44,12 +43,8 @@ class Peer(object):
         return self._lamport_timestamp
 
     def __hash__(self):
-        address = inet_aton(self.address[0]) + pack(">I", self.address[1])
-        mid = self.mid[0:8]
-        out = ""
-        for i in range(8):
-            out += chr(ord(mid[i]) ^ ord(address[i]))
-        return unpack(">Q", out)[0]
+        as_long, = unpack(">Q", self.mid[:8])
+        return as_long
 
     def __eq__(self, other):
         if not isinstance(other, Peer):


### PR DESCRIPTION
Fixes #194 .

Before, a Peer's `__hash__()` was mutable through changes in the address. With this PR the hash is based on only the mid of a Peer, which is immutable (as it should be).