### PR TITLE
Deprecated _ez_unpack_* function calls swap with  lazy_wrapper decorators

### DIFF
--- a/ipv8/deprecated/community.py
+++ b/ipv8/deprecated/community.py
@@ -13,9 +13,7 @@ import sys
 from time import time
 from traceback import format_exception
 
-from ..keyvault.crypto import ECCrypto
-from ..overlay import Overlay
-from ..peer import Peer
+from .lazy_community import lazy_wrapper, lazy_wrapper_unsigned, EZPackOverlay
 from .payload import IntroductionRequestPayload, IntroductionResponsePayload, PuncturePayload, PunctureRequestPayload
 from .payload_headers import BinMemberAuthenticationPayload, GlobalTimeDistributionPayload
 
@@ -43,138 +41,7 @@ _DNS_ADDRESSES = [
 ]
 
 
-BOOTSTRAP_TIMEOUT = 30.0 # Timeout before we bootstrap again (bootstrap kills performance)
-
-
-def lazy_wrapper(*payloads):
-    """
-    This function wrapper will unpack the BinMemberAuthenticationPayload for you.
-
-    You can now write your authenticated and signed functions as follows:
-
-    ::
-
-        @lazy_wrapper(GlobalTimeDistributionPayload, IntroductionRequestPayload, IntroductionResponsePayload)
-        def on_message(peer, payload1, payload2):
-            '''
-            :type peer: Peer
-            :type payload1: IntroductionRequestPayload
-            :type payload2: IntroductionResponsePayload
-            '''
-            pass
-    """
-    def decorator(func):
-        def wrapper(self, source_address, data):
-            # UNPACK
-            auth, remainder = self.serializer.unpack_to_serializables([BinMemberAuthenticationPayload, ], data[23:])
-            signature_valid, remainder = self._verify_signature(auth, data)
-            unpacked = self.serializer.unpack_to_serializables(payloads, remainder[23:])
-            output, unknown_data = unpacked[:-1], unpacked[-1]
-            # ASSERT
-            if len(unknown_data) != 0:
-                raise PacketDecodingError("Incoming packet %s (%s) has extra data: (%s)" %
-                                          (str([payload_class.__name__ for payload_class in payloads]),
-                                           data.encode('HEX'),
-                                           unknown_data.encode('HEX')))
-
-            if not signature_valid:
-                raise PacketDecodingError("Incoming packet %s has an invalid signature" % \
-                                          str([payload_class.__name__ for payload_class in payloads]))
-            # PRODUCE
-            return func(self, Peer(auth.public_key_bin, source_address), *output)
-        return wrapper
-    return decorator
-
-
-def lazy_wrapper_unsigned(*payloads):
-    """
-    This function wrapper will unpack just the normal payloads for you.
-
-    You can now write your non-authenticated and signed functions as follows:
-
-    ::
-
-        @lazy_wrapper(GlobalTimeDistributionPayload, IntroductionRequestPayload, IntroductionResponsePayload)
-        def on_message(source_address, payload1, payload2):
-            '''
-            :type source_address: str
-            :type payload1: IntroductionRequestPayload
-            :type payload2: IntroductionResponsePayload
-            '''
-            pass
-    """
-    def decorator(func):
-        def wrapper(self, source_address, data):
-            # UNPACK
-            unpacked = self.serializer.unpack_to_serializables(payloads, data[23:])
-            output, unknown_data = unpacked[:-1], unpacked[-1]
-            # ASSERT
-            if len(unknown_data) != 0:
-                raise PacketDecodingError("Incoming packet %s (%s) has extra data: (%s)" %
-                                          (str([payload_class.__name__ for payload_class in payloads]),
-                                           data.encode('HEX'),
-                                           unknown_data.encode('HEX')))
-
-            # PRODUCE
-            return func(self, source_address, *output)
-        return wrapper
-    return decorator
-
-
-class PacketDecodingError(RuntimeError):
-    pass
-
-
-class EZPackOverlay(Overlay):
-
-    def _ez_pack(self, prefix, msg_num, format_list_list, sig=True):
-        packet = prefix + chr(msg_num)
-        for format_list in format_list_list:
-            packet += self.serializer.pack_multiple(format_list)[0]
-        if sig:
-            packet += ECCrypto().create_signature(self.my_peer.key, packet)
-        return packet
-
-    def _verify_signature(self, auth, data):
-        ec = ECCrypto()
-        public_key = ec.key_from_public_bin(auth.public_key_bin)
-        signature_length = ec.get_signature_length(public_key)
-        remainder = data[2 + len(auth.public_key_bin):-signature_length]
-        signature = data[-signature_length:]
-        return ec.is_valid_signature(public_key, data[:-signature_length], signature), remainder
-
-    def _ez_unpack_auth(self, payload_class, data):
-        # UNPACK
-        auth, remainder = self.serializer.unpack_to_serializables([BinMemberAuthenticationPayload, ], data[23:])
-        signature_valid, remainder = self._verify_signature(auth, data)
-        format = [GlobalTimeDistributionPayload, payload_class]
-        dist, payload, unknown_data = self.serializer.unpack_to_serializables(format, remainder[23:])
-        # ASSERT
-        if len(unknown_data) != 0:
-            raise PacketDecodingError("Incoming packet %s (%s) has extra data: (%s)" %
-                                      (payload_class.__name__,
-                                       data.encode('HEX'),
-                                       unknown_data.encode('HEX')))
-
-        if not signature_valid:
-            raise PacketDecodingError("Incoming packet %s has an invalid signature" % payload_class.__name__)
-        # PRODUCE
-        return auth, dist, payload
-
-    def _ez_unpack_noauth(self, payload_class, data, global_time=True):
-        # UNPACK
-        format = [GlobalTimeDistributionPayload, payload_class] if global_time else [payload_class]
-        unpacked = self.serializer.unpack_to_serializables(format, data[23:])
-        unknown_data = unpacked.pop()
-        # ASSERT
-        if len(unknown_data) != 0:
-            raise PacketDecodingError("Incoming packet %s (%s) has extra data: (%s)" %
-                                      (payload_class.__name__,
-                                       data.encode('HEX'),
-                                       unknown_data.encode('HEX')))
-        # PRODUCE
-        return unpacked if global_time else unpacked[0]
-
+BOOTSTRAP_TIMEOUT = 30.0  # Timeout before we bootstrap again (bootstrap kills performance)
 
 
 class Community(EZPackOverlay):
@@ -369,7 +236,7 @@ class Community(EZPackOverlay):
         self.introduction_response_callback(peer, dist, payload)
 
     @lazy_wrapper(GlobalTimeDistributionPayload, PuncturePayload)
-    def on_puncture(self, peer, _, __):
+    def on_puncture(self, peer, dist, payload):
         self.network.add_verified_peer(peer)
         self.network.discover_services(peer, [self.master_peer.mid, ])
 

--- a/ipv8/deprecated/lazy_community.py
+++ b/ipv8/deprecated/lazy_community.py
@@ -1,0 +1,208 @@
+from .payload_headers import BinMemberAuthenticationPayload, GlobalTimeDistributionPayload
+from ..keyvault.crypto import ECCrypto
+from ..overlay import Overlay
+from ..peer import Peer
+
+
+def lazy_wrapper(*payloads):
+    """
+    This function wrapper will unpack the BinMemberAuthenticationPayload for you.
+
+    You can now write your authenticated and signed functions as follows:
+
+    ::
+
+        @lazy_wrapper(GlobalTimeDistributionPayload, IntroductionRequestPayload, IntroductionResponsePayload)
+        def on_message(peer, payload1, payload2):
+            '''
+            :type peer: Peer
+            :type payload1: IntroductionRequestPayload
+            :type payload2: IntroductionResponsePayload
+            '''
+            pass
+    """
+    def decorator(func):
+        def wrapper(self, source_address, data):
+            # UNPACK
+            auth, remainder = self.serializer.unpack_to_serializables([BinMemberAuthenticationPayload, ], data[23:])
+            signature_valid, remainder = self._verify_signature(auth, data)
+            unpacked = self.serializer.unpack_to_serializables(payloads, remainder[23:])
+            output, unknown_data = unpacked[:-1], unpacked[-1]
+            # ASSERT
+            if len(unknown_data) != 0:
+                raise PacketDecodingError("Incoming packet %s (%s) has extra data: (%s)" %
+                                          (str([payload_class.__name__ for payload_class in payloads]),
+                                           data.encode('HEX'),
+                                           unknown_data.encode('HEX')))
+
+            if not signature_valid:
+                raise PacketDecodingError("Incoming packet %s has an invalid signature" % \
+                                          str([payload_class.__name__ for payload_class in payloads]))
+            # PRODUCE
+            return func(self, Peer(auth.public_key_bin, source_address), *output)
+        return wrapper
+    return decorator
+
+
+def lazy_wrapper_wd(*payloads):
+    """
+    This function wrapper will unpack the BinMemberAuthenticationPayload for you, as well as pass the raw data to the
+    decorated function
+
+    You can now write your authenticated and signed functions as follows:
+
+    ::
+
+        @lazy_wrapper(GlobalTimeDistributionPayload, IntroductionRequestPayload, IntroductionResponsePayload)
+        def on_message(peer, payload1, payload2, data):
+            '''
+            :type peer: Peer
+            :type payload1: IntroductionRequestPayload
+            :type payload2: IntroductionResponsePayload
+            '''
+            pass
+    """
+    def decorator(func):
+        def wrapper(self, source_address, data):
+            # UNPACK
+            auth, remainder = self.serializer.unpack_to_serializables([BinMemberAuthenticationPayload, ], data[23:])
+            signature_valid, remainder = self._verify_signature(auth, data)
+            unpacked = self.serializer.unpack_to_serializables(payloads, remainder[23:])
+            output, unknown_data = unpacked[:-1], unpacked[-1]
+            # ASSERT
+            if len(unknown_data) != 0:
+                raise PacketDecodingError("Incoming packet %s (%s) has extra data: (%s)" %
+                                          (str([payload_class.__name__ for payload_class in payloads]),
+                                           data.encode('HEX'),
+                                           unknown_data.encode('HEX')))
+
+            if not signature_valid:
+                raise PacketDecodingError("Incoming packet %s has an invalid signature" % \
+                                          str([payload_class.__name__ for payload_class in payloads]))
+            # PRODUCE
+            output = output + [data]
+            return func(self, Peer(auth.public_key_bin, source_address), *output)
+        return wrapper
+    return decorator
+
+
+def lazy_wrapper_unsigned(*payloads):
+    """
+    This function wrapper will unpack just the normal payloads for you.
+
+    You can now write your non-authenticated and signed functions as follows:
+
+    ::
+
+        @lazy_wrapper_unsigned(GlobalTimeDistributionPayload, IntroductionRequestPayload, IntroductionResponsePayload)
+        def on_message(source_address, payload1, payload2):
+            '''
+            :type source_address: str
+            :type payload1: IntroductionRequestPayload
+            :type payload2: IntroductionResponsePayload
+            '''
+            pass
+    """
+    def decorator(func):
+        def wrapper(self, source_address, data):
+            # UNPACK
+            unpacked = self.serializer.unpack_to_serializables(payloads, data[23:])
+            output, unknown_data = unpacked[:-1], unpacked[-1]
+            # ASSERT
+            if len(unknown_data) != 0:
+                raise PacketDecodingError("Incoming packet %s (%s) has extra data: (%s)" %
+                                          (str([payload_class.__name__ for payload_class in payloads]),
+                                           data.encode('HEX'),
+                                           unknown_data.encode('HEX')))
+
+            # PRODUCE
+            return func(self, source_address, *output)
+        return wrapper
+    return decorator
+
+
+def lazy_wrapper_unsigned_wd(*payloads):
+    """
+    This function wrapper will unpack just the normal payloads for you, as well as pass the raw data to the decorated
+    function
+
+    You can now write your non-authenticated and signed functions as follows:
+
+    ::
+
+        @lazy_wrapper_unsigned_wd(GlobalTimeDistributionPayload, IntroductionRequestPayload,
+        IntroductionResponsePayload)
+        def on_message(source_address, payload1, payload2, data):
+            '''
+            :type source_address: str
+            :type payload1: IntroductionRequestPayload
+            :type payload2: IntroductionResponsePayload
+            '''
+            pass
+    """
+    def decorator(func):
+        def wrapper(self, source_address, data):
+
+            @lazy_wrapper_unsigned(*payloads)
+            def inner_wrapper(inner_self, inner_source_address, *pyls):
+                combo = list(pyls) + [data]
+                return func(inner_self, inner_source_address, *combo)
+
+            return inner_wrapper(self, source_address, data)
+        return wrapper
+    return decorator
+
+
+class EZPackOverlay(Overlay):
+
+    def _ez_pack(self, prefix, msg_num, format_list_list, sig=True):
+        packet = prefix + chr(msg_num)
+        for format_list in format_list_list:
+            packet += self.serializer.pack_multiple(format_list)[0]
+        if sig:
+            packet += ECCrypto().create_signature(self.my_peer.key, packet)
+        return packet
+
+    def _verify_signature(self, auth, data):
+        ec = ECCrypto()
+        public_key = ec.key_from_public_bin(auth.public_key_bin)
+        signature_length = ec.get_signature_length(public_key)
+        remainder = data[2 + len(auth.public_key_bin):-signature_length]
+        signature = data[-signature_length:]
+        return ec.is_valid_signature(public_key, data[:-signature_length], signature), remainder
+
+    def _ez_unpack_auth(self, payload_class, data):
+        # UNPACK
+        auth, remainder = self.serializer.unpack_to_serializables([BinMemberAuthenticationPayload, ], data[23:])
+        signature_valid, remainder = self._verify_signature(auth, data)
+        format = [GlobalTimeDistributionPayload, payload_class]
+        dist, payload, unknown_data = self.serializer.unpack_to_serializables(format, remainder[23:])
+        # ASSERT
+        if len(unknown_data) != 0:
+            raise PacketDecodingError("Incoming packet %s (%s) has extra data: (%s)" %
+                                      (payload_class.__name__,
+                                       data.encode('HEX'),
+                                       unknown_data.encode('HEX')))
+
+        if not signature_valid:
+            raise PacketDecodingError("Incoming packet %s has an invalid signature" % payload_class.__name__)
+        # PRODUCE
+        return auth, dist, payload
+
+    def _ez_unpack_noauth(self, payload_class, data, global_time=True):
+        # UNPACK
+        format = [GlobalTimeDistributionPayload, payload_class] if global_time else [payload_class]
+        unpacked = self.serializer.unpack_to_serializables(format, data[23:])
+        unknown_data = unpacked.pop()
+        # ASSERT
+        if len(unknown_data) != 0:
+            raise PacketDecodingError("Incoming packet %s (%s) has extra data: (%s)" %
+                                      (payload_class.__name__,
+                                       data.encode('HEX'),
+                                       unknown_data.encode('HEX')))
+        # PRODUCE
+        return unpacked if global_time else unpacked[0]
+
+
+class PacketDecodingError(RuntimeError):
+    pass

--- a/ipv8/test/dht/test_discovery.py
+++ b/ipv8/test/dht/test_discovery.py
@@ -109,7 +109,6 @@ class TestDHTDiscoveryCommunity(TestBase):
         self.nodes[0].overlay.ping_all()
         self.assertNotIn(node1, self.nodes[0].overlay.store[node1.mid])
 
-
         self.nodes[0].overlay.store_for_me[node1.mid].append(node1)
         self.nodes[0].overlay.ping_all()
         self.assertEqual(self.pinged, None)


### PR DESCRIPTION
Removed the calls to the `_ez_unpack_*` methods, and added calls to the `lazy_wrapper` decorators in lieu. Also refactored the deprecated/community.py module in order to move the `lazy_wrapper` decorators and the `EZPackOverlay` class to a new module:  deprecated/lazy_community.py.