### PR TITLE
Fixed order of unloading

### DIFF
--- a/ipv8/test/mocking/ipv8.py
+++ b/ipv8/test/mocking/ipv8.py
@@ -49,8 +49,8 @@ class MockIPv8(object):
 
     def unload(self):
         self.endpoint.close()
+        self.overlay.unload()
         if self.trustchain:
             self.trustchain.unload()
         if self.dht:
             self.dht.unload()
-        self.overlay.unload()


### PR DESCRIPTION
There are various overlays which are dependent on the TrustChain when shutting down (i.e. the tunnel community).