### PR TITLE
Added VariablePayload

### DIFF
--- a/ipv8/messaging/lazy_payload.py
+++ b/ipv8/messaging/lazy_payload.py
@@ -1,0 +1,120 @@
+from __future__ import absolute_import
+
+import inspect
+
+from six import string_types
+from six.moves import xrange
+
+from .payload import Payload
+
+
+class VariablePayload(Payload):
+    """
+    A Payload instance which mimics a struct. Useful for when you want a less verbose way to specify Payloads.
+
+    This class requires you to only specify your format in:
+
+        - <MyPayload>.format_list : a list of Serializer format specifications
+        - <MyPayload>.names : the field names to use for the given formats
+
+    For instance:
+
+        class MyPayload(VariablePayload):
+            format_list = ['?']
+            names = ["is_this_a_boolean"]
+
+    If you require field-specific pack/unpack operations you can specify them using the `fix_pack_*` and
+    `fix_unpack_*` methods.
+    Custom packing and unpacking rules can be useful for compression methods like socket.inet_aton, which you only
+    want to apply when actually sending over the wire.
+    """
+
+    names = []
+
+    def __init__(self, *args, **kwargs):
+        """
+        Instantiate this VariablePayload class.
+
+        :param args: the anonymous list of arguments, an index-based mapping to self.names and self.format_list
+        :param kwargs: the named arguments, mapping to self.names and self.format_list (in no particular order)
+        :raises KeyError: if the given arguments do not match the class specification
+        """
+        index = 0
+        fwd_args = {}
+        # If our super class is an old-style Payload function, forward the required arguments.
+        if not issubclass(super(VariablePayload, self).__class__, VariablePayload) and \
+                inspect.ismethod(super(VariablePayload, self).__init__):
+            super_argspec = inspect.getargspec(super(VariablePayload, self).__init__).args[1:]
+            for arg in super_argspec:
+                if arg in kwargs:
+                    fwd_args[arg] = kwargs.pop(arg)
+                else:
+                    fwd_args[arg] = args[index]
+                index += 1
+            super(VariablePayload, self).__init__(**fwd_args)
+        Payload.__init__(self)
+        # Try to fill the required format specification.
+        for _ in range(len(self.format_list) - index):
+            # Run out all anonymous arguments, then start popping from the keyword arguments.
+            # This will raise a KeyError if we provide more arguments than we can handle.
+            value = args[index] if index < len(args) else kwargs.pop(self.names[index])
+            setattr(self, self.names[index], value)
+            index += 1
+        if index != len(self.format_list):
+            raise KeyError("%s missing %d arguments!" % (self.__class__.__name__, len(args) - index))
+        # Try to fill in the optional format specification.
+        for _ in self.optional_format_list:
+            # If we run out of anonymous and named arguments, we stop.
+            if index == len(args) and not kwargs:
+                break
+            value = args[index] if index < len(args) else kwargs.pop(self.names[index])
+            setattr(self, self.names[index], value)
+            index += 1
+        if kwargs:
+            raise KeyError("%s has leftover keyword arguments: %s!" % (self.__class__.__name__, str(kwargs)))
+
+    @classmethod
+    def from_unpack_list(cls, *args):
+        """
+        Given a list of raw arguments, initialize a new cls instance.
+
+        If this class has special rules for certain fields, apply them.
+        """
+        unpack_args = list(args)
+        for i in xrange(len(args)):
+            custom_rule = "fix_unpack_" + cls.names[i]
+            if hasattr(cls, custom_rule):
+                unpack_args[i] = getattr(cls, custom_rule)(args[i])
+        return cls(*unpack_args)
+
+    @staticmethod
+    def _to_packlist_fmt(fmt):
+        return fmt if isinstance(fmt, string_types) else 'payload'
+
+    def _fix_pack(self, name):
+        """
+        Check if there are custom rules for sending this field.
+        """
+        raw_value = getattr(self, name)
+        custom_rule = "fix_pack_" + name
+        if hasattr(self, custom_rule):
+            return getattr(self, custom_rule)(raw_value)
+        return raw_value
+
+    def to_pack_list(self):
+        """
+        Convert the VariablePayload to a Serializable pack list.
+        This method will automatically pull from the available format names and set instance fields.
+
+        :return: the pack list
+        """
+        out = []
+        index = 0
+        for _ in range(len(self.format_list)):
+            out.append((self._to_packlist_fmt(self.format_list[index]), self._fix_pack(self.names[index])))
+            index += 1
+        while index < len(self.names) and hasattr(self, self.names[index]):
+            out.append((self._to_packlist_fmt(self.optional_format_list[index-len(self.format_list)]),
+                        self._fix_pack(self.names[index])))
+        index += 1
+        return out

--- a/ipv8/messaging/payload.py
+++ b/ipv8/messaging/payload.py
@@ -32,7 +32,7 @@ class Payload(Serializable):
         out = self.__class__.__name__
         for attribute in dir(self):
             if not (attribute.startswith('_') or callable(getattr(self, attribute))) \
-                    and attribute not in ['format_list', 'optional_format_list', 'is_list_descriptor']:
+                    and attribute not in ['format_list', 'names', 'optional_format_list', 'is_list_descriptor']:
                 out += '\n| %s: %s' % (attribute, repr(getattr(self, attribute)))
         return out
 

--- a/ipv8/test/messaging/test_lazy_payload.py
+++ b/ipv8/test/messaging/test_lazy_payload.py
@@ -1,0 +1,165 @@
+from __future__ import absolute_import
+
+from unittest import TestCase
+
+from ...messaging.lazy_payload import VariablePayload
+from ...messaging.payload import Payload
+from ...messaging.serialization import default_serializer
+
+
+class A(VariablePayload):
+    """
+    A basic VariablePayload.
+    """
+    format_list = ['I', 'H']
+    names = ["a", "b"]
+
+
+class B(VariablePayload):
+    """
+    A VariablePayload with a nested Payload.
+    """
+    format_list = [A]
+    names = ["a"]
+
+
+class C(A):
+    """
+    A VariablePayload with inherited fields.
+    """
+    format_list = A.format_list + ['B']
+    names = A.names + ['c']
+
+
+class OldA(Payload):
+    format_list = ["I", "H"]
+
+    def __init__(self, a, b):
+        self.a = a
+        self.b = b
+
+    def to_pack_list(self):
+        return [("I", self.a),
+                ("H", self.b)]
+
+    @classmethod
+    def from_unpack_list(cls, *args):
+        return OldA(*args) # pylint: disable=E1120
+
+
+class D(VariablePayload):
+    format_list = ["I"]
+    names = ["a"]
+
+    def fix_pack_a(self, value):
+        return value + 1
+
+    @classmethod
+    def fix_unpack_a(cls, value):
+        return value - 1
+
+
+class NewC(VariablePayload, OldA):
+    """
+    A VariablePayload with inherited fields.
+    """
+    format_list = OldA.format_list + ['B']
+    names = ['a', 'b', 'c']
+
+
+class TestVariablePayload(TestCase):
+
+    def _pack_and_unpack(self, payload, instance):
+        """
+        Serialize and unserialize an instance of payload.
+        :param payload: the payload class to serialize for
+        :type payload: type(Payload)
+        :param instance: the payload instance to serialize
+        :type instance: Payload
+        :return: the repacked instance
+        """
+        plist = instance.to_pack_list()
+        serialized, _ = default_serializer.pack_multiple(plist)
+        deserialized, _ = default_serializer.unpack_to_serializables([payload], serialized)  # pylint: disable=E0632
+        return deserialized
+
+    def test_base_unnamed(self):
+        """
+        Check if the wrapper returns the payload correctly with unnamed arguments.
+        """
+        a = A(42, 1337)
+
+        deserialized = self._pack_and_unpack(A, a)
+
+        self.assertEqual(a.a, 42)
+        self.assertEqual(a.b, 1337)
+        self.assertEqual(deserialized.a, 42)
+        self.assertEqual(deserialized.b, 1337)
+
+    def test_base_named(self):
+        """
+        Check if the wrapper returns the payload correctly with named arguments.
+        """
+        a = A(b=1337, a=42)
+
+        deserialized = self._pack_and_unpack(A, a)
+
+        self.assertEqual(a.a, 42)
+        self.assertEqual(a.b, 1337)
+        self.assertEqual(deserialized.a, 42)
+        self.assertEqual(deserialized.b, 1337)
+
+    def test_inheritance(self):
+        """
+        Check if the wrapper allows for nested payloads.
+        """
+        a = A(1, 2)
+        b = B(a)
+
+        deserialized = self._pack_and_unpack(B, b)
+
+        self.assertEqual(b.a.a, deserialized.a.a)
+        self.assertEqual(b.a.b, deserialized.a.b)
+        self.assertIsInstance(deserialized, B)
+        self.assertIsInstance(deserialized.a, A)
+
+    def test_subclass(self):
+        """
+        Check if the wrapper allows for subclasses.
+        """
+        c = C(1, c=3, b=2)
+
+        deserialized = self._pack_and_unpack(C, c)
+
+        self.assertEqual(c.a, deserialized.a)
+        self.assertEqual(c.b, deserialized.b)
+        self.assertEqual(c.c, deserialized.c)
+        self.assertIsInstance(deserialized, C)
+        self.assertIsInstance(deserialized, A)
+
+    def test_old_subclass(self):
+        """
+        Check if the wrapper allows for subclasses from old-style Payloads.
+        """
+        c = NewC(1, c=3, b=2)
+
+        deserialized = self._pack_and_unpack(NewC, c)
+
+        self.assertEqual(c.a, deserialized.a)
+        self.assertEqual(c.b, deserialized.b)
+        self.assertEqual(c.c, deserialized.c)
+        self.assertIsInstance(deserialized, NewC)
+        self.assertIsInstance(deserialized, OldA)
+
+    def test_custom_pack(self):
+        """
+        Check if the wire-format manipulation rules are applied correctly.
+        """
+        d = D(0)
+
+        serialized, _ = default_serializer.pack_multiple(d.to_pack_list())
+        deserialized = self._pack_and_unpack(D, d)
+
+        self.assertEqual(d.a, 0)
+        self.assertEqual(deserialized.a, 0)
+        self.assertEqual(serialized, b'\x00\x00\x00\x01')

--- a/test_classes_list.txt
+++ b/test_classes_list.txt
@@ -27,6 +27,7 @@ ipv8/test/attestation/wallet/primitives/test_structs.py:TestStructs
 ipv8/test/attestation/wallet/test_attestation_community.py:TestCommunity
 
 ipv8/test/messaging/test_serialization.py:TestSerializer
+ipv8/test/messaging/test_lazy_payload.py:TestVariablePayload
 ipv8/test/messaging/deprecated/test_sorting.py:TestSorting
 ipv8/test/messaging/deprecated/test_encoding.py:TestEncoding
 ipv8/test/messaging/interfaces/udp/test_endpoint.py:TestUDPEndpoint


### PR DESCRIPTION
After lessons learned from #388, this is the second attempt to make Payload definitions smaller.

Some examples (also [check out the unit tests for other examples](https://github.com/Tribler/py-ipv8/pull/441/files#diff-c3b5edee13f972a762a9728a27cf9de0R10)):

```python
class A(VariablePayload):
    format_list = ['I', 'H']
    names = ["a", "b"]

class B(VariablePayload):
    format_list = ['4SH']
    names = ["address"]

    def fix_pack_address(value):
         return (socket.inet_aton(value[0]), value[1])

    def fix_unpack_address(value):
         return (socket.inet_ntoa(value[0]), value[1])

a = A(1, 2)
print(a.b) # 2
b = B(("1.1.1.1", 0))
print(b.address) # ("1.1.1.1", 0)
                 # However, the wire format will be: \x01\x01\x01\x01\x00\x00
```