### PR TITLE
Switched to Python 3 compatible meta classes

### DIFF
--- a/ipv8/attestation/trustchain/listener.py
+++ b/ipv8/attestation/trustchain/listener.py
@@ -1,14 +1,13 @@
 import abc
+import six
 
 from .block import TrustChainBlock
 
 
-class BlockListener(object):
+class BlockListener(six.with_metaclass(abc.ABCMeta, object)):
     """
     This class defines a listener for TrustChain blocks with a specific type.
     """
-
-    __metaclass__ = abc.ABCMeta
 
     BLOCK_CLASS = TrustChainBlock
 

--- a/ipv8/database.py
+++ b/ipv8/database.py
@@ -8,6 +8,7 @@ This module provides basic database functionalty and simple version control.
 from collections import defaultdict
 import logging
 import os
+import six
 import sys
 from threading import RLock
 from abc import ABCMeta, abstractmethod
@@ -68,9 +69,7 @@ class DatabaseException(RuntimeError):
     pass
 
 
-class Database(object):
-
-    __metaclass__ = ABCMeta
+class Database(six.with_metaclass(ABCMeta, object)):
 
     def __init__(self, file_path):
         """

--- a/ipv8/keyvault/keys.py
+++ b/ipv8/keyvault/keys.py
@@ -1,13 +1,12 @@
 import abc
 from hashlib import sha1
+import six
 
 
-class Key(object):
+class Key(six.with_metaclass(abc.ABCMeta, object)):
     """
     Interface for a public or private key.
     """
-
-    __metaclass__ = abc.ABCMeta
 
     @abc.abstractmethod
     def pub(self):
@@ -27,12 +26,10 @@ class Key(object):
         return sha1(self.key_to_bin()).digest()
 
 
-class PrivateKey(Key):
+class PrivateKey(six.with_metaclass(abc.ABCMeta, Key)):
     """
     Interface for a private key.
     """
-
-    __metaclass__ = abc.ABCMeta
 
     def has_secret_key(self):
         return True
@@ -42,12 +39,10 @@ class PrivateKey(Key):
         pass
 
 
-class PublicKey(Key):
+class PublicKey(six.with_metaclass(abc.ABCMeta, Key)):
     """
     Interface for a public key.
     """
-
-    __metaclass__ = abc.ABCMeta
 
     def pub(self):
         return self

--- a/ipv8/messaging/interfaces/endpoint.py
+++ b/ipv8/messaging/interfaces/endpoint.py
@@ -1,6 +1,7 @@
 import abc
 import logging
 import netifaces
+import six
 import socket
 import struct
 
@@ -9,12 +10,10 @@ from twisted.internet import reactor
 from ...util import blockingCallFromThread
 
 
-class Endpoint(object):
+class Endpoint(six.with_metaclass(abc.ABCMeta, object)):
     """
     Interface for sending messages over the Internet.
     """
-
-    __metaclass__ = abc.ABCMeta
 
     def __init__(self):
         self._logger = logging.getLogger(self.__class__.__name__)
@@ -81,12 +80,10 @@ class Endpoint(object):
         pass
 
 
-class EndpointListener(object):
+class EndpointListener(six.with_metaclass(abc.ABCMeta, object)):
     """
     Handler for messages coming in through an Endpoint.
     """
-
-    __metaclass__ = abc.ABCMeta
 
     def __init__(self, endpoint, main_thread=True):
         """

--- a/ipv8/messaging/serialization.py
+++ b/ipv8/messaging/serialization.py
@@ -1,5 +1,6 @@
 import abc
 from struct import pack, unpack, unpack_from, Struct
+import six
 import sys
 
 
@@ -304,12 +305,10 @@ class Serializer(object):
         return out
 
 
-class Serializable(object):
+class Serializable(six.with_metaclass(abc.ABCMeta, object)):
     """
     Interface for serializable objects.
     """
-
-    __metaclass__ = abc.ABCMeta
 
     format_list = []
     optional_format_list = []

--- a/ipv8/overlay.py
+++ b/ipv8/overlay.py
@@ -1,20 +1,17 @@
 import abc
 import logging
-from time import time
+import six
 
 from .keyvault.crypto import ECCrypto
 from .messaging.interfaces.endpoint import EndpointListener
 from .messaging.serialization import Serializer
-from .peer import Peer
 from .taskmanager import TaskManager
 
 
-class Overlay(EndpointListener, TaskManager):
+class Overlay(six.with_metaclass(abc.ABCMeta, EndpointListener, TaskManager)):
     """
     Interface for an Internet overlay.
     """
-
-    __metaclass__ = abc.ABCMeta
 
     def __init__(self, master_peer, my_peer, endpoint, network):
         """

--- a/ipv8/peerdiscovery/discovery.py
+++ b/ipv8/peerdiscovery/discovery.py
@@ -1,16 +1,14 @@
 import abc
-
 from random import choice
+import six
 from time import time
 from threading import Lock
 
 
-class DiscoveryStrategy(object):
+class DiscoveryStrategy(six.with_metaclass(abc.ABCMeta, object)):
     """
     Strategy for discovering peers in a network.
     """
-
-    __metaclass__ = abc.ABCMeta
 
     def __init__(self, overlay):
         self.overlay = overlay

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ libnacl>=1.6.1
 netifaces
 Twisted>=17.9.0
 pyOpenSSL
+six


### PR DESCRIPTION
Related to #265. Python 3 requires a different meta class definition style: https://portingguide.readthedocs.io/en/latest/classes.html#metaclasses

This PR switches all metaclass definitions to the `six` Python 2/3 compatible format. Note that we will require six as an "additional" dependency (this is already used by `cryptography` so we don't need to install anything new on our machines).