### PR TITLE
Fixed test setUp without reactor

### DIFF
--- a/ipv8/test/mocking/endpoint.py
+++ b/ipv8/test/mocking/endpoint.py
@@ -35,7 +35,10 @@ class MockEndpoint(Endpoint):
         if not self.is_open():
             return
         if socket_address in internet:
-            reactor.callInThread(internet[socket_address].notify_listeners, (self.wan_address, packet))
+            if reactor.running:
+                reactor.callInThread(internet[socket_address].notify_listeners, (self.wan_address, packet))
+            else:
+                reactor.callWhenRunning(internet[socket_address].notify_listeners, (self.wan_address, packet))
         else:
             raise AssertionError("Received data from unregistered address %s" % repr(socket_address))
 

--- a/ipv8/test/mocking/ipv8.py
+++ b/ipv8/test/mocking/ipv8.py
@@ -48,9 +48,9 @@ class MockIPv8(object):
             self.endpoint.enable_community_statistics(self.overlay.get_prefix(), True)
 
     def unload(self):
-        self.overlay.unload()
+        self.endpoint.close()
         if self.trustchain:
             self.trustchain.unload()
         if self.dht:
             self.dht.unload()
-        self.endpoint.close()
+        self.overlay.unload()


### PR DESCRIPTION
Fixes #299

Fix unconfirmed for #278, #290, #297. Requires further extensive testing on Mac and Windows.