### PR TITLE
Removed unpack_multiple_as_list

### DIFF
--- a/ipv8/messaging/serialization.py
+++ b/ipv8/messaging/serialization.py
@@ -330,40 +330,6 @@ class Serializer(object):
             index += 1
         return out, current_offset
 
-    def unpack_multiple_as_list(self, unpack_list, data, offset=0):
-        """
-        Unpack repeated list elements from a data string.
-
-        Each of the tuples in the pack_list are built as (format, arg1, arg2, .., argn)
-
-        Note that this method cannot have any optional unpack_list arguments.
-
-        :param unpack_list: the list of formats
-        :param data: the data to unpack from
-        :param offset: the optional offset to unpack data from
-        """
-        current_offset = offset
-        out = []
-        index = 0
-        data_length = len(data)
-        while current_offset < data_length:
-            list_element = []
-            for format in unpack_list:
-                try:
-                    unpacked, unpacked_size = self.unpack(format, data, current_offset)
-                    if format == 'bits':
-                        list_element.extend(unpacked)
-                    else:
-                        list_element.append(unpacked)
-                except Exception as e:
-                    six.reraise(PackError, PackError("Could not unpack #%d repetition of item %d: %s\n%s: %s" %
-                                                     (index+1, len(list_element), format, type(e).__name__, str(e))),
-                                sys.exc_info()[2])
-                current_offset += unpacked_size
-                index += 1
-            out.append(list_element)
-        return out, current_offset
-
     def unpack_to_serializables(self, serializables, data):
         """
         Use the formats specified in a serializable object and unpack to it.

--- a/ipv8/test/messaging/test_serialization.py
+++ b/ipv8/test/messaging/test_serialization.py
@@ -120,41 +120,6 @@ class TestSerializer(TestCase):
 
         self.assertRaises(PackError, self.serializer.unpack_multiple, ["H"], serialized)
 
-    def test_unpack_multiple_list_empty(self):
-        """
-        Check if a unpack_multiple_as_list can unpack an empty list.
-        """
-        serialized, _ = self.serializer.pack_multiple([])
-        unserialized, _ = self.serializer.unpack_multiple_as_list([], serialized)
-
-        self.assertEqual([], unserialized)
-
-    def test_unpack_multiple_list_bits(self):
-        """
-        Check if a unpack_multiple_as_list can unpack bits.
-        """
-        serialized, _ = self.serializer.pack("bits", 0, 1, 0, 1, 0, 1, 0, 1)
-        unserialized, _ = self.serializer.unpack_multiple_as_list(["bits"], serialized)
-
-        self.assertEqual(1, len(unserialized))
-        self.assertListEqual([0, 1, 0, 1, 0, 1, 0, 1], unserialized[0])
-
-    def test_unpack_multiple_list_short_from_byte(self):
-        """
-        Check if a unpack_multiple_as_list of a short from a byte raises a PackError.
-        """
-        serialized, _ = self.serializer.pack_multiple([("B", 1)])
-
-        self.assertRaises(PackError, self.serializer.unpack_multiple_as_list, ["H"], serialized)
-
-    def test_unpack_multiple_list_short_from_byte_3rd(self):
-        """
-        Check if a unpack_multiple_as_list of a short from a byte raises a PackError in the third repetition.
-        """
-        serialized, _ = self.serializer.pack_multiple([("H", 1), ("H", 2), ("B", 3)])
-
-        self.assertRaises(PackError, self.serializer.unpack_multiple_as_list, ["H"], serialized)
-
     def test_unpack_serializables_list_short_from_byte(self):
         """
         Check if a unpack_to_serializables of a short from a byte raises a PackError.


### PR DESCRIPTION
Now that the `Serializable` no longer supports list descriptors, we can also remove `unpack_multiple_as_list`.