### PR TITLE
Moved as many classes to six as possible

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -123,7 +123,7 @@ ignore-mixin-members=yes
 # (useful for modules/projects where namespaces are manipulated during runtime
 # and thus existing member attributes cannot be deduced by static analysis. It
 # supports qualified module names, as well as Unix pattern matching.
-ignored-modules=
+ignored-modules=six.moves
 
 # List of classes names for which member attributes should not be checked
 # (useful for classes with attributes dynamically set). This supports can work

--- a/create_test_coverage_report.py
+++ b/create_test_coverage_report.py
@@ -1,24 +1,24 @@
 from __future__ import absolute_import
 from __future__ import print_function
 
+import logging
+import os
+import shutil
 import sys
+
+import coverage
+from six import StringIO
+from twisted.trial.runner import TestLoader
+from twisted.trial.reporter import VerboseTextReporter
 
 if __name__ != '__main__':
     print(__file__, "should be run stand-alone! Instead, it is being imported!", file=sys.stderr)
     sys.exit(1)
 
-import logging
+data_file = os.path.join('coverage', 'raw', 'coverage_file')
 logging.basicConfig(level=logging.CRITICAL)
 logging.disable(logging.CRITICAL)
 
-import coverage
-import os
-import shutil
-from twisted.trial.runner import TestLoader
-from twisted.trial.reporter import VerboseTextReporter
-from ipv8.util import StringIO
-
-data_file = os.path.join('coverage', 'raw', 'coverage_file')
 
 def clean_directory(prepare=False):
     path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'coverage', 'raw')
@@ -26,6 +26,7 @@ def clean_directory(prepare=False):
         shutil.rmtree(path)
     if prepare:
         os.makedirs(path)
+
 
 clean_directory(prepare=True)
 

--- a/ipv8/attestation/trustchain/block.py
+++ b/ipv8/attestation/trustchain/block.py
@@ -4,12 +4,14 @@ from binascii import hexlify
 from hashlib import sha256
 import time
 
+from six import string_types
+
 from ...database import database_blob
 from ...keyvault.crypto import default_eccrypto
 from ...messaging.deprecated.encoding import decode, encode
 from ...messaging.serialization import default_serializer
 from .payload import HalfBlockPayload
-from ...util import is_unicode, old_round
+from ...util import old_round
 
 
 GENESIS_HASH = b'0'*32    # ID of the first block of the chain.
@@ -443,7 +445,7 @@ class TrustChainBlock(object):
         for key, value in self.__dict__.items():
             if key == 'key' or key == 'serializer' or key == 'crypto' or key == '_transaction':
                 continue
-            if (isinstance(value, str) or is_unicode(value)) and key != "insert_time" and key != "type":
+            if isinstance(value, string_types) and key != "insert_time" and key != "type":
                 yield key, hexlify(value)
             else:
                 yield key, value

--- a/ipv8/attestation/trustchain/community.py
+++ b/ipv8/attestation/trustchain/community.py
@@ -12,6 +12,7 @@ import struct
 from functools import wraps
 from threading import RLock
 
+from six.moves import xrange
 from twisted.internet import reactor
 from twisted.internet.defer import Deferred, succeed, fail
 from twisted.internet.task import LoopingCall
@@ -26,7 +27,7 @@ from ...messaging.payload_headers import BinMemberAuthenticationPayload, GlobalT
 from .payload import *
 from ...peer import Peer
 from ...requestcache import RandomNumberCache, RequestCache
-from ...util import addCallback, grange
+from ...util import addCallback
 
 receive_block_lock = RLock()
 
@@ -631,7 +632,7 @@ class TrustChainCommunity(Community):
         total_trust = sum([self.get_trust(peer) for peer in eligible])
         random_trust_i = random.randint(0, total_trust - 1)
         current_trust_i = 0
-        for i in grange(0, len(eligible)):
+        for i in xrange(0, len(eligible)):
             next_trust_i = self.get_trust(eligible[i])
             if current_trust_i + next_trust_i > random_trust_i:
                 return eligible[i]

--- a/ipv8/attestation/trustchain/database.py
+++ b/ipv8/attestation/trustchain/database.py
@@ -6,9 +6,10 @@ from __future__ import absolute_import
 from binascii import hexlify
 import os
 
+from six import text_type
+
 from ...database import database_blob, Database
 from .block import TrustChainBlock
-from ...util import is_unicode
 
 
 DATABASE_DIRECTORY = os.path.join(u"sqlite")
@@ -376,7 +377,7 @@ class TrustChainDB(Database):
         :param database_version: Current version of the database.
         :return:
         """
-        assert is_unicode(database_version)
+        assert isinstance(database_version, text_type)
         assert database_version.isdigit()
         assert int(database_version) >= 0
         database_version = int(database_version)

--- a/ipv8/database.py
+++ b/ipv8/database.py
@@ -15,7 +15,7 @@ import six
 import sys
 from threading import RLock
 
-from .util import is_long_or_int, is_unicode, cast_to_unicode
+from .util import cast_to_unicode
 
 if sys.platform == "darwin":
     # Workaround for annoying MacOS Sierra bug: https://bugs.python.org/issue27126
@@ -90,7 +90,7 @@ class Database(six.with_metaclass(ABCMeta, object)):
         @param file_path: the path to the database file.
         @type file_path: unicode
         """
-        self._assert(is_unicode(file_path),
+        self._assert(isinstance(file_path, six.text_type),
                      "expected file_path to be unicode, but was %s" % str(type(file_path)))
 
         super(Database, self).__init__()
@@ -230,7 +230,7 @@ class Database(six.with_metaclass(ABCMeta, object)):
             version = u"0"
 
         self._database_version = self.check_database(version)
-        self._assert(is_long_or_int(self._database_version),
+        self._assert(isinstance(self._database_version, six.integer_types),
                      "expected databse version to be int or long, but was type %s" % str(type(self._database_version)))
 
     @property
@@ -324,7 +324,7 @@ class Database(six.with_metaclass(ABCMeta, object)):
                      "Database.close() has been called or Database.open() has not been called")
         self._assert(self._connection is not None,
                      "Database.close() has been called or Database.open() has not been called")
-        self._assert(is_unicode(statements), "The SQL statement must be given in unicode")
+        self._assert(isinstance(statements, six.text_type), "The SQL statement must be given in unicode")
 
         self._logger.log(logging.NOTSET, "%s [%s]", statements, self._file_path)
 

--- a/ipv8/dht/discovery.py
+++ b/ipv8/dht/discovery.py
@@ -6,6 +6,7 @@ import time
 
 from collections import defaultdict
 
+from six.moves import xrange
 from twisted.internet.defer import fail
 from twisted.internet.task import LoopingCall
 from twisted.python.failure import Failure
@@ -18,7 +19,6 @@ from .routing import NODE_STATUS_BAD, Node
 from .payload import StorePeerRequestPayload, StorePeerResponsePayload, \
                      ConnectPeerRequestPayload, ConnectPeerResponsePayload, \
                      PingRequestPayload, PingResponsePayload
-from ..util import grange
 
 MSG_STORE_PEER_REQUEST = 13
 MSG_STORE_PEER_RESPONSE = 14
@@ -182,7 +182,7 @@ class DHTDiscoveryCommunity(DHTCommunity):
 
         now = time.time()
         for key, nodes in self.store_for_me.items():
-            for index in grange(len(nodes) - 1, -1, -1):
+            for index in xrange(len(nodes) - 1, -1, -1):
                 node = nodes[index]
                 if node.status == NODE_STATUS_BAD:
                     del self.store_for_me[key][index]
@@ -191,7 +191,7 @@ class DHTDiscoveryCommunity(DHTCommunity):
                     self.ping(node).addErrback(lambda _: None)
 
         for key, nodes in self.store.items():
-            for index in grange(len(nodes) - 1, -1, -1):
+            for index in xrange(len(nodes) - 1, -1, -1):
                 node = nodes[index]
                 if now > node.last_query + 60:
                     self.logger.debug('Deleting peer %s (key %s)', node, hexlify(key))

--- a/ipv8/messaging/anonymization/hidden_services.py
+++ b/ipv8/messaging/anonymization/hidden_services.py
@@ -11,6 +11,8 @@ import hashlib
 import os
 import struct
 
+from six.moves import xrange
+
 from .caches import *
 from .community import TunnelCommunity, message_to_payload, tc_lazy_wrapper_unsigned
 from ...messaging.deprecated.encoding import decode, encode
@@ -18,7 +20,6 @@ from .payload import *
 from ...peer import Peer
 from .tunnel import CIRCUIT_ID_PORT, CIRCUIT_TYPE_IP, CIRCUIT_TYPE_RENDEZVOUS, CIRCUIT_TYPE_RP, EXIT_NODE, \
                     EXIT_NODE_SALT, Hop, RelayRoute, RendezvousPoint, TunnelExitSocket
-from ...util import grange
 
 
 class HiddenTunnelCommunity(TunnelCommunity):
@@ -176,7 +177,7 @@ class HiddenTunnelCommunity(TunnelCommunity):
         blacklist = self.dht_blacklist[info_hash]
 
         # cleanup dht_blacklist
-        for i in grange(len(blacklist) - 1, -1, -1):
+        for i in xrange(len(blacklist) - 1, -1, -1):
             if time.time() - blacklist[i][0] > 60:
                 blacklist.pop(i)
         exclude = [rp[2] for rp in self.my_download_points.values()] + [sock_addr for _, sock_addr in blacklist]

--- a/ipv8/messaging/anonymization/tunnelcrypto.py
+++ b/ipv8/messaging/anonymization/tunnelcrypto.py
@@ -6,11 +6,11 @@ from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.kdf.hkdf import HKDFExpand
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
-
 import libnacl
+from six import integer_types
 
 from ...keyvault.crypto import ECCrypto, LibNaCLPK
-from ...util import cast_to_bin, is_long_or_int
+from ...util import cast_to_bin
 
 
 class CryptoException(Exception):
@@ -62,7 +62,7 @@ class TunnelCrypto(ECCrypto):
 
     def _bulid_iv(self, salt, salt_explicit):
         assert isinstance(salt, (bytes, str)), type(salt)
-        assert is_long_or_int(salt_explicit), type(salt_explicit)
+        assert isinstance(salt_explicit, integer_types), type(salt_explicit)
 
         if salt_explicit == 0:
             raise CryptoException("salt_explicit wrapped")

--- a/ipv8/messaging/bloomfilter.py
+++ b/ipv8/messaging/bloomfilter.py
@@ -30,7 +30,9 @@ from struct import Struct
 from binascii import hexlify, unhexlify
 import logging
 
-from ..util import cast_to_bin, cast_to_chr, is_long_or_int
+from six import integer_types
+
+from ..util import cast_to_bin, cast_to_chr
 
 logger = logging.getLogger(__name__)
 
@@ -133,7 +135,7 @@ class BloomFilter(object):
         assert 0 < self._k_functions <= self._m_size, [self._k_functions, self._m_size]
         assert isinstance(self._prefix, str), type(self._prefix)
         assert 0 <= len(self._prefix) < 256, len(self._prefix)
-        assert is_long_or_int(self._filter), type(self._filter)
+        assert isinstance(self._filter, integer_types), type(self._filter)
 
         # determine hash function
         if self._m_size >= (1 << 31):

--- a/ipv8/messaging/deprecated/sorting.py
+++ b/ipv8/messaging/deprecated/sorting.py
@@ -1,6 +1,8 @@
+from __future__ import absolute_import
+
 from collections import OrderedDict
 
-from ...util import is_long_or_int, is_unicode
+from six import integer_types, string_types
 
 
 class OrderedSet(set):
@@ -104,9 +106,9 @@ class Sortable(object):
             self.type = SortableTypeEnum.NONE
         elif isinstance(self.value, bool):
             self.type = SortableTypeEnum.BOOLEAN
-        elif isinstance(self.value, float) or is_long_or_int(self.value):
+        elif isinstance(self.value, (float, integer_types)):
             self.type = SortableTypeEnum.NUMBER
-        elif isinstance(self.value, (bytes, str)) or is_unicode(self.value):
+        elif isinstance(self.value, (bytes, string_types)):
             self.type = SortableTypeEnum.STRING
         elif isinstance(self.value, (set, dict, tuple, list)):
             self.type = SortableTypeEnum.LIST

--- a/ipv8/messaging/interfaces/udp/endpoint.py
+++ b/ipv8/messaging/interfaces/udp/endpoint.py
@@ -5,11 +5,11 @@ from collections import deque
 import socket
 import sys
 
+from six.moves import xrange
 from twisted.internet import protocol, reactor, error
 from twisted.internet.error import MessageLengthError
 
 from ..endpoint import Endpoint, EndpointClosedException
-from ....util import grange
 
 UDP_MAX_SIZE = 2 ** 16 - 60
 
@@ -58,7 +58,7 @@ class UDPEndpoint(Endpoint, protocol.DatagramProtocol):
             self._logger.error("Sending a packet that is too big (length: %d)", len(packet))
 
     def open(self):
-        for _ in grange(10000):
+        for _ in xrange(10000):
             try:
                 self._listening_port = reactor.listenUDP(self._port, self, self._ip, UDP_MAX_SIZE)
                 self._logger.debug("Listening at %d", self._port)

--- a/ipv8/peerdiscovery/network.py
+++ b/ipv8/peerdiscovery/network.py
@@ -4,7 +4,9 @@ from threading import RLock
 from socket import inet_aton, inet_ntoa
 from struct import pack, unpack
 
-from ..util import cast_to_chr, grange
+from six.moves import xrange
+
+from ..util import cast_to_chr
 
 
 class Network(object):
@@ -227,7 +229,7 @@ class Network(object):
             logging.error("Snapshot has invalid length! Aborting snapshot load.")
             return
         with self.graph_lock:
-            for i in grange(0, snaplen, 6):
+            for i in xrange(0, snaplen, 6):
                 sub = snapshot[i:i+6]
                 ip = inet_ntoa(sub[0:4])
                 port = unpack(">H", sub[4:])[0]

--- a/ipv8/requestcache.py
+++ b/ipv8/requestcache.py
@@ -4,17 +4,17 @@ import logging
 from random import random
 from threading import Lock
 
-from twisted.internet import reactor
+from six import integer_types, text_type
+from six.moves import xrange
 
 from .taskmanager import TaskManager
-from .util import grange, is_long_or_int, is_unicode
 
 
 class NumberCache(object):
 
     def __init__(self, request_cache, prefix, number):
-        assert is_long_or_int(number), type(number)
-        assert is_unicode(prefix), type(prefix)
+        assert isinstance(number, integer_types), type(number)
+        assert isinstance(prefix, text_type), type(prefix)
 
         super(NumberCache, self).__init__()
         self._logger = logging.getLogger(self.__class__.__name__)
@@ -47,7 +47,7 @@ class NumberCache(object):
 class RandomNumberCache(NumberCache):
 
     def __init__(self, request_cache, prefix):
-        assert is_unicode(prefix), type(prefix)
+        assert isinstance(prefix, text_type), type(prefix)
 
         # find an unclaimed identifier
         number = RandomNumberCache.find_unclaimed_identifier(request_cache, prefix)
@@ -55,7 +55,7 @@ class RandomNumberCache(NumberCache):
 
     @classmethod
     def find_unclaimed_identifier(cls, request_cache, prefix):
-        for _ in grange(1000):
+        for _ in xrange(1000):
             number = int(random() * 2 ** 16)
             if not request_cache.has(prefix, number):
                 break
@@ -86,8 +86,8 @@ class RequestCache(TaskManager):
         Returns CACHE when CACHE.identifier was not yet added, otherwise returns None.
         """
         assert isinstance(cache, NumberCache), type(cache)
-        assert is_long_or_int(cache.number), type(cache.number)
-        assert is_unicode(cache.prefix), type(cache.prefix)
+        assert isinstance(cache.number, integer_types), type(cache.number)
+        assert isinstance(cache.prefix, text_type), type(cache.prefix)
         assert isinstance(cache.timeout_delay, float), type(cache.timeout_delay)
         assert cache.timeout_delay > 0.0, cache.timeout_delay
 
@@ -111,16 +111,16 @@ class RequestCache(TaskManager):
         """
         Returns True when IDENTIFIER is part of this RequestCache.
         """
-        assert is_long_or_int(number), type(number)
-        assert is_unicode(prefix), type(prefix)
+        assert isinstance(number, integer_types), type(number)
+        assert isinstance(prefix, text_type), type(prefix)
         return self._create_identifier(number, prefix) in self._identifiers
 
     def get(self, prefix, number):
         """
         Returns the Cache associated with IDENTIFIER when it exists, otherwise returns None.
         """
-        assert is_long_or_int(number), type(number)
-        assert is_unicode(prefix), type(prefix)
+        assert isinstance(number, integer_types), type(number)
+        assert isinstance(prefix, text_type), type(prefix)
         return self._identifiers.get(self._create_identifier(number, prefix))
 
     def pop(self, prefix, number):
@@ -128,8 +128,8 @@ class RequestCache(TaskManager):
         Returns the Cache associated with IDENTIFIER, and removes it from this RequestCache, when it exists, otherwise
         raises a KeyError exception.
         """
-        assert is_long_or_int(number), type(number)
-        assert is_unicode(prefix), type(prefix)
+        assert isinstance(number, integer_types), type(number)
+        assert isinstance(prefix, text_type), type(prefix)
 
         identifier = self._create_identifier(number, prefix)
         cache = self._identifiers.pop(identifier)

--- a/ipv8/test/attestation/trustchain/test_community.py
+++ b/ipv8/test/attestation/trustchain/test_community.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+from six.moves import xrange
 from twisted.internet.defer import inlineCallbacks
 
 from ....attestation.trustchain.block import TrustChainBlock
@@ -11,7 +12,6 @@ from ....database import database_blob
 from ....keyvault.crypto import default_eccrypto
 from ...base import TestBase
 from ...mocking.ipv8 import MockIPv8
-from ....util import grange
 
 
 class DummyBlock(TrustChainBlock):
@@ -485,7 +485,7 @@ class TestTrustChainCommunity(TestBase):
         """
         self.nodes[0].overlay.settings.max_db_blocks = 5
 
-        for _ in grange(10):
+        for _ in xrange(10):
             test_block = TestBlock()
             self.nodes[0].overlay.persistence.add_block(test_block)
 

--- a/ipv8/test/messaging/interfaces/udp/test_endpoint.py
+++ b/ipv8/test/messaging/interfaces/udp/test_endpoint.py
@@ -4,12 +4,12 @@ import socket
 import sys
 from unittest import skipIf
 
+from six.moves import xrange
 from twisted.internet.defer import inlineCallbacks
 
 from .....messaging.interfaces.endpoint import EndpointListener
 from .....messaging.interfaces.udp.endpoint import UDPEndpoint, UDP_MAX_SIZE
 from ....base import TestBase
-from .....util import grange
 
 
 class DummyEndpointListener(EndpointListener):
@@ -65,7 +65,7 @@ class TestUDPEndpoint(TestBase):
         """
         Test sending multiple messages through the UDP endpoint.
         """
-        for ind in grange(0, 50):
+        for ind in xrange(0, 50):
             self.endpoint1.send(self.ep2_address, b'a' * ind)
         yield self.sleep(0.05)
         self.assertEqual(len(self.endpoint2_listener.incoming), 50)
@@ -121,7 +121,7 @@ class TestUDPEndpoint(TestBase):
         self.endpoint1.transport.socket.sendto = cb_err_sendto
 
         # The following send raises a WSAEWOULDBLOCK and should queue the packet
-        for i in grange(102):
+        for i in xrange(102):
             self.endpoint1.send(self.ep2_address, str(i))
         self.endpoint1.transport.socket.sendto = real_sendto
         yield self.sleep(0.05)
@@ -134,4 +134,4 @@ class TestUDPEndpoint(TestBase):
         yield self.sleep(0.05)
         self.assertEqual(len(self.endpoint2_listener.incoming), 101)
         self.assertSetEqual({data for _, data in self.endpoint2_listener.incoming},
-                            {str(i) for i in grange(2, 103)})
+                            {str(i) for i in xrange(2, 103)})

--- a/ipv8/test/messaging/test_bloomfilter.py
+++ b/ipv8/test/messaging/test_bloomfilter.py
@@ -3,8 +3,9 @@ from __future__ import division
 
 from unittest import TestCase
 
+from six.moves import xrange
+
 from ...messaging.bloomfilter import BloomFilter
-from ...util import grange
 
 
 class TestBloomFilter(TestCase):
@@ -18,7 +19,7 @@ class TestBloomFilter(TestCase):
                   BloomFilter(128 * 8, 0.25, prefix="")]
 
         for bloom in blooms:
-            bloom.add_keys(str(i) for i in grange(100))
+            bloom.add_keys(str(i) for i in xrange(100))
             self.assertEqual(bloom.size, 128 * 8)
             self.assertEqual(len(bloom.bytes), 128)
             self.assertEqual(bloom.prefix, "")
@@ -27,7 +28,7 @@ class TestBloomFilter(TestCase):
                   BloomFilter(128 * 8, 0.25, prefix="p")]
 
         for bloom in blooms:
-            bloom.add_keys(str(i) for i in grange(100))
+            bloom.add_keys(str(i) for i in xrange(100))
             self.assertEqual(bloom.size, 128 * 8)
             self.assertEqual(len(bloom.bytes), 128)
             self.assertEqual(bloom.prefix, "p")
@@ -41,14 +42,14 @@ class TestBloomFilter(TestCase):
                   BloomFilter(0.25, 142, prefix="")]
 
         for bloom in blooms:
-            bloom.add_keys(str(i) for i in grange(100))
+            bloom.add_keys(str(i) for i in xrange(100))
             self.assertEqual(bloom.prefix, "")
 
         blooms = [BloomFilter(0.25, 142, "p"),
                   BloomFilter(0.25, 142, prefix="p")]
 
         for bloom in blooms:
-            bloom.add_keys(str(i) for i in grange(100))
+            bloom.add_keys(str(i) for i in xrange(100))
             self.assertEqual(bloom.prefix, "p")
 
     def test_load_constructor(self):
@@ -56,7 +57,7 @@ class TestBloomFilter(TestCase):
         Testing BloomFilter(str:bytes, int:k_functions, str:prefix="")
         """
         bloom = BloomFilter(128 * 8, 0.25)
-        bloom.add_keys(str(i) for i in grange(100))
+        bloom.add_keys(str(i) for i in xrange(100))
         bytes_, functions = bloom.bytes, bloom.functions
 
         blooms = [BloomFilter(bytes_, functions),
@@ -67,10 +68,10 @@ class TestBloomFilter(TestCase):
             self.assertEqual(bloom.size, 128 * 8)
             self.assertEqual(bloom.bytes, bytes_)
             self.assertEqual(bloom.prefix, "")
-            self.assertTrue(all(str(i) in bloom for i in grange(100)))
+            self.assertTrue(all(str(i) in bloom for i in xrange(100)))
 
         bloom = BloomFilter(128 * 8, 0.25, "p")
-        bloom.add_keys(str(i) for i in grange(100))
+        bloom.add_keys(str(i) for i in xrange(100))
         bytes_, functions = bloom.bytes, bloom.functions
 
         blooms = [BloomFilter(bytes_, functions, "p"),
@@ -80,7 +81,7 @@ class TestBloomFilter(TestCase):
             self.assertEqual(bloom.size, 128 * 8)
             self.assertEqual(bloom.bytes, bytes_)
             self.assertEqual(bloom.prefix, "p")
-            self.assertTrue(all(str(i) in bloom for i in grange(100)))
+            self.assertTrue(all(str(i) in bloom for i in xrange(100)))
 
     def test_clear(self):
         """
@@ -88,7 +89,7 @@ class TestBloomFilter(TestCase):
         """
         bloom = BloomFilter(128 * 8, 0.25)
         self.assertEqual(bloom.bits_checked, 0)
-        bloom.add_keys(str(i) for i in grange(100))
+        bloom.add_keys(str(i) for i in xrange(100))
         self.assertNotEqual(bloom.bits_checked, 0)
         bloom.clear()
         self.assertEqual(bloom.bits_checked, 0)
@@ -116,7 +117,7 @@ class TestBloomFilter(TestCase):
 
         for f_error_rate, n_capacity, prefix in args:
             bloom = BloomFilter(f_error_rate, n_capacity, prefix)
-            bloom.add_keys(str(i) for i in grange(n_capacity))
-            self.assertTrue(all(str(i) in bloom for i in grange(n_capacity)))
-            false_positives = sum(str(i) in bloom for i in grange(n_capacity, n_capacity + 10000))
+            bloom.add_keys(str(i) for i in xrange(n_capacity))
+            self.assertTrue(all(str(i) in bloom for i in xrange(n_capacity)))
+            false_positives = sum(str(i) in bloom for i in xrange(n_capacity, n_capacity + 10000))
             self.assertAlmostEqual(1.0 * false_positives / 10000, f_error_rate, delta=0.05)

--- a/ipv8/test/mocking/rest/base.py
+++ b/ipv8/test/mocking/rest/base.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 import os
 import random
 import socket
@@ -5,13 +7,13 @@ from shutil import rmtree
 from string import ascii_uppercase, digits
 from threading import Thread
 
+from six.moves import xrange
 from twisted.internet import reactor
 from twisted.internet.defer import inlineCallbacks
 from twisted.internet.task import deferLater
 from twisted.trial import unittest
 
 from .rest_api_peer import RestTestPeer
-from ....util import grange
 
 TEST_FOLDER_PREFIX = "test_temp"
 
@@ -42,7 +44,7 @@ class RESTTestBase(unittest.TestCase):
             "peer_configurations not properly structured"
 
         for count, peer_type in peer_configurations:
-            for _ in grange(count):
+            for _ in xrange(count):
                 self.create_new_peer(peer_type, None)
 
         self._get_style_requests = get_style_requests

--- a/ipv8/test/mocking/rest/rest_peer_communication.py
+++ b/ipv8/test/mocking/rest/rest_peer_communication.py
@@ -1,13 +1,15 @@
+from __future__ import absolute_import
+
 import logging
 from json import loads
 
+from six.moves.urllib_parse import quote
 from twisted.internet import reactor
 from twisted.internet.defer import inlineCallbacks, returnValue
 from twisted.web.client import Agent, readBody
 from twisted.web.http_headers import Headers
 
 from .peer_communication import IGetStyleRequestsAE, RequestException, IPostStyleRequestsAE
-from ....util import quote
 
 
 def process_json_response(func):

--- a/ipv8/test/test_taskmanager.py
+++ b/ipv8/test/test_taskmanager.py
@@ -1,12 +1,12 @@
 from __future__ import absolute_import
 
+from six.moves import xrange
 from twisted.internet import reactor
 from twisted.internet.defer import Deferred, succeed
 from twisted.internet.task import Clock, deferLater, LoopingCall
 
 from .base import TestBase
 from ..taskmanager import CLEANUP_FREQUENCY, TaskManager
-from ..util import grange
 
 
 class TestTaskManager(TestBase):
@@ -134,7 +134,7 @@ class TestTaskManager(TestBase):
         Test if the tasks are cleaned up after the cleanup frequency has been met.
         """
         deferred = succeed(None)
-        for _ in grange(CLEANUP_FREQUENCY):
+        for _ in xrange(CLEANUP_FREQUENCY):
             self.tm.register_anonymous_task("test", deferred)
 
         deferred_list = self.tm.wait_for_deferred_tasks()
@@ -146,7 +146,7 @@ class TestTaskManager(TestBase):
         """
         deferred = succeed(None)
         self.tm.register_anonymous_task("test", Deferred()).addErrback(lambda _: None)
-        for _ in grange(CLEANUP_FREQUENCY-1):
+        for _ in xrange(CLEANUP_FREQUENCY-1):
             self.tm.register_anonymous_task("test", deferred)
 
         deferred_list = self.tm.wait_for_deferred_tasks()

--- a/ipv8/util.py
+++ b/ipv8/util.py
@@ -1,10 +1,10 @@
 from __future__ import absolute_import
 
-from collections import namedtuple
 import logging
 import sys
 import traceback
 
+from six.moves.queue import Queue
 from twisted.internet import reactor, defer
 from twisted.python.failure import Failure
 from twisted.python.threadable import isInIOThread
@@ -12,13 +12,7 @@ from twisted.python.threadable import isInIOThread
 logger = logging.getLogger(__name__)
 
 if sys.version_info.major > 2:
-    from io import StringIO
     import math
-    import queue as Queue
-    from urllib.parse import parse_qsl, ParseResult, unquote, urlencode, urlparse, quote
-    grange = range
-    is_long_or_int = lambda x: isinstance(x, int)
-    is_unicode = lambda x: isinstance(x, str)
     cast_to_long = lambda x: x
     cast_to_unicode = lambda x: "".join([chr(c) for c in x]) if isinstance(x, bytes) else str(x)
     cast_to_bin = lambda x: x if isinstance(x, bytes) else bytes([ord(c) for c in x])
@@ -26,22 +20,12 @@ if sys.version_info.major > 2:
     maximum_integer = sys.maxsize
     old_round = lambda x: float(math.floor((x) + math.copysign(0.5, x)))
 else:
-    from StringIO import StringIO
-    import Queue
-    from urllib import unquote, urlencode, quote
-    from urlparse import urlparse, parse_qsl, ParseResult
-    grange = xrange
-    is_long_or_int = lambda x: isinstance(x, (int, long))
-    is_unicode = lambda x: isinstance(x, unicode)
     cast_to_long = lambda x: long(x)
     cast_to_unicode = lambda x: unicode(x)
     cast_to_bin = str
     cast_to_chr = lambda x: x
     maximum_integer = sys.maxint
     old_round = round
-StringIO = StringIO
-urllib_future = namedtuple('urllib_future', ['unquote', 'urlencode', 'urlparse', 'parse_qsl', 'ParseResult', 'quote'])\
-    (unquote, urlencode, urlparse, parse_qsl, ParseResult, quote)
 
 
 def blocking_call_on_reactor_thread(func):
@@ -60,7 +44,7 @@ def blockingCallFromThread(reactor, f, *args, **kwargs):
     if isInIOThread():
             return f(*args, **kwargs)
     else:
-        queue = Queue.Queue()
+        queue = Queue()
 
         def _callFromThread():
             result = defer.maybeDeferred(f, *args, **kwargs)

--- a/stresstest/endpoint_stresstest.py
+++ b/stresstest/endpoint_stresstest.py
@@ -9,6 +9,7 @@ from subprocess import call
 from sys import exit as _exit
 from time import sleep, time
 
+from six.moves import xrange
 from twisted.internet import reactor
 from twisted.internet.defer import Deferred, DeferredList
 
@@ -26,7 +27,6 @@ from ipv8.configuration import get_default_configuration
 from ipv8.keyvault.crypto import default_eccrypto
 from ipv8.overlay import Overlay
 from ipv8.peer import Peer
-from ipv8.util import grange
 
 
 test_results = {}
@@ -219,7 +219,7 @@ if retcode > 0:
         6: 'data_asnd_initiator',
         7: 'data_asnd_counterparty'
     }
-    for i in grange(len(binretcode)):
+    for i in xrange(len(binretcode)):
         if binretcode[i] == '1':
             print("Significant slowdown in %s" % errmap[i])
 else:


### PR DESCRIPTION
Fixes #382, I don't think we can move anything else to `six`.

The following `six` functionality is now used:
 - `StringIO`
 - `Queue`
 - `urllib`/`urlparse`
 - `xrange` (formerly`grange`)
 - `isinstance( ... , integer_types)` (formerly `is_long_or_int`)
 - `isinstance( ... , text_type)` (formerly `is_unicode`)