### PR TITLE
Use feature detection instead of version detection

### DIFF
--- a/ipv8/database.py
+++ b/ipv8/database.py
@@ -40,10 +40,10 @@ def execute_or_script(cursor, statement):
 
 
 # In Python 3 sqlite expects bytes instead of buffer objects.
-if sys.version_info.major > 2:
-    database_blob = bytes
-else:
+try:
     database_blob = buffer
+except NameError:
+    database_blob = bytes
 
 
 db_locks = defaultdict(RLock)

--- a/ipv8/util.py
+++ b/ipv8/util.py
@@ -10,21 +10,23 @@ from twisted.python.failure import Failure
 from twisted.python.threadable import isInIOThread
 
 logger = logging.getLogger(__name__)
+maximum_integer = sys.maxsize
+
+try:
+    cast_to_long = lambda x: long(x)
+    cast_to_unicode = lambda x: unicode(x)
+except NameError:
+    cast_to_long = lambda x: int(x)
+    cast_to_unicode = lambda x: "".join([chr(c) for c in x]) if isinstance(x, bytes) else str(x)
 
 if sys.version_info.major > 2:
     import math
-    cast_to_long = lambda x: x
-    cast_to_unicode = lambda x: "".join([chr(c) for c in x]) if isinstance(x, bytes) else str(x)
     cast_to_bin = lambda x: x if isinstance(x, bytes) else bytes([ord(c) for c in x])
     cast_to_chr = lambda x: "".join([chr(c) for c in x])
-    maximum_integer = sys.maxsize
     old_round = lambda x: float(math.floor((x) + math.copysign(0.5, x)))
 else:
-    cast_to_long = lambda x: long(x)
-    cast_to_unicode = lambda x: unicode(x)
     cast_to_bin = str
     cast_to_chr = lambda x: x
-    maximum_integer = sys.maxint
     old_round = round
 
 

--- a/ipv8/util.py
+++ b/ipv8/util.py
@@ -1,16 +1,16 @@
 from __future__ import absolute_import
 
 import logging
-import sys
 import traceback
 
+from six import PY3
 from six.moves.queue import Queue
 from twisted.internet import reactor, defer
 from twisted.python.failure import Failure
 from twisted.python.threadable import isInIOThread
 
 logger = logging.getLogger(__name__)
-maximum_integer = sys.maxsize
+maximum_integer = 2147483647
 
 try:
     cast_to_long = long  # pylint: disable=long-builtin
@@ -19,7 +19,7 @@ except NameError:
     cast_to_long = int
     cast_to_unicode = lambda x: "".join([chr(c) for c in x]) if isinstance(x, bytes) else str(x)
 
-if sys.version_info.major > 2:
+if PY3:
     import math
     cast_to_bin = lambda x: x if isinstance(x, bytes) else bytes([ord(c) for c in x])
     cast_to_chr = lambda x: "".join([chr(c) for c in x])

--- a/ipv8/util.py
+++ b/ipv8/util.py
@@ -13,10 +13,10 @@ logger = logging.getLogger(__name__)
 maximum_integer = sys.maxsize
 
 try:
-    cast_to_long = lambda x: long(x)
-    cast_to_unicode = lambda x: unicode(x)
+    cast_to_long = long  # pylint: disable=long-builtin
+    cast_to_unicode = unicode  # pylint: disable=unicode-builtin
 except NameError:
-    cast_to_long = lambda x: int(x)
+    cast_to_long = int
     cast_to_unicode = lambda x: "".join([chr(c) for c in x]) if isinstance(x, bytes) else str(x)
 
 if sys.version_info.major > 2:


### PR DESCRIPTION
Follows the Python porting best practice [___use feature detection instead of version detection___](https://docs.python.org/3/howto/pyporting.html#use-feature-detection-instead-of-version-detection).

Also:
* __cast_to_long(3.2)__ should return a non-floatingpoint result in both Python 2 and Python 3
* __python2 -c "import sys ; print(sys.maxsize == sys.maxint)"__  # True

[flake8](http://flake8.pycqa.org) testing of https://github.com/Tribler/py-ipv8 on Python 3.7.1

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./ipv8/util.py:23:30: F821 undefined name 'long'
    cast_to_long = lambda x: long(x)
                             ^
./ipv8/util.py:24:33: F821 undefined name 'unicode'
    cast_to_unicode = lambda x: unicode(x)
                                ^
./ipv8/database.py:46:21: F821 undefined name 'buffer'
    database_blob = buffer
                    ^
3
```
__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. These 5 are different from most other flake8 issues which are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree
