### PR TITLE
Small ammendment to decoration of on_introduction_response method

### DIFF
--- a/ipv8/attestation/trustchain/community.py
+++ b/ipv8/attestation/trustchain/community.py
@@ -14,7 +14,7 @@ from .block import TrustChainBlock, ValidationResult, EMPTY_PK, GENESIS_SEQ, UNK
 from .caches import CrawlRequestCache, HalfBlockSignCache, IntroCrawlTimeout
 from .database import TrustChainDB
 from ...deprecated.community import Community
-from ...deprecated.lazy_community import lazy_wrapper, lazy_wrapper_unsigned, lazy_wrapper_unsigned_wd
+from ...deprecated.lazy_community import lazy_wrapper, lazy_wrapper_unsigned, lazy_wrapper_unsigned_wd, lazy_wrapper_wd
 from ...deprecated.payload import IntroductionResponsePayload
 from ...deprecated.payload_headers import BinMemberAuthenticationPayload, GlobalTimeDistributionPayload
 from .payload import *
@@ -549,9 +549,9 @@ class TrustChainCommunity(Community):
         return eligible[-1]
 
     @synchronized
-    @lazy_wrapper(GlobalTimeDistributionPayload, IntroductionResponsePayload)
-    def on_introduction_response(self, peer, dist, payload):
-        super(TrustChainCommunity, self).on_introduction_response(peer, dist, payload)
+    @lazy_wrapper_wd(GlobalTimeDistributionPayload, IntroductionResponsePayload)
+    def on_introduction_response(self, peer, dist, payload, data):
+        super(TrustChainCommunity, self).on_introduction_response(peer.address, data)
 
         if self.request_cache.has(u"introcrawltimeout", IntroCrawlTimeout.get_number_for(peer)):
             self.logger.debug("Not crawling %s, as we have already crawled it in the last %d seconds!",

--- a/ipv8/deprecated/community.py
+++ b/ipv8/deprecated/community.py
@@ -13,7 +13,7 @@ import sys
 from time import time
 from traceback import format_exception
 
-from .lazy_community import lazy_wrapper, lazy_wrapper_unsigned, EZPackOverlay
+from .lazy_community import lazy_wrapper, lazy_wrapper_unsigned, EZPackOverlay, lazy_wrapper_wd
 from .payload import IntroductionRequestPayload, IntroductionResponsePayload, PuncturePayload, PunctureRequestPayload
 from .payload_headers import BinMemberAuthenticationPayload, GlobalTimeDistributionPayload
 
@@ -221,8 +221,8 @@ class Community(EZPackOverlay):
 
         self.introduction_request_callback(peer, dist, payload)
 
-    @lazy_wrapper(GlobalTimeDistributionPayload, IntroductionResponsePayload)
-    def on_introduction_response(self, peer, dist, payload):
+    @lazy_wrapper_wd(GlobalTimeDistributionPayload, IntroductionResponsePayload)
+    def on_introduction_response(self, peer, dist, payload, _):
         self.my_estimated_wan = payload.destination_address
 
         self.network.add_verified_peer(peer)


### PR DESCRIPTION
Changed the decorator from `@lazy_wrapper` to `@lazy_wrapper_wd` for the `on_introduction_response method` method in both the `TrustChainCommunity` and `Community` classes. Noticed the need for this change when rebasing the #233 PR branch onto the **upstream/master**, as `@lazy_wrapper`'s inner method `wrapper` would throw an error which flagged that too many parameters were passed (4 instead of 3). It should be mentioned that the REST API and the tests were working normally (and were passing), but errors were thrown. The disadvantage of this change is that Pylint errors are introduced, and the data gets unpacked twice. The advantage is that errors are not thrown any longer. 