### PR TITLE
Fixed TrustChain introductions

### DIFF
--- a/ipv8/attestation/trustchain/community.py
+++ b/ipv8/attestation/trustchain/community.py
@@ -654,7 +654,10 @@ class TrustChainCommunity(Community):
 
     @synchronized
     def introduction_response_callback(self, peer, dist, payload):
-        chain_length = struct.unpack('>H', payload.extra_bytes)[0]
+        chain_length = None
+        if payload.extra_bytes:
+            chain_length = struct.unpack('>H', payload.extra_bytes)[0]
+
         if peer.address in self.network.blacklist:  # Do not crawl addresses in our blacklist (trackers)
             return
 

--- a/ipv8/messaging/anonymization/community.py
+++ b/ipv8/messaging/anonymization/community.py
@@ -664,13 +664,13 @@ class TunnelCommunity(Community):
     def introduction_response_callback(self, peer, dist, payload):
         self.update_exit_candidates(peer, self.parse_extra_bytes(payload.extra_bytes))
 
-    def create_introduction_request(self, socket_address, extra_bytes=''):
+    def create_introduction_request(self, socket_address, extra_bytes=b''):
         extra_payload = ExtraIntroductionPayload(self.become_exitnode())
         extra_bytes = self.serializer.pack_multiple(extra_payload.to_pack_list())[0]
         return super(TunnelCommunity, self).create_introduction_request(socket_address, extra_bytes)
 
     def create_introduction_response(self, lan_socket_address, socket_address, identifier,
-                                     introduction=None, extra_bytes=''):
+                                     introduction=None, extra_bytes=b''):
         extra_payload = ExtraIntroductionPayload(self.become_exitnode())
         extra_bytes = self.serializer.pack_multiple(extra_payload.to_pack_list())[0]
         return super(TunnelCommunity, self).create_introduction_response(lan_socket_address, socket_address,


### PR DESCRIPTION
The `extra_bytes` field in the payload is not always set, i.e. when being introduced by someone else through the IPv8 crawler.