### PR TITLE
Changed validation rule when sending crawl resp.

### DIFF
--- a/ipv8/attestation/trustchain/community.py
+++ b/ipv8/attestation/trustchain/community.py
@@ -490,8 +490,8 @@ class TrustChainCommunity(Community):
 
         # Don't answer with any invalid blocks.
         validation = self.validate_persist_block(block)
-        if validation[0] != ValidationResult.partial_next and validation[0] != ValidationResult.valid \
-                and total_count > 0:  # We send an empty block to the crawl requester if no blocks should be sent back
+        if validation[0] == ValidationResult.invalid and total_count > 0:
+            # We send an empty block to the crawl requester if no blocks should be sent back
             self.logger.error("Not sending crawl response, the block is invalid. Result %s", repr(validation))
             self.persistence_integrity_check()
             return


### PR DESCRIPTION
We assumed that we are always sending blocks in our own chain when responding to a crawl request. However, the new IPv8 crawler can request blocks that are not in your chain. This check was not consistent with that notion, which results in many missing blocks for the crawler (since they were simply not being sent).