### PR TITLE
Added custom sorting method for encoding

### DIFF
--- a/ipv8/messaging/deprecated/encoding.py
+++ b/ipv8/messaging/deprecated/encoding.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 import logging
 from json import dumps
 
+from .sorting import sortable_sort
 from ...util import cast_to_bin, cast_to_long, is_long_or_int, is_unicode, urllib_future
 
 logger = logging.getLogger(__name__)
@@ -106,7 +107,7 @@ def _a_encode_dictionary(values, mapping):
     assert isinstance(values, dict), "VALUE has invalid type: %s" % type(values)
     encoded = [str(len(values)).encode("UTF-8"), b"d"]
     extend = encoded.extend
-    for key, value in sorted(values.items()):
+    for key, value in sortable_sort(list(values.items())):
         assert type(key).__name__ in mapping, (key, values)
         assert type(value).__name__ in mapping, (value, values)
         extend(mapping[type(key).__name__](key, mapping))
@@ -138,6 +139,7 @@ _a_encode_mapping = {'int': _a_encode_int,
                      'set': _a_encode_set,
                      'tuple': _a_encode_tuple,
                      'dict': _a_encode_dictionary,
+                     'OrderedDict': _a_encode_dictionary,
                      'NoneType': _a_encode_none,
                      'bool': _a_encode_bool}
 

--- a/ipv8/messaging/deprecated/sorting.py
+++ b/ipv8/messaging/deprecated/sorting.py
@@ -1,0 +1,163 @@
+from collections import OrderedDict
+
+from ...util import is_long_or_int, is_unicode
+
+
+class SortableTypeEnum(object):
+    """
+    Initial type sorting enum: the lower enum values are inserted closer to the head of the list.
+
+    We distinguish:
+     - NONE: None
+     - BOOLEAN: bool
+     - NUMBER: float, int, long
+     - STRING: bytes, str, unicode
+     - LIST: dict, list, set, tuple*
+
+     * Note that a tuple is a special kind of LIST, which is not sorted.
+       This would, for instance, sort (key, value) pairs.
+    """
+
+    NONE = 0
+    BOOLEAN = 1
+    NUMBER = 2
+    STRING = 3
+    LIST = 4
+
+
+class Sortable(object):
+    """
+    Wrapper for sortable types.
+    """
+
+    def __init__(self, value):
+        """
+        Wrap a value as a Sortable, which allows it to be sorted with `sorted()` or `list.sort()`.
+
+        :param value: a wrappable value
+        """
+        self.source = value # The source value
+        self.value = value # The sorted value
+        if self.value is None:
+            self.type = SortableTypeEnum.NONE
+        elif isinstance(self.value, bool):
+            self.type = SortableTypeEnum.BOOLEAN
+        elif isinstance(self.value, float) or is_long_or_int(self.value):
+            self.type = SortableTypeEnum.NUMBER
+        elif isinstance(self.value, (bytes, str)) or is_unicode(self.value):
+            self.type = SortableTypeEnum.STRING
+        elif isinstance(self.value, (set, dict, tuple, list)):
+            self.type = SortableTypeEnum.LIST
+            if isinstance(value, dict):
+                self.value = sorted([Sortable((k, v)) for k, v in list(value.items())])
+            elif isinstance(value, tuple):
+                self.value = [Sortable(v) for v in value]
+            else:
+                self.value = sorted([Sortable(v) for v in value])
+        else:
+            raise RuntimeError("Unsortable value %s!" % repr(self.value))
+
+    def compare(self, other):
+        """
+        Compare this Sortable to another Sortable.
+
+        :param other: the Sortable to compare to
+        :type other: Sortable
+        :return: -1, 0 or 1 if this object is smaller, equal or larger than the other object
+        """
+        # Initially we sort on enum value (NONE < BOOLEAN < .. < LIST)
+        if other.type == self.type:
+            if self.type == SortableTypeEnum.NONE:
+                # None is always equal
+                return 0
+            if self.type == SortableTypeEnum.BOOLEAN:
+                # False < True
+                if self.value == other.value:
+                    return 0
+                if self.value:
+                    return 1
+                return -1
+            if self.type == SortableTypeEnum.NUMBER:
+                # Python allows us to intrinsically compare float to int and long
+                if self.value == other.value:
+                    return 0
+                if self.value < other.value:
+                    return -1
+                return 1
+            if self.type == SortableTypeEnum.STRING:
+                # To deal with unicode we cast all string types to a list of ordinals
+                my_ordinals = self.value if isinstance(self.value, bytes) else [ord(c) for c in self.value]
+                other_ordinals = other.value if isinstance(other.value, bytes) else [ord(c) for c in other.value]
+            else:
+                # All list types can simply give their sorted values for comparison
+                my_ordinals = self.value
+                other_ordinals = other.value
+            n = min(len(my_ordinals), len(other_ordinals))
+            for i in range(n):
+                # Compare each value between lists, this is supported through the Sortable wrapper.
+                if my_ordinals[i] < other_ordinals[i]:
+                    return -1
+                elif my_ordinals[i] > other_ordinals[i]:
+                    return 1
+            # If all list entries are equal, the shortest list is smaller
+            if len(my_ordinals) < len(other_ordinals):
+                return -1
+            elif len(my_ordinals) > len(other_ordinals):
+                return 1
+            return 0
+        elif self.type < other.type:
+            return -1
+        return 1
+
+    def finalize(self):
+        """
+        Unwrap this Sortable to its sorted value.
+
+        Note that LISTs are type-changed:
+         - dict -> OrderedDict
+         - list -> list
+         - set -> list
+         - tuple -> tuple (order preserved)
+
+        :return: this Sortable as its source data type
+        """
+        if self.type == SortableTypeEnum.LIST:
+            converted = [v.finalize() for v in self.value]
+            if isinstance(self.source, dict):
+                out = OrderedDict()
+                for v in converted:
+                    out[v[0]] = v[1]
+                return out
+            return tuple(converted) if isinstance(self.source, tuple) else converted
+        return self.value
+
+    def __lt__(self, other):
+        return self.compare(other) < 0
+
+    def __gt__(self, other):
+        return self.compare(other) > 0
+
+
+def sortable_sort(data):
+    """
+    Sort complex input containing any combination of:
+
+     - None
+     - bool
+     - float
+     - int
+     - long
+     - bytes
+     - str
+     - unicode
+     - dict
+     - list
+     - set
+     - tuple
+
+    :return: the sorted input
+    """
+    return Sortable(data).finalize()
+
+
+__all__ = ["sortable_sort"]

--- a/ipv8/test/messaging/deprecated/test_encoding.py
+++ b/ipv8/test/messaging/deprecated/test_encoding.py
@@ -99,7 +99,6 @@ class TestEncoding(unittest.TestCase):
 
         self.assertEqual(value, decoded)
 
-    @skipIf(sys.version_info.major > 2, "https://github.com/Tribler/py-ipv8/issues/295")
     def test_encode_dict(self):
         """
         Check if a dictionary can be encoded and decoded.

--- a/ipv8/test/messaging/deprecated/test_sorting.py
+++ b/ipv8/test/messaging/deprecated/test_sorting.py
@@ -1,0 +1,304 @@
+from __future__ import absolute_import
+
+from collections import OrderedDict
+
+from twisted.trial import unittest
+
+from ....messaging.deprecated.sorting import sortable_sort
+
+
+class TestSorting(unittest.TestCase):
+
+    def test_illegal_object(self):
+        self.assertRaises(RuntimeError, sortable_sort, self)
+
+    def test_type_ordering(self):
+        """
+        Check if types form the primary sorting key.
+        """
+        out = sortable_sort(["1", None, [1, 2], True, 1])
+
+        self.assertListEqual(out, [None, True, 1, "1", [1, 2]])
+
+    def test_single_none(self):
+        """
+        Check if a None is returned as is.
+        """
+        self.assertEqual(sortable_sort(None), None)
+
+    def test_single_bool_true(self):
+        """
+        Check if a True is returned as is.
+        """
+        self.assertEqual(sortable_sort(True), True)
+
+    def test_single_bool_false(self):
+        """
+        Check if a False is returned as is.
+        """
+        self.assertEqual(sortable_sort(False), False)
+
+    def test_single_float_zero(self):
+        """
+        Check if a 0.0 is returned as is.
+        """
+        self.assertEqual(sortable_sort(0.0), 0.0)
+
+    def test_single_float_minus_one(self):
+        """
+        Check if a -1.0 is returned as is.
+        """
+        self.assertEqual(sortable_sort(-1.0), -1.0)
+
+    def test_single_float_plus_one(self):
+        """
+        Check if a 1.0 is returned as is.
+        """
+        self.assertEqual(sortable_sort(1.0), 1.0)
+
+    def test_single_float_large(self):
+        """
+        Check if a 99999.9999 is returned as is.
+        """
+        self.assertEqual(sortable_sort(99999.9999), 99999.9999)
+
+    def test_single_int_zero(self):
+        """
+        Check if a 0 is returned as is.
+        """
+        self.assertEqual(sortable_sort(0), 0)
+
+    def test_single_int_minus_one(self):
+        """
+        Check if a -1 is returned as is.
+        """
+        self.assertEqual(sortable_sort(-1), -1)
+
+    def test_single_int_plus_one(self):
+        """
+        Check if a 1 is returned as is.
+        """
+        self.assertEqual(sortable_sort(1), 1)
+
+    def test_single_float_int(self):
+        """
+        Check if a 999999999 is returned as is.
+        """
+        self.assertEqual(sortable_sort(999999999), 999999999)
+
+    def test_single_bytes_empty(self):
+        """
+        Check if an empty byte string is returned as is.
+        """
+        self.assertEqual(sortable_sort(b""), b"")
+
+    def test_single_bytes_one(self):
+        """
+        Check if a single character byte string is returned as is.
+        """
+        self.assertEqual(sortable_sort(b"\x01"), b"\x01")
+
+    def test_single_bytes_many(self):
+        """
+        Check if an all different bytes string is returned as is.
+        """
+        self.assertEqual(sortable_sort(bytes(range(256))), bytes(range(256)))
+
+    def test_single_str_empty(self):
+        """
+        Check if an empty string is returned as is.
+        """
+        self.assertEqual(sortable_sort(""), "")
+
+    def test_single_str_one(self):
+        """
+        Check if a single character string is returned as is.
+        """
+        self.assertEqual(sortable_sort("\x01"), "\x01")
+
+    def test_single_str_many(self):
+        """
+        Check if an all different character string is returned as is.
+        """
+        self.assertEqual(sortable_sort("".join([chr(c) for c in range(256)])), "".join([chr(c) for c in range(256)]))
+
+    def test_single_tuple_empty(self):
+        """
+        Check if an empty tuple is returned as is.
+        """
+        self.assertTupleEqual(sortable_sort(tuple()), tuple())
+
+    def test_single_tuple_one(self):
+        """
+        Check if a single entry tuple is returned as is.
+        """
+        self.assertTupleEqual(sortable_sort((b"\x01", )), (b"\x01", ))
+
+    def test_single_tuple_many(self):
+        """
+        Check if a filled tuple is returned as is.
+        """
+        data = (5, 4, "z", "a", [4, 2])
+        expected = (5, 4, "z", "a", [2, 4])
+
+        self.assertTupleEqual(sortable_sort(data), expected)
+
+    def test_single_set_empty(self):
+        """
+        Check if an empty set is returned as is.
+        """
+        self.assertListEqual(sortable_sort(set()), [])
+
+    def test_single_set_one(self):
+        """
+        Check if a single entry set is returned as is.
+        """
+        self.assertListEqual(sortable_sort({b"\x01"}), [b"\x01"])
+
+    def test_single_set_many(self):
+        """
+        Check if a filled set is returned sorted.
+        """
+        data = {5, 4, "z", "a"}
+        expected = [4, 5, "a", "z"]
+
+        self.assertListEqual(sortable_sort(data), expected)
+
+    def test_single_list_empty(self):
+        """
+        Check if an empty list is returned as is.
+        """
+        self.assertListEqual(sortable_sort([]), [])
+
+    def test_single_list_one(self):
+        """
+        Check if a single entry list is returned as is.
+        """
+        self.assertListEqual(sortable_sort([b"\x01"]), [b"\x01"])
+
+    def test_single_list_many(self):
+        """
+        Check if a filled list is returned sorted.
+        """
+        data = [5, 4, "z", "a", [4, 2]]
+        expected = [4, 5, "a", "z", [2, 4]]
+
+        self.assertListEqual(sortable_sort(data), expected)
+
+    def test_single_dict_empty(self):
+        """
+        Check if an empty dict is returned as is.
+        """
+        self.assertDictEqual(sortable_sort({}), {})
+
+    def test_single_dict_one(self):
+        """
+        Check if a single entry dict is returned as is.
+        """
+        self.assertDictEqual(sortable_sort({b"\x01": b"\x02"}), {b"\x01": b"\x02"})
+
+    def test_single_dict_many(self):
+        """
+        Check if a filled dict is returned sorted.
+        """
+        data = {5: 4, "z": "a", 1: [4, 2]}
+        expected = {1: [2, 4], 5: 4, "z": "a"}
+
+        self.assertDictEqual(sortable_sort(data), expected)
+
+    def test_nested_list_single(self):
+        """
+        Check if a list of lists is sorted.
+        """
+        data = [[5, 4], [2, 3], [1, 0]]
+        expected = [[0, 1], [2, 3], [4, 5]]
+
+        self.assertListEqual(sortable_sort(data), expected)
+
+    def test_nested_list_equal(self):
+        """
+        Check if a list of equal lists is sorted.
+        """
+        data = [[0, 1], [1, 0]]
+        expected = [[0, 1], [0, 1]]
+
+        self.assertListEqual(sortable_sort(data), expected)
+
+    def test_nested_list_partial(self):
+        """
+        Check if a list of lists with overlap is sorted.
+        """
+        data = [[1, 2], [0, 1, 2, 3], [2, 1, 0], [0, 1, 4, 3, 2]]
+        expected = [[0, 1, 2], [0, 1, 2, 3], [0, 1, 2, 3, 4], [1, 2]]
+
+        self.assertListEqual(sortable_sort(data), expected)
+
+    def test_nested_list_double_mixed(self):
+        """
+        Check if a list of lists of half list is sorted.
+        """
+        data = [[5, 4], [[2, 2.5], 3], [1, 0]]
+        expected = [[0, 1], [3, [2, 2.5]], [4, 5]]
+
+        self.assertListEqual(sortable_sort(data), expected)
+
+    def test_nested_list_double_pure(self):
+        """
+        Check if a list of lists of list is sorted.
+        """
+        data = [[5, 4], [[2, 2.5], [3, 3.5]], [1, 0]]
+        expected = [[0, 1], [4, 5], [[2, 2.5], [3, 3.5]]]
+
+        self.assertListEqual(sortable_sort(data), expected)
+
+    def test_nested_list_bools(self):
+        """
+        Check if booleans are propertly sorted in a list.
+        """
+        data = [True, False, False, True, False]
+        expected = [False, False, False, True, True]
+
+        self.assertListEqual(sortable_sort(data), expected)
+
+    def test_nested_list_none(self):
+        """
+        Check if nones are propertly sorted in a list.
+        """
+        data = [None, None, [None]]
+        expected = [None, None, [None]]
+
+        self.assertListEqual(sortable_sort(data), expected)
+
+    def test_nested_dict_single(self):
+        """
+        Check if a dict of lists is sorted.
+        """
+        data = {1: [5, 4], 3: [2, 3], 2: [1, 0]}
+        expected = OrderedDict([(1, [4, 5]), (2, [0, 1]), (3, [2, 3])])
+
+        self.assertDictEqual(sortable_sort(data), expected)
+
+    def test_nested_dict_double(self):
+        """
+        Check if a dict of dicts is sorted.
+        """
+        data = {7: {2: 4, 4: 5}, 1: {4: 5, 2: 3}}
+        expected = OrderedDict([(1, OrderedDict([(2, 3), (4, 5)])), (7, OrderedDict([(2, 4), (4, 5)]))])
+
+        self.assertDictEqual(sortable_sort(data), expected)
+
+    def test_payload_of_doom(self):
+        """
+        Check if an inconsistent sorted() list is sorted correctly.
+
+        In other words:
+            Given: set(data) == set(data2)
+
+            Given: sorted(data) != sorted(data2)
+
+            Then: sortable_sort(data) == sortable_sort(data2)
+        """
+        data = ['a', u'b', (1, ), 'c']
+        data2 = ['a', u'b', 'c', (1, )]
+
+        self.assertListEqual(sortable_sort(data), sortable_sort(data2))

--- a/test_classes_list.txt
+++ b/test_classes_list.txt
@@ -26,6 +26,7 @@ ipv8/test/attestation/wallet/primitives/test_structs.py:TestStructs
 ipv8/test/attestation/wallet/test_attestation_community.py:TestCommunity
 
 ipv8/test/messaging/test_serialization.py:TestSerializer
+ipv8/test/messaging/deprecated/test_sorting.py:TestSorting
 ipv8/test/messaging/deprecated/test_encoding.py:TestEncoding
 ipv8/test/messaging/interfaces/udp/test_endpoint.py:TestUDPEndpoint
 ipv8/test/messaging/anonymization/test_community.py:TestTunnelCommunity


### PR DESCRIPTION
This is a platform agnostic sorting method for mixed-type datastructures, this allows us to port to other languages like Java (or even Python 3).

Fixes #295. Requires a hard reset of the TrustChain database.

![afbeelding](https://user-images.githubusercontent.com/3630389/46143085-36ad3900-c259-11e8-9417-9f24ede79a95.png)
