### PR TITLE
Fixed Python3 JSON only handling and returning unicode

### DIFF
--- a/ipv8/REST/rest_manager.py
+++ b/ipv8/REST/rest_manager.py
@@ -56,7 +56,7 @@ class RESTRequest(server.Request):
             u"error": {
                 u"handled": False,
                 u"code": failure.value.__class__.__name__,
-                u"message": failure.value.message
+                u"message": str(failure.value)
             }
         }
         if self.site.displayTracebacks:

--- a/ipv8/attestation/wallet/community.py
+++ b/ipv8/attestation/wallet/community.py
@@ -21,7 +21,7 @@ from .primitives.attestation import (attest_sha256_4, binary_relativity_certaint
 from .primitives.structs import Attestation, BonehPrivateKey, BonehPublicKey, pack_pair, unpack_pair
 from ...peer import Peer
 from ...requestcache import RequestCache
-from ...util import cast_to_bin, cast_to_chr
+from ...util import cast_to_bin, cast_to_chr, cast_to_unicode
 
 
 from threading import Lock
@@ -129,7 +129,7 @@ class AttestationCommunity(Community):
             "public_key": cast_to_chr(encodestring(public_key.serialize()))
         }
         meta_dict.update(metadata)
-        metadata = cast_to_bin(json.dumps(meta_dict))
+        metadata = cast_to_bin(json.dumps({cast_to_unicode(k): cast_to_unicode(v) for k, v in meta_dict.items()}))
 
         global_time = self.claim_global_time()
         auth = BinMemberAuthenticationPayload(self.my_peer.public_key.key_to_bin()).to_pack_list()

--- a/ipv8/test/attestation/wallet/test_attestation_community.py
+++ b/ipv8/test/attestation/wallet/test_attestation_community.py
@@ -59,7 +59,7 @@ class TestCommunity(TestBase):
         def f(peer, attribute_name, metadata):
             self.assertEqual(peer.address, self.nodes[1].endpoint.wan_address)
             self.assertEqual(attribute_name, "MyAttribute")
-            self.assertDictEqual(metadata, {'test': 123})
+            self.assertDictEqual(metadata, {u'test': u'123'})
 
             f.called = True
 

--- a/ipv8/util.py
+++ b/ipv8/util.py
@@ -20,7 +20,7 @@ if sys.version_info.major > 2:
     is_long_or_int = lambda x: isinstance(x, int)
     is_unicode = lambda x: isinstance(x, str)
     cast_to_long = lambda x: x
-    cast_to_unicode = lambda x: str(x)
+    cast_to_unicode = lambda x: "".join([chr(c) for c in x]) if isinstance(x, bytes) else str(x)
     cast_to_bin = lambda x: x if isinstance(x, bytes) else bytes([ord(c) for c in x])
     cast_to_chr = lambda x: "".join([chr(c) for c in x])
     maximum_integer = sys.maxsize


### PR DESCRIPTION
This PR fixes the IdentityCommunity receiving 50/50 unicode and byte string attribute values due to the `json` library. Everything is now a byte string again.

This PR also fixes `cast_to_unicode` performing `str()` on a `bytes` object, which causes the following:
```python
>>> str(b'a')
"b'a'"
```
Instead this PR uses the following function for `bytes` in `cast_to_unicode`:
```python
>>> f = lambda x: "".join([chr(c) for c in x])
>>> f(b'a')
'a'
```