### PR TITLE
Fixed database trying to cursor wrap an int

### DIFF
--- a/ipv8/database.py
+++ b/ipv8/database.py
@@ -315,7 +315,7 @@ class Database(six.with_metaclass(ABCMeta, object)):
         self._logger.log(logging.NOTSET, "%s <-- %s [%s]", statement, bindings, self._file_path)
         result = self._cursor.execute(statement, bindings)
         if get_lastrowid:
-            result = self._cursor.lastrowid
+            return self._cursor.lastrowid
         return _thread_safe_result_it(result, fetch_all)
 
     @db_call


### PR DESCRIPTION
Solves the following bug for calls with `get_lastrowid=True`:

```python
  File "/home/quinten/Documents/py-ipv8/ipv8/database.py", line 54, in wrapper
    return f(self, *args, **kwargs)
  File "/home/quinten/Documents/py-ipv8/ipv8/database.py", line 319, in execute
    return _thread_safe_result_it(result, fetch_all)
  File "/home/quinten/Documents/py-ipv8/ipv8/database.py", line 60, in _thread_safe_result_it
    rows = (result.fetchall() if fetch_all else result.fetchone()) or []
AttributeError: 'int' object has no attribute 'fetchall'
```