### PR TITLE
Various improvements to TrustChain

### DIFF
--- a/ipv8/attestation/trustchain/block.py
+++ b/ipv8/attestation/trustchain/block.py
@@ -170,7 +170,7 @@ class TrustChainBlock(object):
         self.update_block_invariant(database, result)
 
         # Check if this block as retrieved from our database is the same as this block.
-        self.update_block_consistency(blk, result)
+        self.update_block_consistency(blk, result, database)
 
         # Check if the linked block as retrieved from our database is the same as the one linked by this block.
         self.update_linked_consistency(database, link, result)
@@ -283,7 +283,7 @@ class TrustChainBlock(object):
             if self.sequence_number != GENESIS_SEQ and self.previous_hash == GENESIS_HASH:
                 result.err("Sequence number implies previous hash should not be Genesis ID")
 
-    def update_block_consistency(self, blk, result):
+    def update_block_consistency(self, blk, result, database):
         """
         Check if a given block is consistent with this block.
 
@@ -293,6 +293,8 @@ class TrustChainBlock(object):
         :type blk: TrustChainBlock or None
         :param result: the result to update
         :type result: ValidationResult
+        :param database: the TrustChain database object, used to store detected double spend attempts
+        :type database: TrustChainDB
         :returns: None
         """
         if blk:
@@ -308,6 +310,7 @@ class TrustChainBlock(object):
             if self.hash != blk.hash and "Invalid signature" not in result.errors and\
                "Public key is not valid" not in result.errors:
                 result.err("Double sign fraud")
+                database.add_double_spend(blk, self)
 
     def update_linked_consistency(self, database, link, result):
         """

--- a/ipv8/attestation/trustchain/caches.py
+++ b/ipv8/attestation/trustchain/caches.py
@@ -17,8 +17,8 @@ class IntroCrawlTimeout(NumberCache):
     We wish to slow down the amount of crawls we do to not overload any node with database IO.
     """
 
-    def __init__(self, community, peer):
-        super(IntroCrawlTimeout, self).__init__(community.request_cache, u"introcrawltimeout",
+    def __init__(self, community, peer, identifier=u"introcrawltimeout"):
+        super(IntroCrawlTimeout, self).__init__(community.request_cache, identifier,
                                                 self.get_number_for(peer))
 
     @classmethod
@@ -42,6 +42,25 @@ class IntroCrawlTimeout(NumberCache):
         The node is then allowed to be crawled again.
         """
         pass
+
+
+class ChainCrawlCache(IntroCrawlTimeout):
+    """
+    This cache keeps track of the crawl of a whole chain.
+    """
+    def __init__(self, community, peer, known_chain_length=-1):
+        super(ChainCrawlCache, self).__init__(community, peer, identifier=u"chaincrawl")
+        self.community = community
+        self.current_crawl_deferred = None
+        self.peer = peer
+        self.known_chain_length = known_chain_length
+
+        self.current_request_range = (0, 0)
+        self.current_request_attempts = 0
+
+    @property
+    def timeout_delay(self):
+        return 120.0
 
 
 class HalfBlockSignCache(NumberCache):

--- a/ipv8/attestation/trustchain/caches.py
+++ b/ipv8/attestation/trustchain/caches.py
@@ -99,6 +99,10 @@ class CrawlRequestCache(NumberCache):
             self.community.request_cache.pop(u"crawl", self.number)
             reactor.callFromThread(self.crawl_deferred.callback, self.received_half_blocks)
 
+    def received_empty_response(self):
+        self.community.request_cache.pop(u"crawl", self.number)
+        reactor.callFromThread(self.crawl_deferred.callback, self.received_half_blocks)
+
     def on_timeout(self):
         self._logger.info("Timeout for crawl with id %d", self.number)
         self.crawl_deferred.callback(self.received_half_blocks)

--- a/ipv8/attestation/trustchain/community.py
+++ b/ipv8/attestation/trustchain/community.py
@@ -51,7 +51,7 @@ class TrustChainCommunity(Community):
 
     DB_CLASS = TrustChainDB
     DB_NAME = 'trustchain'
-    BROADCAST_FANOUT = 10
+    BROADCAST_FANOUT = 25
     version = '\x02'
 
     def __init__(self, *args, **kwargs):

--- a/ipv8/attestation/trustchain/community.py
+++ b/ipv8/attestation/trustchain/community.py
@@ -382,6 +382,7 @@ class TrustChainCommunity(Community):
 
         # determine if we want to sign this block
         if not self.should_sign(blk):
+            self.logger.info("Not signing block %s", blk)
             return
 
         # It is important that the request matches up with its previous block, gaps cannot be tolerated at

--- a/ipv8/attestation/trustchain/community.py
+++ b/ipv8/attestation/trustchain/community.py
@@ -598,7 +598,10 @@ class TrustChainCommunity(Community):
         elif peer.address not in self.network.blacklist:
             # Do not crawl addresses in our blacklist (trackers)
             self.request_cache.add(IntroCrawlTimeout(self, peer))
-            self.crawl_lowest_unknown(peer)
+
+            known_blocks = self.persistence.get_number_of_known_blocks(public_key=peer.public_key.key_to_bin())
+            if known_blocks < 1000 or random.random() > 0.5:
+                self.crawl_lowest_unknown(peer)
 
     def unload(self):
         self.logger.debug("Unloading the TrustChain Community.")

--- a/ipv8/attestation/trustchain/community.py
+++ b/ipv8/attestation/trustchain/community.py
@@ -5,7 +5,7 @@ Every node has a chain and these chains intertwine by blocks shared by chains.
 """
 from __future__ import absolute_import
 
-from binascii import hexlify
+from binascii import hexlify, unhexlify
 import logging
 import random
 import struct
@@ -47,10 +47,11 @@ class TrustChainCommunity(Community):
     """
     Community for reputation based on TrustChain tamper proof interaction history.
     """
-    master_peer = Peer(("3081a7301006072a8648ce3d020106052b810400270381920004057a1c4c4f8422b328209d99724bd30cf08d1f8"
-                        "1a2961b003affd2964f92c457572f2f79de0968c42698e2d1cfb371dd71b275332a0a4c19f35f16166272baae8e"
-                        "230bba377cc5c40643b83206088075559ec2f13a090e8786d04d84802268bef12e52983978da360589a2b7e293c"
-                        "e4f16d02f37da2c3256f4703b9623d3750f7af437befebc8935c0f0726f58c1c1e9").decode("HEX"))
+    master_peer = Peer(unhexlify("3081a7301006072a8648ce3d020106052b810400270381920004026c015f205478073708b9a50b0e74"
+                                 "60139b615ba34830b3b3a288e41480eda48ad6adfb39d3d17636169fc06cc68844b5e6ef4e264faa96"
+                                 "76f487bb4e445ca52188076296fb9a9a037c37d977cd0fff8b367318a088ad64b46b1e947eab3356e1"
+                                 "50cf14a3a4b58c6ee59a33ce7036f2c39e0099b68c8cf7430d88ad2b67a4565e07b1e37e94dbc832fb"
+                                 "b4b1927fc297"))
 
     DB_CLASS = TrustChainDB
     DB_NAME = 'trustchain'
@@ -692,7 +693,8 @@ class TrustChainTestnetCommunity(TrustChainCommunity):
     """
     DB_NAME = 'trustchain_testnet'
 
-    master_peer = Peer(("3081a7301006072a8648ce3d020106052b810400270381920004017aa18185c6c8a3741aed970f5476d50932980"
-                        "66670c6557f9d2519a77c2abe293f9438444fdb73d9e36d0b43a4a254f96c563c0da7915def980270d88da4079e"
-                        "83a6039ce97f2205528c69087f88a6d6f35d83b93b3fb8a360260114729d4cfb5acc4b190e067695b4ae5e240a3"
-                        "939a1f45520e87a459ed0f358bf5e66371a748daa041997da69cab227596948bffd").decode("HEX"))
+    master_peer = Peer(unhexlify("3081a7301006072a8648ce3d020106052b81040027038192000404494ce33365dbf1e9b93647b7ff8c"
+                                 "979ba4d883421928ac7f7130900605e4fdece109d6ec3a1716537cb1ab284aa307f1dfc2aebe2e2d03"
+                                 "7d27cd68ccc6b3dc560c20e4fc8a670500fb8e653bd286ce0be52b1d43d53041bb74204e5af9662eca"
+                                 "b890ae518caeb11a7ef1510cf79c7b22e72529923b8f1cb08e518adb49a0da131a51c1254e49cd657b"
+                                 "60fd7ddd8e19"))

--- a/ipv8/attestation/trustchain/community.py
+++ b/ipv8/attestation/trustchain/community.py
@@ -117,7 +117,7 @@ class TrustChainCommunity(Community):
 
         return False
 
-    def send_block(self, block, address=None, ttl=2):
+    def send_block(self, block, address=None, ttl=1):
         """
         Send a block to a specific address, or do a broadcast to known peers if no peer is specified.
         """
@@ -138,7 +138,7 @@ class TrustChainCommunity(Community):
                 self.endpoint.send(peer.address, packet)
             self.relayed_broadcasts.append(block.block_id)
 
-    def send_block_pair(self, block1, block2, address=None, ttl=2):
+    def send_block_pair(self, block1, block2, address=None, ttl=1):
         """
         Send a half block pair to a specific address, or do a broadcast to known peers if no peer is specified.
         """
@@ -294,6 +294,7 @@ class TrustChainCommunity(Community):
         """
         We received a half block, part of a broadcast. Disseminate it further.
         """
+        payload.ttl -= 1
         block = self.get_block_class(payload.type).from_payload(payload, self.serializer)
         self.validate_persist_block(block)
 
@@ -316,6 +317,7 @@ class TrustChainCommunity(Community):
         """
         We received a half block pair, part of a broadcast. Disseminate it further.
         """
+        payload.ttl -= 1
         block1, block2 = self.get_block_class(payload.type1).from_pair_payload(payload, self.serializer)
         self.validate_persist_block(block1)
         self.validate_persist_block(block2)

--- a/ipv8/attestation/trustchain/database.py
+++ b/ipv8/attestation/trustchain/database.py
@@ -97,6 +97,25 @@ class TrustChainDB(Database):
         """
         return self._getall(u"", ())
 
+    def get_number_of_known_blocks(self, public_key=None):
+        """
+        Return the total number of blocks in the database or the number of known blocks for a specific user.
+        """
+        if public_key:
+            return list(self.execute(u"SELECT COUNT(*) FROM blocks WHERE public_key = ?",
+                                     (database_blob(public_key), )))[0][0]
+        return list(self.execute(u"SELECT COUNT(*) FROM blocks"))[0][0]
+
+    def remove_old_blocks(self, num_blocks_to_remove, my_pub_key):
+        """
+        Remove old blocks from the database.
+        :param num_blocks_to_remove: The number of blocks to remove from the database.
+        :param my_pub_key: Your public key, specified since we don't want to remove your own blocks.
+        """
+        self.execute(u"DELETE FROM blocks WHERE block_hash IN "
+                     u"(SELECT block_hash FROM blocks WHERE public_key != ? ORDER BY block_timestamp LIMIT ?)",
+                     (database_blob(my_pub_key), num_blocks_to_remove))
+
     def get_block_with_hash(self, block_hash):
         """
         Return the block with a specific hash or None if it's not available in the database.

--- a/ipv8/attestation/trustchain/payload.py
+++ b/ipv8/attestation/trustchain/payload.py
@@ -9,24 +9,46 @@ class CrawlRequestPayload(Payload):
     Request a crawl of blocks starting with a specific sequence number or the first if 0.
     """
 
-    format_list = ['74s', 'l', 'I']
+    format_list = ['74s', 'l', 'l', 'I']
 
-    def __init__(self, public_key, requested_sequence_number, crawl_id):
+    def __init__(self, public_key, start_seq_num, end_seq_num, crawl_id):
         super(CrawlRequestPayload, self).__init__()
         self.public_key = public_key
-        self.requested_sequence_number = requested_sequence_number
+        self.start_seq_num = start_seq_num
+        self.end_seq_num = end_seq_num
         self.crawl_id = crawl_id
 
     def to_pack_list(self):
         data = [('74s', self.public_key),
-                ('l', self.requested_sequence_number),
+                ('l', self.start_seq_num),
+                ('l', self.end_seq_num),
                 ('I', self.crawl_id)]
 
         return data
 
     @classmethod
-    def from_unpack_list(cls, public_key, sequence_number, crawl_id):
-        return CrawlRequestPayload(public_key, sequence_number, crawl_id)
+    def from_unpack_list(cls, public_key, start_seq_num, end_seq_num, crawl_id):
+        return CrawlRequestPayload(public_key, start_seq_num, end_seq_num, crawl_id)
+
+
+class EmptyCrawlResponsePayload(Payload):
+    """
+    Payload for the message that indicates that there are no blocks to respond.
+    """
+
+    format_list = ['I']
+
+    def __init__(self, crawl_id):
+        super(EmptyCrawlResponsePayload, self).__init__()
+        self.crawl_id = crawl_id
+
+    def to_pack_list(self):
+        data = [('I', self.crawl_id)]
+        return data
+
+    @classmethod
+    def from_unpack_list(cls, crawl_id):
+        return EmptyCrawlResponsePayload(crawl_id)
 
 
 class HalfBlockPayload(Payload):

--- a/ipv8/attestation/trustchain/settings.py
+++ b/ipv8/attestation/trustchain/settings.py
@@ -12,3 +12,6 @@ class TrustChainSettings(object):
 
         # How many prior blocks we require before signing a new incoming block
         self.validation_range = 5
+
+        # The maximum number of blocks we want to store in the database
+        self.max_db_blocks = 1000000

--- a/ipv8/attestation/trustchain/settings.py
+++ b/ipv8/attestation/trustchain/settings.py
@@ -15,3 +15,6 @@ class TrustChainSettings(object):
 
         # The maximum number of blocks we want to store in the database
         self.max_db_blocks = 1000000
+
+        # Whether we are a crawler (and fetching whole chains)
+        self.crawler = False

--- a/ipv8/attestation/trustchain/settings.py
+++ b/ipv8/attestation/trustchain/settings.py
@@ -1,0 +1,14 @@
+class TrustChainSettings(object):
+    """
+    This class holds various settings regarding TrustChain.
+    """
+
+    def __init__(self):
+        # Whether we should broadcast newly created blocks to others
+        self.broadcast_blocks = True
+
+        # The fan-out of the broadcast when a new block is created
+        self.broadcast_fanout = 25
+
+        # How many prior blocks we require before signing a new incoming block
+        self.validation_range = 5

--- a/ipv8/test/attestation/trustchain/test_block.py
+++ b/ipv8/test/attestation/trustchain/test_block.py
@@ -51,6 +51,7 @@ class MockDatabase(object):
     def __init__(self):
         super(MockDatabase, self).__init__()
         self.data = dict()
+        self.double_spends = []
 
     def add_block(self, block):
         if self.data.get(block.public_key) is None:
@@ -85,6 +86,9 @@ class MockDatabase(object):
             return None
         item = [i for i in self.data[blk.public_key] if i.sequence_number < blk.sequence_number]
         return item[-1] if item else None
+
+    def add_double_spend(self, block1, block2):
+        self.double_spends.append((block1, block2))
 
 
 class TestTrustChainBlock(unittest.TestCase):
@@ -424,7 +428,7 @@ class TestTrustChainBlock(unittest.TestCase):
         block1.link_public_key = "1234"
         block2 = TestBlock()
         block2.link_public_key = "5678"
-        block1.update_block_consistency(block2, result)
+        block1.update_block_consistency(block2, result, MockDatabase())
 
         self.assertEqual(ValidationResult.invalid, result.state)
 
@@ -437,7 +441,7 @@ class TestTrustChainBlock(unittest.TestCase):
         block1.link_sequence_number = 0
         block2 = TestBlock()
         block2.link_sequence_number = 1
-        block1.update_block_consistency(block2, result)
+        block1.update_block_consistency(block2, result, MockDatabase())
 
         self.assertEqual(ValidationResult.invalid, result.state)
 
@@ -450,7 +454,7 @@ class TestTrustChainBlock(unittest.TestCase):
         block1.previous_hash = "1234"
         block2 = TestBlock()
         block2.previous_hash = "5678"
-        block1.update_block_consistency(block2, result)
+        block1.update_block_consistency(block2, result, MockDatabase())
 
         self.assertEqual(ValidationResult.invalid, result.state)
 
@@ -463,7 +467,7 @@ class TestTrustChainBlock(unittest.TestCase):
         block1.signature = "1234"
         block2 = TestBlock()
         block2.signature = "5678"
-        block1.update_block_consistency(block2, result)
+        block1.update_block_consistency(block2, result, MockDatabase())
 
         self.assertEqual(ValidationResult.invalid, result.state)
 
@@ -476,7 +480,7 @@ class TestTrustChainBlock(unittest.TestCase):
         block1.pack = lambda: "1234"
         block2 = TestBlock()
         block2.pack = lambda: "5678"
-        block1.update_block_consistency(block2, result)
+        block1.update_block_consistency(block2, result, MockDatabase())
 
         self.assertEqual(ValidationResult.invalid, result.state)
 

--- a/ipv8/test/attestation/trustchain/test_community.py
+++ b/ipv8/test/attestation/trustchain/test_community.py
@@ -129,7 +129,7 @@ class TestTrustChainCommunity(TestBase):
         self.assertIsNone(self.nodes[1].overlay.persistence.get(my_pubkey, 1))
 
         self.nodes[0].endpoint.open()
-        self.nodes[1].overlay.send_crawl_request(self.nodes[0].my_peer, my_pubkey, 1)
+        self.nodes[1].overlay.send_crawl_request(self.nodes[0].my_peer, my_pubkey, 1, 1)
 
         yield self.deliver_messages()
 
@@ -157,7 +157,7 @@ class TestTrustChainCommunity(TestBase):
         self.assertIsNone(self.nodes[1].overlay.persistence.get(my_pubkey, 1))
 
         self.nodes[0].endpoint.open()
-        self.nodes[1].overlay.send_crawl_request(self.nodes[0].my_peer, my_pubkey)
+        self.nodes[1].overlay.send_crawl_request(self.nodes[0].my_peer, my_pubkey, 1, 1)
 
         yield self.deliver_messages()
 
@@ -173,7 +173,7 @@ class TestTrustChainCommunity(TestBase):
 
         my_pubkey = self.nodes[0].my_peer.public_key.key_to_bin()
         CrawlRequestCache.CRAWL_TIMEOUT = 0.1
-        response = yield self.nodes[1].overlay.send_crawl_request(self.nodes[0].my_peer, my_pubkey, 1)
+        response = yield self.nodes[1].overlay.send_crawl_request(self.nodes[0].my_peer, my_pubkey, 1, 1)
         self.assertFalse(response)
 
     @inlineCallbacks
@@ -194,7 +194,7 @@ class TestTrustChainCommunity(TestBase):
         self.assertIsNone(self.nodes[1].overlay.persistence.get(my_pubkey, 1))
         self.nodes[0].endpoint.open()
 
-        self.nodes[1].overlay.send_crawl_request(self.nodes[0].my_peer, my_pubkey, -1)
+        self.nodes[1].overlay.send_crawl_request(self.nodes[0].my_peer, my_pubkey, -1, -1)
 
         yield self.deliver_messages()
 
@@ -238,7 +238,7 @@ class TestTrustChainCommunity(TestBase):
         self.add_node_to_experiment(self.create_node())
 
         my_pubkey = self.nodes[0].my_peer.public_key.key_to_bin()
-        yield self.nodes[2].overlay.send_crawl_request(self.nodes[0].my_peer, my_pubkey, -1)
+        yield self.nodes[2].overlay.send_crawl_request(self.nodes[0].my_peer, my_pubkey, 1, 1)
 
         # Check whether we have both blocks now
         self.assertEqual(self.nodes[2].overlay.persistence.get(my_pubkey, 1).link_sequence_number, UNKNOWN_SEQ)
@@ -433,7 +433,7 @@ class TestTrustChainCommunity(TestBase):
         Test a crawl request to a peer without any blocks
         """
         my_pubkey = self.nodes[0].my_peer.public_key.key_to_bin()
-        yield self.nodes[1].overlay.send_crawl_request(self.nodes[0].my_peer, my_pubkey, 1)
+        yield self.nodes[1].overlay.send_crawl_request(self.nodes[0].my_peer, my_pubkey, 1, 1)
 
     @inlineCallbacks
     def test_invalid_block(self):

--- a/ipv8/test/attestation/trustchain/test_community.py
+++ b/ipv8/test/attestation/trustchain/test_community.py
@@ -53,8 +53,6 @@ class TestTrustChainCommunity(TestBase):
         """
         self.nodes[1].overlay.should_sign = lambda x: False
 
-        yield self.introduce_nodes()
-
         my_pubkey = self.nodes[0].my_peer.public_key.key_to_bin()
         his_pubkey = self.nodes[0].network.verified_peers[0].public_key.key_to_bin()
         self.nodes[0].overlay.sign_block(self.nodes[0].network.verified_peers[0], public_key=his_pubkey,
@@ -71,8 +69,6 @@ class TestTrustChainCommunity(TestBase):
         """
         Check if a double signed transaction is stored in the databases of both parties.
         """
-        yield self.introduce_nodes()
-
         his_pubkey = self.nodes[0].network.verified_peers[0].public_key.key_to_bin()
         block, link_block = yield self.nodes[0].overlay.sign_block(self.nodes[0].network.verified_peers[0],
                                                                    public_key=his_pubkey, block_type='test',
@@ -89,8 +85,6 @@ class TestTrustChainCommunity(TestBase):
         """
         Check if a both halves of a fully signed block link to each other.
         """
-        yield self.introduce_nodes()
-
         my_pubkey = self.nodes[0].my_peer.public_key.key_to_bin()
         his_pubkey = self.nodes[0].network.verified_peers[0].public_key.key_to_bin()
         self.nodes[0].overlay.sign_block(self.nodes[0].network.verified_peers[0], public_key=his_pubkey,
@@ -114,9 +108,6 @@ class TestTrustChainCommunity(TestBase):
          3. Node 0 sends his half block back
         """
         self.nodes[1].overlay.should_sign = lambda x: False
-
-        yield self.introduce_nodes()
-
         self.nodes[0].endpoint.close()
 
         my_pubkey = self.nodes[0].my_peer.public_key.key_to_bin()
@@ -142,9 +133,6 @@ class TestTrustChainCommunity(TestBase):
         Check if the default crawl strategy produces blocks.
         """
         self.nodes[1].overlay.should_sign = lambda x: False
-
-        yield self.introduce_nodes()
-
         self.nodes[0].endpoint.close()
 
         my_pubkey = self.nodes[0].my_peer.public_key.key_to_bin()
@@ -169,8 +157,6 @@ class TestTrustChainCommunity(TestBase):
         """
         Check if blocks don't magically appear.
         """
-        yield self.introduce_nodes()
-
         my_pubkey = self.nodes[0].my_peer.public_key.key_to_bin()
         CrawlRequestCache.CRAWL_TIMEOUT = 0.1
         response = yield self.nodes[1].overlay.send_crawl_request(self.nodes[0].my_peer, my_pubkey, 1, 1)
@@ -182,7 +168,6 @@ class TestTrustChainCommunity(TestBase):
         Check if a block can be crawled by negative range.
         """
         self.nodes[1].overlay.should_sign = lambda x: False
-        yield self.introduce_nodes()
         self.nodes[0].endpoint.close()
 
         my_pubkey = self.nodes[0].my_peer.public_key.key_to_bin()
@@ -206,8 +191,6 @@ class TestTrustChainCommunity(TestBase):
         """
         Test crawling the lowest unknown block of a specific peer.
         """
-        yield self.introduce_nodes()
-
         my_pubkey = self.nodes[0].my_peer.public_key.key_to_bin()
         his_pubkey = self.nodes[0].network.verified_peers[0].public_key.key_to_bin()
         for _ in [0, 1, 2]:
@@ -229,8 +212,6 @@ class TestTrustChainCommunity(TestBase):
         """
         Test crawling a block pair.
         """
-        yield self.introduce_nodes()
-
         his_pubkey = self.nodes[0].network.verified_peers[0].public_key.key_to_bin()
         yield self.nodes[0].overlay.sign_block(self.nodes[0].network.verified_peers[0], public_key=his_pubkey,
                                                block_type='test', transaction={})
@@ -249,8 +230,6 @@ class TestTrustChainCommunity(TestBase):
         """
         Check if blocks created in parallel will properly be stored in the database.
         """
-        yield self.introduce_nodes()
-
         his_pubkey = self.nodes[0].network.verified_peers[0].public_key.key_to_bin()
         self.nodes[0].overlay.sign_block(self.nodes[0].network.verified_peers[0], public_key=his_pubkey,
                                          block_type='test', transaction={})
@@ -282,8 +261,6 @@ class TestTrustChainCommunity(TestBase):
         """
         Check if missing blocks are retrieved through a crawl request.
         """
-        yield self.introduce_nodes()
-
         his_pubkey = self.nodes[0].network.verified_peers[0].public_key.key_to_bin()
         self.nodes[0].endpoint.close()
         signed1 = self.nodes[0].overlay.sign_block(self.nodes[0].network.verified_peers[0], public_key=his_pubkey,
@@ -311,8 +288,6 @@ class TestTrustChainCommunity(TestBase):
         """
         Test sending and receiving a pair of blocks from one to another peer.
         """
-        yield self.introduce_nodes()
-
         block1 = TestBlock()
         block2 = TestBlock()
         self.nodes[0].overlay.send_block_pair(block1, block2, self.nodes[0].network.verified_peers[0].address)
@@ -327,8 +302,6 @@ class TestTrustChainCommunity(TestBase):
         """
         Test broadcasting a half block
         """
-        yield self.introduce_nodes()
-
         # Let node 3 discover node 2.
         node3 = self.create_node()
         self.nodes.append(node3)
@@ -356,8 +329,6 @@ class TestTrustChainCommunity(TestBase):
         """
         Test broadcasting a half block pair
         """
-        yield self.introduce_nodes()
-
         # Let node 3 discover node 2.
         node3 = self.create_node()
         self.nodes.append(node3)
@@ -440,8 +411,6 @@ class TestTrustChainCommunity(TestBase):
         """
         See if we can recover from database corruption.
         """
-        yield self.introduce_nodes()
-
         # Create an invalid block
         invalid_block = TestBlock(key=self.nodes[0].overlay.my_peer.key)
         invalid_block.signature = 'a' * 64
@@ -466,8 +435,6 @@ class TestTrustChainCommunity(TestBase):
         """
         Test creating and disseminating a half block, signed by yourself
         """
-        yield self.introduce_nodes()
-
         my_pubkey = self.nodes[0].overlay.my_peer.public_key.key_to_bin()
         yield self.nodes[0].overlay.self_sign_block(block_type='test', transaction={})
 
@@ -482,8 +449,6 @@ class TestTrustChainCommunity(TestBase):
         """
         Test creating and disseminating a link block
         """
-        yield self.introduce_nodes()
-
         source_peer_pubkey = self.nodes[0].my_peer.public_key.key_to_bin()
         counter_peer_pubkey = self.nodes[1].my_peer.public_key.key_to_bin()
 
@@ -540,13 +505,12 @@ class TestTrustChainCommunity(TestBase):
         """
         Test that a double spend is correctly detected and stored
         """
-        yield self.introduce_nodes()
-
         my_pubkey = self.nodes[0].overlay.my_peer.public_key.key_to_bin()
         his_pubkey = self.nodes[0].network.verified_peers[0].public_key.key_to_bin()
         block1, block2 = yield self.nodes[0].overlay.sign_block(self.nodes[0].network.verified_peers[0],
                                                                 public_key=his_pubkey, block_type=b'test',
                                                                 transaction={})
+        yield self.deliver_messages()
         self.nodes[0].overlay.persistence.remove_block(block1)
         self.nodes[0].overlay.persistence.remove_block(block2)
 

--- a/ipv8/test/attestation/trustchain/test_community.py
+++ b/ipv8/test/attestation/trustchain/test_community.py
@@ -194,12 +194,10 @@ class TestTrustChainCommunity(TestBase):
         my_pubkey = self.nodes[0].my_peer.public_key.key_to_bin()
         his_pubkey = self.nodes[0].network.verified_peers[0].public_key.key_to_bin()
         for _ in [0, 1, 2]:
-            self.nodes[0].overlay.sign_block(self.nodes[0].network.verified_peers[0], public_key=his_pubkey,
-                                             block_type='test', transaction={})
+            yield self.nodes[0].overlay.sign_block(self.nodes[0].network.verified_peers[0], public_key=his_pubkey,
+                                                   block_type=b'test', transaction={})
 
-        yield self.deliver_messages()
-
-        self.nodes[1].overlay.persistence.execute(u"DELETE FROM blocks WHERE sequence_number=2", tuple())
+        self.nodes[1].overlay.persistence.execute(u"DELETE FROM blocks WHERE sequence_number = 2", tuple())
         self.assertIsNone(self.nodes[1].overlay.persistence.get(my_pubkey, 2))
 
         yield self.nodes[1].overlay.crawl_lowest_unknown(self.nodes[0].my_peer)

--- a/ipv8/test/attestation/trustchain/test_community.py
+++ b/ipv8/test/attestation/trustchain/test_community.py
@@ -401,7 +401,7 @@ class TestTrustChainCommunity(TestBase):
         self.nodes.append(node3)
         # Disable broadcasting to others on signing (we don't want to test that here)
         for node in self.nodes:
-            node.overlay.broadcast_block = False
+            node.overlay.settings.broadcast_blocks = False
 
         my_pubkey = self.nodes[0].my_peer.public_key.key_to_bin()
         his_pubkey = self.nodes[0].network.verified_peers[0].public_key.key_to_bin()


### PR DESCRIPTION
In this PR, I made quite a few changes to the TrustChain code and protocol. It includes:
- A fix for the block broadcast mechanism, where each block was unintentionally pushed to 1110 users. When this PR is merged, it is pushed to _only_ 25 users.
- An extension of the introduction request/response, where information about the length of ones chain is included (sequence number of their latest block).
- A separate file to store various important TrustChain settings. This includes settings for the block validation ranges (how many blocks do I need prior to signing one) and maximum number of blocks in the database.
- Made the database upgrade script idempotent.
- A database pruning loop that removes old blocks when the database grows too big.
- Made the crawler less aggressive when we already have over 1000 blocks of a specific user.
- A refactor of the crawl mechanism. In particular, each crawl request now contains a 'begin' and 'end' sequence number, or a range. I've also added an additional message when there are no blocks to return. This is more clean than the current mechanism where we return an invalid block in the `send_crawl_response` with type `noblocks`.
- Storing double spend attempts in a separate database table.
- Removed most of the `introduce_nodes` invocations from the TrustChain tests. Peer introduction is already done when creating the node itself.
- Refactored `test_intro_response_crawl` test to make it more simple.
- Added a separate 'crawler' mode to TrustChain, where a node attempts to crawl the whole chain of a target peer.