### PR TITLE
Fix adding task with duplicate name to taskmanager

### DIFF
--- a/ipv8/taskmanager.py
+++ b/ipv8/taskmanager.py
@@ -44,11 +44,11 @@ class TaskManager(object):
                     stopfn()
                 return task
 
+            assert isinstance(task, (Deferred, DelayedCall, LoopingCall)), (task, isinstance(task, Deferred))
+
             if self.is_pending_task_active(name):
                 self.replace_task(name, task)
                 raise RuntimeError("Task already exists: '%s'" % name)
-
-            assert isinstance(task, (Deferred, DelayedCall, LoopingCall)), (task, type(task) == type(Deferred))
 
             if delay is not None:
                 if isinstance(task, Deferred):

--- a/ipv8/test/test_taskmanager.py
+++ b/ipv8/test/test_taskmanager.py
@@ -131,6 +131,13 @@ class TestTaskManager(TestBase):
         self.assertEquals(42, self.counter)
         self.assertFalse(self.tm.is_pending_task_active("test"))
 
+    @twisted_wrapper
+    @untwisted_wrapper
+    def test_raise_on_duplicate_task_name(self):
+        self.tm.register_task("test", reactor.callLater(10, lambda: None))
+        with self.assertRaises(RuntimeError):
+            self.tm.register_task("test", reactor.callLater(10, lambda: None))
+
     def count(self):
         self.counter += 1
 


### PR DESCRIPTION
Fix for https://github.com/Tribler/py-ipv8/issues/253
Raises an error in case of duplicate name and replaces the task with the new one.
The shutdown check is moved to be the 1st one to prevent replacing tasks before the shutdown.