### PR TITLE
WIP: Fixed double accounting of bytes

### DIFF
--- a/ipv8/messaging/anonymization/community.py
+++ b/ipv8/messaging/anonymization/community.py
@@ -879,7 +879,6 @@ class TunnelCommunity(Community):
         circuit = self.circuits.get(circuit_id, None)
         if circuit and origin and sock_addr == circuit.peer.address:
             circuit.beat_heart()
-            self.increase_bytes_received(circuit, len(data))
 
             if DataChecker.could_be_ipv8(data):
                 self.logger.debug("Giving incoming data packet to IPv8 (circuit ID %d)", circuit_id)


### PR DESCRIPTION
When receiving bytes, they were accounted twice, one time when receiving the encrypted cell, and again in the on_data method, when dealing with the actual payload.