### PR TITLE
Fix potential peer leaks

### DIFF
--- a/ipv8/community.py
+++ b/ipv8/community.py
@@ -273,8 +273,7 @@ class Community(EZPackOverlay):
 
     @lazy_wrapper(GlobalTimeDistributionPayload, PuncturePayload)
     def on_puncture(self, peer, dist, payload):
-        self.network.add_verified_peer(peer)
-        self.network.discover_services(peer, [self.master_peer.mid, ])
+        pass
 
     @lazy_wrapper_unsigned(GlobalTimeDistributionPayload, PunctureRequestPayload)
     def on_puncture_request(self, source_address, dist, payload):

--- a/ipv8/dht/community.py
+++ b/ipv8/dht/community.py
@@ -160,13 +160,6 @@ class DHTCommunity(Community):
     def introduction_response_callback(self, peer, dist, payload):
         self.on_node_discovered(peer.public_key.key_to_bin(), peer.address)
 
-    @lazy_wrapper(GlobalTimeDistributionPayload, PuncturePayload)
-    def on_puncture(self, peer, dist, payload):
-        # Since the DHT sends punctures manually, we often discover peers that the
-        # DiscoveryStrategy did not ask for. In order to keep these peers from entering
-        # our list of verified peers, we ignore punctures.
-        pass
-
     def on_node_discovered(self, public_key_bin, source_address):
         # Filter out trackers
         if source_address not in self.network.blacklist:

--- a/ipv8/messaging/anonymization/community.py
+++ b/ipv8/messaging/anonymization/community.py
@@ -788,7 +788,6 @@ class TunnelCommunity(Community):
             extend_candidate = self.network.get_verified_by_public_key_bin(payload.node_public_key)
             if not extend_candidate:
                 extend_candidate = Peer(payload.node_public_key, payload.node_addr)
-                self.network.add_verified_peer(extend_candidate)
 
         self.logger.info("On_extend send CREATE for circuit (%s, %d) to %s:%d", source_address,
                          circuit_id, *extend_candidate.address)

--- a/ipv8/peerdiscovery/discovery.py
+++ b/ipv8/peerdiscovery/discovery.py
@@ -130,6 +130,8 @@ class EdgeWalk(DiscoveryStrategy):
                             verified = self.overlay.network.get_verified_by_address(intro)
                             if verified:
                                 introductions.append(verified)
+                            else:
+                                self.overlay.walk_to(intro)
                         if introductions:
                             # We got (multiple?) introductions from this peer, add it as verified
                             self.last_edge_responses[root] = time()

--- a/ipv8/test/peerdiscovery/test_edge_discovery.py
+++ b/ipv8/test/peerdiscovery/test_edge_discovery.py
@@ -42,6 +42,9 @@ class TestEdgeWalk(TestBase):
 
         yield self.deliver_messages()
 
+        self.strategies[0].take_step() # Find out the neighbor has been introduced and walk to it
+        yield self.deliver_messages()
+
         self.assertEqual(len(self.overlays[0].network.verified_peers), 2)
 
     @inlineCallbacks
@@ -68,7 +71,9 @@ class TestEdgeWalk(TestBase):
         # 2. Detect intro (NODE2) from root and query for nodes
         # 3. Detect no more intros from NODE2 and finish edge
         for _ in range(3):
-            self.strategies[0].take_step()
+            self.strategies[0].take_step() # Attempt intro
+            yield self.deliver_messages()
+            self.strategies[0].take_step() # Complete intro
             yield self.deliver_messages()
 
         self.assertEqual(len(self.overlays[0].network.verified_peers), 2)
@@ -110,7 +115,7 @@ class TestEdgeWalk(TestBase):
         Check if we can complete an edge.
         """
         self.strategies[0].edge_length = 2 # Finish with one other node
-        self.strategies[0].edge_timeout = 0.0  # Finish the edge immediately
+        self.strategies[0].edge_timeout = 0.1  # Finish the edge, but allow the network to walk
         self.overlays[0].network.add_verified_peer(self.overlays[1].my_peer)
         self.overlays[0].network.discover_services(self.overlays[1].my_peer, [self.overlays[1].master_peer.mid, ])
 

--- a/ipv8/test/peerdiscovery/test_random_discovery.py
+++ b/ipv8/test/peerdiscovery/test_random_discovery.py
@@ -38,7 +38,8 @@ class TestRandomWalk(TestBase):
         self.overlays[1].network.discover_services(self.overlays[2].my_peer, [self.overlays[2].master_peer.mid, ])
         # We expect NODE1 to introduce NODE0 to NODE2
         self.strategies[0].take_step()
-
+        yield self.deliver_messages()
+        self.strategies[0].take_step()
         yield self.deliver_messages()
 
         self.assertEqual(len(self.overlays[0].network.verified_peers), 2)
@@ -58,7 +59,8 @@ class TestRandomWalk(TestBase):
         self.overlays[0].network.discover_services(self.overlays[1].my_peer, [self.overlays[1].master_peer.mid, ])
         # We expect NODE0 to visit NODE2
         self.strategies[0].take_step()
-
+        yield self.deliver_messages()
+        self.strategies[0].take_step()
         yield self.deliver_messages()
 
         self.assertEqual(len(self.overlays[0].network.verified_peers), 2)


### PR DESCRIPTION
- Only depend on `add_verified_peer` from intro requests and responses (our tests didn't like this)
- Don't add verified peers on TunnelCommunity extends