### PR TITLE
Optionally load a DHT community in tests

### DIFF
--- a/ipv8/dht/community.py
+++ b/ipv8/dht/community.py
@@ -113,10 +113,9 @@ class DHTCommunity(Community):
 
         self.logger.info('DHT community initialized (peer mid %s)', self.my_peer.mid.encode('HEX'))
 
-    @inlineCallbacks
     def unload(self):
-        self.request_cache.clear()
-        yield super(DHTCommunity, self).unload()
+        self.request_cache.shutdown()
+        super(DHTCommunity, self).unload()
 
     @property
     def my_node_id(self):

--- a/ipv8/test/base.py
+++ b/ipv8/test/base.py
@@ -59,7 +59,6 @@ class TestBase(unittest.TestCase):
         finally:
             shutil.rmtree("temp", ignore_errors=True)
 
-
     @classmethod
     def setUpClass(cls):
         cls.__lockup_timestamp__ = time.time()
@@ -78,6 +77,13 @@ class TestBase(unittest.TestCase):
                     print >> sys.stderr, "THREAD#%d" % tid
                     for line in traceback.format_list(traceback.extract_stack(stack)):
                         print >> sys.stderr, "|", line[:-1].replace('\n', '\n|   ')
+
+            delayed_calls = reactor.getDelayedCalls()
+            if delayed_calls:
+                print "Delayed calls:"
+                for dc in delayed_calls:
+                    print ">     %s" % dc
+
             os._exit(1)
         t = threading.Thread(target=check_twisted)
         t.daemon = True

--- a/ipv8/test/base.py
+++ b/ipv8/test/base.py
@@ -48,7 +48,7 @@ class TestBase(unittest.TestCase):
 
     def setUp(self):
         super(TestBase, self).setUp()
-        self.__lockup_timestamp__ = time.time()
+        TestBase.__lockup_timestamp__ = time.time()
 
     def tearDown(self):
         try:


### PR DESCRIPTION
Similar to how a TrustChain community can be side-loaded during the tests.