### PR TITLE
Enable VarLen.pack() and DefaultStruct.pack() to handle str input

### DIFF
--- a/ipv8/messaging/serialization.py
+++ b/ipv8/messaging/serialization.py
@@ -158,7 +158,7 @@ class VarLen(object):
         self.base = base
 
     def pack(self, *data):
-        raw = b''.join(*(make_bytes(s) for s in data))
+        raw = b''.join(make_bytes(s) for s in data)
         length = len(raw) // self.base
         size = self.format_size + len(raw)
         return pack('>%s%ds' % (self.format, len(raw)), length, raw), size
@@ -177,7 +177,7 @@ class DefaultStruct(Struct):
         self.single_value = single_value
 
     def pack(self, *data):
-        return super(DefaultStruct, self).pack(make_bytes(s) for s in data), self.size
+        return super(DefaultStruct, self).pack(*(make_bytes(s) for s in data)), self.size
 
     def unpack_from(self, buffer, offset=0):
         out = super(DefaultStruct, self).unpack_from(buffer, offset)

--- a/ipv8/messaging/serialization.py
+++ b/ipv8/messaging/serialization.py
@@ -9,6 +9,15 @@ import six
 import sys
 
 
+def make_bytes(s):
+    """Utility function for gracefully dealing with str input in Python 3
+    """
+    try:
+        return s.encode('utf-8')  # Python 3 str --> bytes
+    except AttributeError:
+        return s
+
+
 class PackError(RuntimeError):
     pass
 
@@ -149,7 +158,7 @@ class VarLen(object):
         self.base = base
 
     def pack(self, *data):
-        raw = b''.join(data)
+        raw = b''.join(*(make_bytes(s) for s in data))
         length = len(raw) // self.base
         size = self.format_size + len(raw)
         return pack('>%s%ds' % (self.format, len(raw)), length, raw), size
@@ -168,7 +177,7 @@ class DefaultStruct(Struct):
         self.single_value = single_value
 
     def pack(self, *data):
-        return super(DefaultStruct, self).pack(*data), self.size
+        return super(DefaultStruct, self).pack(*(make_bytes(s) for s in data)), self.size
 
     def unpack_from(self, buffer, offset=0):
         out = super(DefaultStruct, self).unpack_from(buffer, offset)

--- a/ipv8/messaging/serialization.py
+++ b/ipv8/messaging/serialization.py
@@ -177,7 +177,7 @@ class DefaultStruct(Struct):
         self.single_value = single_value
 
     def pack(self, *data):
-        return super(DefaultStruct, self).pack(*(make_bytes(s) for s in data)), self.size
+        return super(DefaultStruct, self).pack(make_bytes(s) for s in data), self.size
 
     def unpack_from(self, buffer, offset=0):
         out = super(DefaultStruct, self).unpack_from(buffer, offset)


### PR DESCRIPTION
```
ERROR: Test creating an ask and sending it to others
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/defer.py", line 1418, in _inlineCallbacks
    result = g.send(result)
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Test/Community/Market/test_community.py", line 70, in test_create_ask
    yield self.nodes[0].overlay.create_ask(AssetPair(AssetAmount(1, 'DUM1'), AssetAmount(2, 'DUM2')), 3600)
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/community/market/community.py", line 625, in create_ask
    return self.create_new_tick_block(tick).addCallback(on_block_created)
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/community/market/community.py", line 73, in wrapper
    return f(self, *args, **kwargs)
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/community/market/community.py", line 703, in create_new_tick_block
    return self.trustchain.create_source_block(block_type=block_type, transaction=tx_dict)
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/pyipv8/ipv8/attestation/trustchain/community.py", line 185, in create_source_block
    block_type=block_type, transaction=transaction)
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/pyipv8/ipv8/attestation/trustchain/community.py", line 39, in wrapper
    return f(self, *args, **kwargs)
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/pyipv8/ipv8/attestation/trustchain/community.py", line 241, in sign_block
    link_pk=public_key)
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/pyipv8/ipv8/attestation/trustchain/block.py", line 427, in create
    ret.hash = ret.calculate_hash()
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/pyipv8/ipv8/attestation/trustchain/block.py", line 111, in calculate_hash
    return sha256(self.pack()).digest()
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/pyipv8/ipv8/attestation/trustchain/block.py", line 141, in pack
    return self.serializer.pack_multiple(HalfBlockPayload(*args).to_pack_list())[0]
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/pyipv8/ipv8/messaging/serialization.py", line 270, in pack_multiple
    sys.exc_info()[2])
  File "/home/jenkins/.local/lib/python3.5/site-packages/six.py", line 692, in reraise
    raise value.with_traceback(tb)
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/pyipv8/ipv8/messaging/serialization.py", line 264, in pack_multiple
    packed, packed_size = self.pack(*packable)
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/pyipv8/ipv8/messaging/serialization.py", line 248, in pack
    return self._packers[format].pack(*data)
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/pyipv8/ipv8/messaging/serialization.py", line 152, in pack
    raw = b''.join(data)
Tribler.pyipv8.ipv8.messaging.serialization.PackError: Could not pack item 6: ('varlenI', 'ask')
TypeError: sequence item 0: expected a bytes-like object, str found
-------------------- >> begin captured logging << --------------------
TrustChainCommunity: DEBUG: Launching TrustChainCommunity with prefix b'00025ad767b05ae592a02488272ca2a86b847d4562e1'.
TrustChainDB: DEBUG: loading database [:memory:]
TrustChainDB: DEBUG: TrustChain database path: :memory:
TrustChainDB: DEBUG: open database [:memory:]
TrustChainDB: DEBUG: PRAGMA page_size = 8192 (previously: 4096) [:memory:]
TrustChainDB: DEBUG: PRAGMA journal_mode = MEMORY (no change) [:memory:]
TrustChainDB: DEBUG: PRAGMA synchronous = NORMAL (previously: 2) [:memory:]
TrustChainDB: DEBUG: commit [:memory:]
TrustChainCommunity: DEBUG: The trustchain community started with Public Key: b'4c69624e61434c504b3a56fd047d99ec8e9c19d54bb0867a2d5e7324d0f5848ea985c63ed0c56bb11c1deace6f0688bbb9ab3cbf7114690f2789b66625d5fdf5d9a3bc0c6e6d6082641a'
DHTDiscoveryCommunity: DEBUG: Launching DHTDiscoveryCommunity with prefix b'0002111e130aa68be3bb97dc30622baee5e8faaaafaa'.
DHTDiscoveryCommunity: INFO: DHT community initialized (peer mid b'af3e7c39514e2a775b62ef80eaeebf5c36fcd0e5')
MarketCommunity: DEBUG: Launching MarketCommunity with prefix b'000244866c7a6e29d39e5d98d764920745c7c058446d'.
MarketDB: DEBUG: loading database [:memory:]
MarketDB: DEBUG: TrustChain database path: :memory:
MarketDB: DEBUG: open database [:memory:]
MarketDB: DEBUG: PRAGMA page_size = 8192 (previously: 4096) [:memory:]
MarketDB: DEBUG: PRAGMA journal_mode = MEMORY (no change) [:memory:]
MarketDB: DEBUG: PRAGMA synchronous = NORMAL (previously: 2) [:memory:]
MarketDB: DEBUG: commit [:memory:]
MemoryOrderRepository: INFO: Memory order repository used
MemoryTransactionRepository: INFO: Memory transaction repository used
OrderManager: INFO: Market order manager initialized
TransactionManager: INFO: Transaction manager initialized
MarketCommunity: INFO: Market community initialized with mid b'af3e7c39514e2a775b62ef80eaeebf5c36fcd0e5'
TrustChainCommunity: DEBUG: Launching TrustChainCommunity with prefix b'00025ad767b05ae592a02488272ca2a86b847d4562e1'.
TrustChainDB: DEBUG: loading database [:memory:]
TrustChainDB: DEBUG: TrustChain database path: :memory:
TrustChainDB: DEBUG: open database [:memory:]
TrustChainDB: DEBUG: PRAGMA page_size = 8192 (previously: 4096) [:memory:]
TrustChainDB: DEBUG: PRAGMA journal_mode = MEMORY (no change) [:memory:]
TrustChainDB: DEBUG: PRAGMA synchronous = NORMAL (previously: 2) [:memory:]
TrustChainDB: DEBUG: commit [:memory:]
TrustChainCommunity: DEBUG: The trustchain community started with Public Key: b'4c69624e61434c504b3ab722522db54fc040cd0db4029ea611d86f0be8896e3c027f78ec472bd40aae0ac9a8c2d0d543d27d15fcfa108d10a52afff03b8f0297a4c8326010dbee3a80ee'
DHTDiscoveryCommunity: DEBUG: Launching DHTDiscoveryCommunity with prefix b'0002111e130aa68be3bb97dc30622baee5e8faaaafaa'.
DHTDiscoveryCommunity: INFO: DHT community initialized (peer mid b'e55bb4f01a2f748007090ababe1a08787bc69c5b')
MarketCommunity: DEBUG: Launching MarketCommunity with prefix b'000244866c7a6e29d39e5d98d764920745c7c058446d'.
MarketDB: DEBUG: loading database [:memory:]
MarketDB: DEBUG: TrustChain database path: :memory:
MarketDB: DEBUG: open database [:memory:]
MarketDB: DEBUG: PRAGMA page_size = 8192 (previously: 4096) [:memory:]
MarketDB: DEBUG: PRAGMA journal_mode = MEMORY (no change) [:memory:]
MarketDB: DEBUG: PRAGMA synchronous = NORMAL (previously: 2) [:memory:]
MarketDB: DEBUG: commit [:memory:]
MemoryOrderRepository: INFO: Memory order repository used
MemoryTransactionRepository: INFO: Memory transaction repository used
OrderManager: INFO: Market order manager initialized
TransactionManager: INFO: Transaction manager initialized
MarketCommunity: INFO: Market community initialized with mid b'e55bb4f01a2f748007090ababe1a08787bc69c5b'
TrustChainCommunity: DEBUG: Launching TrustChainCommunity with prefix b'00025ad767b05ae592a02488272ca2a86b847d4562e1'.
TrustChainDB: DEBUG: loading database [:memory:]
TrustChainDB: DEBUG: TrustChain database path: :memory:
TrustChainDB: DEBUG: open database [:memory:]
TrustChainDB: DEBUG: PRAGMA page_size = 8192 (previously: 4096) [:memory:]
TrustChainDB: DEBUG: PRAGMA journal_mode = MEMORY (no change) [:memory:]
TrustChainDB: DEBUG: PRAGMA synchronous = NORMAL (previously: 2) [:memory:]
TrustChainDB: DEBUG: commit [:memory:]
TrustChainCommunity: DEBUG: The trustchain community started with Public Key: b'4c69624e61434c504b3a86cf9b78a3086d5926abca8b509615a95844ec0902a437e24d2527aa7f204d4f1dae8ae8088c8f5be55a2943b4a361a575ddc2bd0786f850c10e33e26fc1d1f2'
DHTDiscoveryCommunity: DEBUG: Launching DHTDiscoveryCommunity with prefix b'0002111e130aa68be3bb97dc30622baee5e8faaaafaa'.
DHTDiscoveryCommunity: INFO: DHT community initialized (peer mid b'5bf14665855ac208fef897ab2100b5ca59383d26')
MarketCommunity: DEBUG: Launching MarketCommunity with prefix b'000244866c7a6e29d39e5d98d764920745c7c058446d'.
MarketDB: DEBUG: loading database [:memory:]
MarketDB: DEBUG: TrustChain database path: :memory:
MarketDB: DEBUG: open database [:memory:]
MarketDB: DEBUG: PRAGMA page_size = 8192 (previously: 4096) [:memory:]
MarketDB: DEBUG: PRAGMA journal_mode = MEMORY (no change) [:memory:]
MarketDB: DEBUG: PRAGMA synchronous = NORMAL (previously: 2) [:memory:]
MarketDB: DEBUG: commit [:memory:]
MemoryOrderRepository: INFO: Memory order repository used
MemoryTransactionRepository: INFO: Memory transaction repository used
OrderManager: INFO: Market order manager initialized
TransactionManager: INFO: Transaction manager initialized
MarketCommunity: INFO: Market community initialized with mid b'5bf14665855ac208fef897ab2100b5ca59383d26'
MarketCommunity: DEBUG: Updating ip of trader b'af3e7c39514e2a775b62ef80eaeebf5c36fcd0e5' to (151.72.42.216, 57689)
Tribler.pyipv8.ipv8.messaging.bloomfilter: DEBUG: constructing bloom filter based on f_error_rate 0.005000 and 1 n_capacity
MarketCommunity: ERROR: Exception occurred while handling packet!
Traceback (most recent call last):
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/pyipv8/ipv8/messaging/serialization.py", line 264, in pack_multiple
    packed, packed_size = self.pack(*packable)
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/pyipv8/ipv8/messaging/serialization.py", line 248, in pack
    return self._packers[format].pack(*data)
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/pyipv8/ipv8/messaging/serialization.py", line 171, in pack
    return super(DefaultStruct, self).pack(*data), self.size
struct.error: char format requires a bytes object of length 1
```