### PR TITLE
Add double type to serializer

### DIFF
--- a/ipv8/messaging/serialization.py
+++ b/ipv8/messaging/serialization.py
@@ -190,6 +190,7 @@ class Serializer(object):
             'BH': DefaultStruct(">BH"),
             'c': DefaultStruct(">c", True),
             'f': DefaultStruct(">f", True),
+            'd': DefaultStruct(">d", True),
             'H': DefaultStruct(">H", True),
             'HH': DefaultStruct(">HH"),
             'I': DefaultStruct(">I", True),


### PR DESCRIPTION
This, ahem, adds double precision float to our serializer. Necessary for GigaChannels.