### PR TITLE
Added statistics to IPv8 overlay endpoint

### DIFF
--- a/ipv8/REST/overlays_endpoint.py
+++ b/ipv8/REST/overlays_endpoint.py
@@ -22,12 +22,15 @@ class OverlaysEndpoint(resource.Resource):
         overlay_stats = []
         for overlay in self.session.overlays:
             peers = overlay.get_peers()
+            statistics = self.session.endpoint.get_aggregate_statistics(overlay.get_prefix()) \
+                if isinstance(self.session.endpoint, StatisticsEndpoint) else {}
             overlay_stats.append({
                 "master_peer": hexlify(overlay.master_peer.public_key.key_to_bin()),
                 "my_peer": hexlify(overlay.my_peer.public_key.key_to_bin()),
                 "global_time": overlay.global_time,
                 "peers": [str(peer) for peer in peers],
-                "overlay_name": overlay.__class__.__name__
+                "overlay_name": overlay.__class__.__name__,
+                "statistics": statistics
             })
         return overlay_stats
 

--- a/twisted/plugins/ipv8_plugin.py
+++ b/twisted/plugins/ipv8_plugin.py
@@ -23,7 +23,10 @@ from ipv8.REST.rest_manager import RESTManager
 
 class Options(usage.Options):
     optParameters = []
-    optFlags = [["no-rest-api", "a", "Autonomous: disable the REST api"], ]
+    optFlags = [
+        ["no-rest-api", "a", "Autonomous: disable the REST api"],
+        ["statistics", "s", "Enable IPv8 overlay statistics"],
+    ]
 
 
 class IPV8ServiceMaker(object):
@@ -44,7 +47,7 @@ class IPV8ServiceMaker(object):
         """
         Main method to startup IPv8.
         """
-        self.ipv8 = IPv8(get_default_configuration())
+        self.ipv8 = IPv8(get_default_configuration(), enable_statistics=options['statistics'])
 
         def signal_handler(sig, _):
             msg("Received shut down signal %s" % sig)


### PR DESCRIPTION
With this, we could remove the `/statistics/overlays` endpoint in Tribler and use `/ipv8/overlays` instead 👍 