### PR TITLE
Correct shutdown order for mock IPv8

### DIFF
--- a/ipv8/test/mocking/ipv8.py
+++ b/ipv8/test/mocking/ipv8.py
@@ -48,9 +48,9 @@ class MockIPv8(object):
             self.endpoint.enable_community_statistics(self.overlay.get_prefix(), True)
 
     def unload(self):
-        self.endpoint.close()
+        self.overlay.unload()
         if self.trustchain:
             self.trustchain.unload()
         if self.dht:
             self.dht.unload()
-        self.overlay.unload()
+        self.endpoint.close()


### PR DESCRIPTION
On creating a mock IPv8 instance we *first* create the node and *second* open the endpoint. The teardown process should be done in reverse order.
This patch fixes a lot of "unclean reactor" errors produced by Tribler tests, when using Trial-based `unittest` module.