### PR TITLE
Added default config Community intro stresstest

### DIFF
--- a/ipv8/attestation/trustchain/community.py
+++ b/ipv8/attestation/trustchain/community.py
@@ -29,8 +29,6 @@ from ...peer import Peer
 from ...requestcache import RandomNumberCache, RequestCache
 from ...util import addCallback
 
-receive_block_lock = RLock()
-
 
 def synchronized(f):
     """
@@ -38,7 +36,7 @@ def synchronized(f):
     """
     @wraps(f)
     def wrapper(self, *args, **kwargs):
-        with receive_block_lock:
+        with self.receive_block_lock:
             return f(self, *args, **kwargs)
     return wrapper
 
@@ -58,6 +56,7 @@ class TrustChainCommunity(Community):
         working_directory = kwargs.pop('working_directory', '')
         db_name = kwargs.pop('db_name', self.DB_NAME)
         self.settings = kwargs.pop('settings', TrustChainSettings())
+        self.receive_block_lock = RLock()
         super(TrustChainCommunity, self).__init__(*args, **kwargs)
         self.request_cache = RequestCache()
         self.logger = logging.getLogger(self.__class__.__name__)

--- a/ipv8/community.py
+++ b/ipv8/community.py
@@ -257,12 +257,17 @@ class Community(EZPackOverlay):
 
         self.network.add_verified_peer(peer)
         self.network.discover_services(peer, [self.master_peer.mid, ])
-        if (payload.wan_introduction_address != ("0.0.0.0", 0)) and \
-                (payload.wan_introduction_address[0] != self.my_estimated_wan[0] or
-                 payload.lan_introduction_address == ("0.0.0.0", 0)):
+
+        if (payload.wan_introduction_address != ("0.0.0.0", 0) and
+                payload.wan_introduction_address[0] != self.my_estimated_wan[0]):
             self.network.discover_address(peer, payload.wan_introduction_address, self.master_peer.mid)
-        elif payload.lan_introduction_address != ("0.0.0.0", 0):
+        elif (payload.lan_introduction_address != ("0.0.0.0", 0) and
+              payload.wan_introduction_address[0] == self.my_estimated_wan[0]):
             self.network.discover_address(peer, payload.lan_introduction_address, self.master_peer.mid)
+        elif payload.wan_introduction_address != ("0.0.0.0", 0):
+            self.network.discover_address(peer, payload.wan_introduction_address, self.master_peer.mid)
+            self.network.discover_address(peer, (self.my_estimated_lan[0], payload.wan_introduction_address[1]),
+                                          self.master_peer.mid)
 
         self.introduction_response_callback(peer, dist, payload)
 

--- a/ipv8/peerdiscovery/community.py
+++ b/ipv8/peerdiscovery/community.py
@@ -25,7 +25,7 @@ class PeriodicSimilarity(DiscoveryStrategy):
 
     def take_step(self, service_id=None):
         now = time()
-        if (now - self.last_step < 0.2) or not self.overlay.network.verified_peers:
+        if (now - self.last_step < 1.0) or not self.overlay.network.verified_peers:
             return
         self.last_step = now
         with self.walk_lock:

--- a/ipv8/peerdiscovery/discovery.py
+++ b/ipv8/peerdiscovery/discovery.py
@@ -111,6 +111,8 @@ class EdgeWalk(DiscoveryStrategy):
                 # Wait for our immediate neighborhood to be discovered
                 self._neighborhood = self.overlay.get_peers()[:self.neighborhood_size]
                 self.overlay.bootstrap()
+                for peer in self.overlay.network.get_walkable_addresses(service_id)[:self.neighborhood_size]:
+                    self.overlay.walk_to(peer)
             else:
                 waiting_root = self.get_available_root()
                 # Make sure we have as many outstanding/actively growing edges as roots

--- a/ipv8/test/peerdiscovery/test_community.py
+++ b/ipv8/test/peerdiscovery/test_community.py
@@ -24,6 +24,8 @@ class TestDiscoveryCommunity(TestBase):
 
         node_count = 2
         self.overlays = [MockCommunity() for _ in range(node_count)]
+        for overlay in self.overlays:
+            overlay.network.blacklist.append(self.tracker.endpoint.wan_address)
 
     def tearDown(self):
         self.tracker.unload()

--- a/stresstest/peer_discovery_defaults.py
+++ b/stresstest/peer_discovery_defaults.py
@@ -1,0 +1,74 @@
+from __future__ import absolute_import
+from __future__ import print_function
+
+from os import chdir, getcwd, mkdir, path
+from random import randint
+import time
+
+from twisted.internet import reactor
+
+# Check if we are running from the root directory
+# If not, modify our path so that we can import IPv8
+try:
+    import ipv8
+    del ipv8
+except ImportError:
+    import sys
+    sys.path.append(path.abspath(path.join(path.dirname(__file__), "..")))
+
+from ipv8_service import _COMMUNITIES, IPv8, _WALKERS  # pylint: disable=ungrouped-imports
+from ipv8.configuration import get_default_configuration  # pylint: disable=ungrouped-imports
+from ipv8.keyvault.crypto import ECCrypto  # pylint: disable=ungrouped-imports
+from ipv8.peer import Peer  # pylint: disable=ungrouped-imports
+
+
+START_TIME = time.time()
+RESULTS = {}
+
+
+# Wait until we get a non-tracker response
+# Once all overlays have finished, stop the script
+def custom_intro_response_cb(self, peer, dist, payload):
+    if (peer.address not in self.network.blacklist) and (self.__class__.__name__ not in RESULTS):
+        RESULTS[self.__class__.__name__] = time.time() - START_TIME
+        print(self.__class__.__name__, "found a peer!", file=sys.stderr)
+        if len(get_default_configuration()['overlays']) == len(RESULTS):
+            reactor.callFromThread(reactor.stop)
+
+
+# If it takes longer than 30 seconds to find anything, abort the experiment and set the intro time to -1.0
+def on_timeout():
+    for definition in get_default_configuration()['overlays']:
+        if definition['class'] not in RESULTS:
+            RESULTS[definition['class']] = -1.0
+            print(definition['class'], "found no peers at all!", file=sys.stderr)
+    reactor.callFromThread(reactor.stop)
+
+
+# Override the Community master peers so we don't interfere with the live network
+# Also hook in our custom logic for introduction responses
+for community_cls in _COMMUNITIES.values():
+    community_cls.master_peer = Peer(ECCrypto().generate_key(u"medium"))
+    community_cls.introduction_response_callback = custom_intro_response_cb
+
+# Create two peers with separate working directories
+previous_workdir = getcwd()
+for i in [1, 2]:
+    configuration = get_default_configuration()
+    configuration['port'] = 12000 + randint(0, 10000)
+    configuration['logger']['level'] = "CRITICAL"
+    for overlay in configuration['overlays']:
+        overlay['walkers'] = [walker for walker in overlay['walkers'] if walker['strategy'] in _WALKERS]
+    workdir = path.abspath(path.join(path.dirname(__file__), "%d" % i))
+    if not path.exists(workdir):
+        mkdir(workdir)
+    chdir(workdir)
+    IPv8(configuration)
+    chdir(previous_workdir)
+
+# Actually start running everything, this blocks until the experiment finishes
+reactor.callLater(30.0, on_timeout)
+reactor.run()
+
+# Print the introduction times for all default Communities, sorted alphabetically.
+print(','.join(['%.4f' % RESULTS[key] for key in sorted(RESULTS)]))


### PR DESCRIPTION
Fixes #427 

This allows us to spot regressions in the peer discovery logic of full-blown Communities.

Note that this is quite a bit heavier than `peer_discovery.py` and loads the entire stack.