### PR TITLE
ON HOLD: Added ezpayload definition

### DIFF
--- a/ipv8/messaging/lazy_payload.py
+++ b/ipv8/messaging/lazy_payload.py
@@ -1,0 +1,100 @@
+from __future__ import absolute_import
+
+import inspect
+
+from six.moves import xrange
+
+from .payload import Payload
+
+
+class RuntimePayload(Payload):
+    """
+    A "Runtime" (actually on module load) generated Payload definition.
+
+    You should never be initializing this directly.
+    Instead, creation should be done through the ezpayload wrapper.
+    """
+
+    ez_names = []
+
+    def __init__(self, *args, **kwargs):
+        """
+        Interpret the keyword arguments as class field assignments.
+
+        Ergo:
+            ..
+            >> mypayload = MyPayload(a=2)
+
+            >> mypayload.a == 2
+
+            True
+        """
+        # Extract the arguments used by the super
+        args_offset = 0
+        if inspect.ismethod(super(RuntimePayload, self).__init__):
+            superargs = inspect.getargspec(super(RuntimePayload, self).__init__).args[1:] # Ignore 'self'
+            runtimesuperargs = getattr(super(RuntimePayload, self), 'ez_names', [])
+            superargs += runtimesuperargs
+            superkwargs = {}
+            for k in list(kwargs.keys()):
+                if k in superargs:
+                    superkwargs[k] = kwargs.pop(k)
+            fwargs = args[:len(superargs)]
+            args = args[len(superargs):]
+            args_offset = len(runtimesuperargs)
+            super(RuntimePayload, self).__init__(*fwargs, **superkwargs)
+        # If everything matches, we assign our own fields
+        for i in xrange(len(args)):
+            setattr(self, self.ez_names[i + args_offset], args[i])
+        for k, v in kwargs.items():
+            setattr(self, k, v)
+
+    def to_pack_list(self):
+        return (super(RuntimePayload, self).to_pack_list() or []) +\
+               list(zip([(fmt if isinstance(fmt, str) else "payload")
+                         for fmt in self.format_list[-len(self.ez_names):]],
+                        [getattr(self, name) for name in self.ez_names]))
+
+    @classmethod
+    def from_unpack_list(cls, *args):
+        superargs = args[:-len(cls.ez_names)]
+        names = []
+        if superargs:
+            for base in cls.__bases__:
+                names += inspect.getargspec(base.__init__).args[1:]
+        names += cls.ez_names
+        return cls(**{kwtuple[0]: kwtuple[1] for kwtuple in list(zip(names, args))})
+
+
+def ezdecorator(ezfunc, baseclass=RuntimePayload):
+    """
+    Decorate a (function) specification as a class type with a certain baseclass.
+    The function name becomes the class name and the arguments become the fields.
+
+    :param ezfunc: the function to wrap
+    :type ezfunc: function
+    :param baseclass: the baseclass to inherit from
+    :type baseclass: type(Payload)
+    :return: the runtime definition of the required type
+    """
+    argspec = inspect.getargspec(ezfunc)
+    bases = (baseclass,) if issubclass(baseclass, RuntimePayload) else (RuntimePayload, baseclass)
+    return type(ezfunc.__name__, bases, {'ez_names': getattr(baseclass, 'ez_names', []) + argspec.args,
+                                         'format_list': baseclass.format_list + list(argspec.defaults)})
+
+def ezpayload(ezfunc):
+    """
+    Wrap a function to turn it into a Payload class definition (yes, you can do this in Python).
+    Optionally supply another Payload to inherit from.
+
+    :param ezfunc: the function to wrap or the base class to inherit from for the following function to wrap
+    :type ezfunc: function or Payload
+    :return: the new runtime Payload type
+    """
+    if inspect.isclass(ezfunc):
+        return lambda wrapped: ezdecorator(wrapped, ezfunc)
+    else:
+        return ezdecorator(ezfunc)
+
+
+__all__ = ['ezpayload']

--- a/ipv8/messaging/payload.py
+++ b/ipv8/messaging/payload.py
@@ -32,7 +32,7 @@ class Payload(Serializable):
         out = self.__class__.__name__
         for attribute in dir(self):
             if not (attribute.startswith('_') or callable(getattr(self, attribute))) \
-                    and attribute not in ['format_list', 'optional_format_list', 'is_list_descriptor']:
+                    and attribute not in ['ez_names', 'format_list', 'optional_format_list', 'is_list_descriptor']:
                 out += '\n| %s: %s' % (attribute, repr(getattr(self, attribute)))
         return out
 

--- a/ipv8/test/messaging/test_lazy_payload.py
+++ b/ipv8/test/messaging/test_lazy_payload.py
@@ -1,0 +1,142 @@
+from __future__ import absolute_import
+
+from unittest import TestCase
+
+from ...messaging.lazy_payload import ezpayload
+from ...messaging.payload import Payload
+from ...messaging.serialization import default_serializer
+
+
+@ezpayload
+def A(a='I', b='H'):  # pylint: disable=W0613
+    """
+    :type a: int
+    :type b: int
+    """
+    return A
+
+
+@ezpayload
+def B(a=A):  # pylint: disable=W0613
+    """
+    :type a: A
+    """
+    return B
+
+
+@ezpayload(A)
+def C(c='B'):  # pylint: disable=W0613
+    """
+    :type c: int
+    """
+    return C
+
+
+class OldA(Payload):
+    format_list = ["I", "H"]
+
+    def __init__(self, a, b):
+        self.a = a
+        self.b = b
+
+    def to_pack_list(self):
+        return [("I", self.a),
+                ("H", self.b)]
+
+    @classmethod
+    def from_unpack_list(cls, *args):
+        return OldA(*args)  # pylint: disable=E1120
+
+
+@ezpayload(OldA)
+def NewC(c='B'):  # pylint: disable=W0613
+    """
+    :type c: int
+    """
+    return NewC
+
+
+class TestEZPayload(TestCase):
+
+    def _pack_and_unpack(self, payload, instance):
+        """
+        Serialize and unserialize an instance of payload.
+
+        :param payload: the payload class to serialize for
+        :type payload: type(Payload)
+        :param instance: the payload instance to serialize
+        :type instance: Payload
+        :return: the repacked instance
+        """
+        plist = instance.to_pack_list()
+        serialized, _ = default_serializer.pack_multiple(plist)
+        deserialized, _ = default_serializer.unpack_to_serializables([payload], serialized)  # pylint: disable=E0632
+        return deserialized
+
+    def test_base_unnamed(self):
+        """
+        Check if the wrapper returns the payload correctly with unnamed arguments.
+        """
+        a = A(42, 1337)
+
+        deserialized = self._pack_and_unpack(A, a)
+
+        self.assertEqual(a.a, 42)
+        self.assertEqual(a.b, 1337)
+        self.assertEqual(deserialized.a, 42)
+        self.assertEqual(deserialized.b, 1337)
+
+    def test_base_named(self):
+        """
+        Check if the wrapper returns the payload correctly with named arguments.
+        """
+        a = A(b=1337, a=42)
+
+        deserialized = self._pack_and_unpack(A, a)
+
+        self.assertEqual(a.a, 42)
+        self.assertEqual(a.b, 1337)
+        self.assertEqual(deserialized.a, 42)
+        self.assertEqual(deserialized.b, 1337)
+
+    def test_inheritance(self):
+        """
+        Check if the wrapper allows for nested payloads.
+        """
+        a = A(1, 2)
+        b = B(a)
+
+        deserialized = self._pack_and_unpack(B, b)
+
+        self.assertEqual(b.a.a, deserialized.a.a)
+        self.assertEqual(b.a.b, deserialized.a.b)
+        self.assertIsInstance(deserialized, B)
+        self.assertIsInstance(deserialized.a, A)
+
+    def test_subclass(self):
+        """
+        Check if the wrapper allows for subclasses.
+        """
+        c = C(1, c=3, b=2)  # pylint: disable=E1123,E1124
+
+        deserialized = self._pack_and_unpack(C, c)
+
+        self.assertEqual(c.a, deserialized.a)
+        self.assertEqual(c.b, deserialized.b)
+        self.assertEqual(c.c, deserialized.c)
+        self.assertIsInstance(deserialized, C)
+        self.assertIsInstance(deserialized, A)
+
+    def test_old_subclass(self):
+        """
+        Check if the wrapper allows for subclasses from old-style Payloads.
+        """
+        c = NewC(1, c=3, b=2)  # pylint: disable=E1123,E1124
+
+        deserialized = self._pack_and_unpack(NewC, c)
+
+        self.assertEqual(c.a, deserialized.a)
+        self.assertEqual(c.b, deserialized.b)
+        self.assertEqual(c.c, deserialized.c)
+        self.assertIsInstance(deserialized, NewC)
+        self.assertIsInstance(deserialized, OldA)

--- a/test_classes_list.txt
+++ b/test_classes_list.txt
@@ -26,6 +26,7 @@ ipv8/test/attestation/wallet/primitives/test_attestation.py:TestAttestation
 ipv8/test/attestation/wallet/primitives/test_structs.py:TestStructs
 ipv8/test/attestation/wallet/test_attestation_community.py:TestCommunity
 
+ipv8/test/messaging/test_lazy_payload.py:TestEZPayload
 ipv8/test/messaging/test_serialization.py:TestSerializer
 ipv8/test/messaging/deprecated/test_sorting.py:TestSorting
 ipv8/test/messaging/deprecated/test_encoding.py:TestEncoding


### PR DESCRIPTION
This PR uses some of the most rancid Python magic available to allow for shorter `Payload` definitions.

```python
class A(Payload):
    format_list = ["I", "H"]

    def __init__(self, a, b):
        self.a = a
        self.b = b

    def to_pack_list(self):
        return [("I", self.a),
                ("H", self.b)]

    @classmethod
    def from_unpack_list(cls, *args):
        return A(*args)
```

Becomes:

```python
@ezpayload
def A(a='I', b='H'):
    return A
```

See [the test file](https://github.com/Tribler/py-ipv8/pull/388/files#diff-c3b5edee13f972a762a9728a27cf9de0) for more examples.

Do note that aside from being shorter in definition, this is worse than the old format in every way imaginable. That's why I put this on `on hold`.