### PR TITLE
Return connected peers

### DIFF
--- a/ipv8/test/attestation/trustchain/test_database.py
+++ b/ipv8/test/attestation/trustchain/test_database.py
@@ -1,0 +1,45 @@
+from __future__ import absolute_import
+
+import unittest
+
+from six.moves import xrange
+
+from ....attestation.trustchain.block import TrustChainBlock
+from ....attestation.trustchain.database import TrustChainDB
+from ....keyvault.crypto import default_eccrypto
+from ....test.attestation.trustchain.test_block import TestBlock
+
+
+class TestTrustChainDB(unittest.TestCase):
+
+    def setUp(self):
+        self.db = TrustChainDB(u":memory:", 'temp_trustchain')
+
+    def test_connected_users(self):
+        """
+        Test returning connected users for a given public key works.
+        """
+        user_key = default_eccrypto.generate_key(u"curve25519")
+        public_key = user_key.pub().key_to_bin()
+
+        # No users initially
+        self.assertEqual(len(self.db.get_users()), 0)
+        self.assertEqual(len(self.db.get_connected_users(public_key)), 0)
+
+        # Add 10 random blocks, implying 10 unique peers
+        random_blocks = []
+        for i in range(0, 10):
+            block = TestBlock()
+            random_blocks.append(block)
+            self.db.add_block(block)
+
+        self.assertEqual(len(self.db.get_users()), 10)
+        self.assertEqual(len(self.db.get_connected_users(public_key)), 0)
+
+        # Create 5 link block implying 5 connected peers to the current user
+        for i in xrange(0, 5):
+            block = TrustChainBlock.create(b'test', {b'id': i}, self.db, public_key, link=random_blocks[i])
+            self.db.add_block(block)
+
+        self.assertEqual(len(self.db.get_users()), 11)
+        self.assertEqual(len(self.db.get_connected_users(public_key)), 5)

--- a/test_classes_list.txt
+++ b/test_classes_list.txt
@@ -18,6 +18,7 @@ ipv8/test/keyvault/test_signature.py:TestSignatures
 
 ipv8/test/attestation/trustchain/test_community.py:TestTrustChainCommunity
 ipv8/test/attestation/trustchain/test_block.py:TestTrustChainBlock
+ipv8/test/attestation/trustchain/test_database.py:TestTrustChainDB
 ipv8/test/attestation/identity/test_identity.py:TestIdentityCommunity
 ipv8/test/attestation/wallet/primitives/cryptosystem/test_boneh.py:TestBoneh
 ipv8/test/attestation/wallet/primitives/cryptosystem/test_ec.py:TestPairing


### PR DESCRIPTION
Added an option to fetch the connected peers to a public key (user). It is added to build a beautiful trust graph in Tribler.

Instead of this (expensive)
![all_peers](https://user-images.githubusercontent.com/1442867/56902447-a0fdb480-6a9a-11e9-998b-267f4970b94e.png)

Only show connected peers (cheaper)
![circular_graph](https://user-images.githubusercontent.com/1442867/56902451-a3f8a500-6a9a-11e9-8bb1-b0c5151088ec.png)

