### PR TITLE
Fixed two errors with source/link blocks

### DIFF
--- a/ipv8/attestation/trustchain/block.py
+++ b/ipv8/attestation/trustchain/block.py
@@ -340,7 +340,8 @@ class TrustChainBlock(object):
                 # self counter signs another block (link). If link has a linked block that is not equal to self,
                 # then self is fraudulent, since it tries to countersign a block that is already countersigned
                 linklinked = database.get_linked(link)
-                if linklinked is not None and linklinked.hash != self.hash:
+                if linklinked is not None and linklinked.hash != self.hash and \
+                        link.link_public_key != ANY_COUNTERPARTY_PK:
                     result.err("Double countersign fraud")
 
     def update_chain_consistency(self, prev_blk, next_blk, result):

--- a/ipv8/attestation/trustchain/block.py
+++ b/ipv8/attestation/trustchain/block.py
@@ -404,7 +404,7 @@ class TrustChainBlock(object):
         blk = database.get_latest(public_key)
         ret = cls()
         if link:
-            ret.type = link.type
+            ret.type = link.type if link.link_public_key != ANY_COUNTERPARTY_PK else block_type
             ret.transaction = link.transaction if additional_info is None else additional_info
             ret.link_public_key = link.public_key
             ret.link_sequence_number = link.sequence_number

--- a/ipv8/attestation/trustchain/community.py
+++ b/ipv8/attestation/trustchain/community.py
@@ -188,7 +188,7 @@ class TrustChainCommunity(Community):
         return self.sign_block(peer=None, public_key=ANY_COUNTERPARTY_PK,
                                block_type=block_type, transaction=transaction)
 
-    def create_link(self, source, block_type=b'unknown', additional_info=None, public_key=None):
+    def create_link(self, source, block_type, additional_info=None, public_key=None):
         """
         Create a Link Block to a source block
 
@@ -200,8 +200,8 @@ class TrustChainCommunity(Community):
         """
         public_key = source.public_key if public_key is None else public_key
 
-        self.sign_block(self.my_peer, linked=source, public_key=public_key, block_type=block_type,
-                        additional_info=additional_info)
+        return self.sign_block(self.my_peer, linked=source, public_key=public_key, block_type=block_type,
+                               additional_info=additional_info)
 
     @synchronized
     def sign_block(self, peer, public_key=EMPTY_PK, block_type=b'unknown', transaction=None, linked=None,
@@ -235,7 +235,10 @@ class TrustChainCommunity(Community):
         assert additional_info is None or isinstance(additional_info, dict), "Additional info should be a dictionary"
 
         self.persistence_integrity_check()
-        block_type = linked.type if linked else block_type
+
+        if linked and linked.link_public_key != ANY_COUNTERPARTY_PK:
+            block_type = linked.type
+
         block = self.get_block_class(block_type).create(block_type, transaction, self.persistence,
                                                         self.my_peer.public_key.key_to_bin(),
                                                         link=linked, additional_info=additional_info,

--- a/ipv8/attestation/trustchain/database.py
+++ b/ipv8/attestation/trustchain/database.py
@@ -236,8 +236,20 @@ class TrustChainDB(Database):
         :return: the latest block or None if it is not known
         """
         return self._get(u"WHERE public_key = ? AND sequence_number = ? OR link_public_key = ? AND "
-                         u"link_sequence_number = ?", (database_blob(block.link_public_key), block.link_sequence_number,
-                                                       database_blob(block.public_key), block.sequence_number))
+                         u"link_sequence_number = ? ORDER BY block_timestamp ASC",
+                         (database_blob(block.link_public_key), block.link_sequence_number,
+                          database_blob(block.public_key), block.sequence_number))
+
+    def get_all_linked(self, block):
+        """
+        Return all linked blocks for a specific block.
+        :param block: The block for which to get the linked block
+        :return: A list of all linked blocks
+        """
+        return self._getall(u"WHERE public_key = ? AND sequence_number = ? OR link_public_key = ? AND "
+                            u"link_sequence_number = ?", (database_blob(block.link_public_key),
+                                                          block.link_sequence_number, database_blob(block.public_key),
+                                                          block.sequence_number))
 
     def crawl(self, public_key, start_seq_num, end_seq_num, limit=100):
         query = u"SELECT * FROM (%s WHERE sequence_number >= ? AND sequence_number <= ? AND public_key = ? LIMIT ?) " \

--- a/ipv8/test/attestation/trustchain/test_community.py
+++ b/ipv8/test/attestation/trustchain/test_community.py
@@ -461,6 +461,24 @@ class TestTrustChainCommunity(TestBase):
         self.assertEqual(block_node_0.transaction, {b'a': 1, b'b': 2})
         self.assertEqual(block_node_1.transaction, {b'a': 1, b'b': 2})
 
+    @inlineCallbacks
+    def test_link_block_multiple(self):
+        """
+        Test whether we can create multiple link blocks for the same source block
+        """
+        source_peer_pubkey = self.nodes[0].my_peer.public_key.key_to_bin()
+
+        source_block, _ = yield self.nodes[0].overlay.create_source_block(b'test', {})
+        yield self.deliver_messages()
+
+        block = self.nodes[1].overlay.persistence.get(source_peer_pubkey, 1)
+
+        yield self.nodes[1].overlay.create_link(block, b'link', additional_info={b'a': 1, b'b': 2})
+        yield self.nodes[1].overlay.create_link(block, b'link', additional_info={b'a': 2, b'b': 3})
+        yield self.deliver_messages()
+
+        self.assertEqual(len(self.nodes[0].overlay.persistence.get_all_linked(source_block)), 2)
+
     def test_db_remove(self):
         """
         Test pruning of the database when it grows too large

--- a/ipv8/test/attestation/trustchain/test_community.py
+++ b/ipv8/test/attestation/trustchain/test_community.py
@@ -447,7 +447,8 @@ class TestTrustChainCommunity(TestBase):
         self.assertIsNotNone(block)
 
         # Create a Link Block
-        yield self.nodes[1].overlay.create_link(block, block_type=b'link', additional_info={b'a': 1, b'b': 2})
+        link_block, _ = yield self.nodes[1].overlay.create_link(block, b'link', additional_info={b'a': 1, b'b': 2})
+        self.assertEqual(link_block.type, b'link')
         yield self.deliver_messages()
 
         # Check the dissemination of the link block


### PR DESCRIPTION
In this PR, I fixed two errors related to source/link blocks:
- fixed the block type of a linked block. Without the proper logic, the provided `block_type` parameter when creating a linked block would be ignored.
- fixed the validation mechanism when creating multiple linked blocks for a single source block. This was classified as a double-spend attempt.