### PR TITLE
Use new key in whitewashing attack

### DIFF
--- a/ipv8/REST/attestation_endpoint.py
+++ b/ipv8/REST/attestation_endpoint.py
@@ -8,6 +8,8 @@ from ..attestation.identity.community import IdentityCommunity
 from ..attestation.wallet.community import AttestationCommunity
 from ..attestation.wallet.primitives.attestation import binary_relativity_sha256_4
 from ..attestation.wallet.primitives.cryptosystem.boneh import generate_keypair
+from ..keyvault.crypto import ECCrypto
+from ..peer import Peer
 
 
 class AttestationEndpoint(resource.Resource):
@@ -111,6 +113,9 @@ class AttestationEndpoint(resource.Resource):
             self.attestation_overlay.database.execute('DELETE FROM %s' % self.attestation_overlay.database.db_name)
             self.attestation_overlay.database.commit()
             self.attestation_requests.clear()
+            my_new_peer = Peer(ECCrypto().generate_key(u"curve25519"))
+            self.identity_overlay.my_peer = my_new_peer
+            self.attestation_overlay.my_peer = my_new_peer
         return ""
 
     def render_POST(self, request):


### PR DESCRIPTION
The existing whitewashing attack was not good enough: Trustchain detected it as double spending. It turns out we need an entirely new key to subvert the detection mechanism. Good for Trustchain, bad for the attacker.