### PR TITLE
Updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,20 +34,6 @@ The dependencies for IPv8 are collected in the `requirements.txt` file and can b
 pip install --upgrade -r requirements.txt
 ```
 
-The libsodium library will have to be installed manually.
-Please follow the instructions for your platform below:
-
-**Debian/Ubuntu:**
-``sudo apt-get install libsodium18``
-
-**Mac:**
-``sudo port -N install libsodium`` or ``brew install libsodium``
-
-**Windows:**
-Download [an MSVC binary release from the libsodium website](https://download.libsodium.org/libsodium/releases/).
-Open the archive and browse to the version applicable to your OS (x32 or x64).
-Extract the files in the `dynamic` folder to a location on your `PATH` (the folder containing `python.exe` for example).
-
 ### Tests
 The test suite can run without any external packages, but the `nosetests` package is recommended (`pip install nose`).
 The test suite will automatically detect your back-end when running the tests.


### PR DESCRIPTION
Libsodium no longer needs manual installation. This is handled by `pip`.