### PR TITLE
Support for large block retrieval in DHTs 

### DIFF
--- a/ipv8/REST/dht_endpoint.py
+++ b/ipv8/REST/dht_endpoint.py
@@ -234,7 +234,7 @@ class DHTBlockEndpoint(BaseEndpoint, BlockListener):
                         u"error": {
                             u"handled": True,
                             u"message": "Could not reconstruct any block successfully." if start_idx != 0 else
-                            u"Could not find any blocks for the specified key."
+                                        u"Could not find any blocks for the specified key."
                         }
                     }))
 

--- a/ipv8/REST/dht_endpoint.py
+++ b/ipv8/REST/dht_endpoint.py
@@ -14,7 +14,7 @@ from .base_endpoint import BaseEndpoint
 from ..attestation.trustchain.community import TrustChainCommunity
 from ..attestation.trustchain.listener import BlockListener
 from ..attestation.trustchain.payload import DHTBlockPayload
-from ..dht.community import DHTCommunity, MAX_ENTRY_SIZE
+from ..dht.community import DHTCommunity, MAX_ENTRY_SIZE, MAX_VALUES_IN_FIND
 from ..dht.discovery import DHTDiscoveryCommunity
 from ..keyvault.public.libnaclkey import LibNaCLPK
 from ..messaging.serialization import PackError, Serializer
@@ -88,19 +88,29 @@ class DHTBlockEndpoint(BaseEndpoint, BlockListener):
         if block:
             self.publish_block(block, republish=True)
 
-    def reconstruct_all_blocks(self, block_chunks, public_key):
+    def reconstruct_all_blocks(self, new_chunks, public_key, chunk_dict=None, counts=None):
         """
         Given a list of block chunks, reconstruct all the blocks in a dictionary indexed by their version
 
-        :param block_chunks: the list of block chunks
+        :param new_chunks: the list of block chunks
         :param public_key: the public key of the publishing node, which will be used for verifying the chunks
-        :return: a dictionary of block_maintenance_taskreconstructed blocks (in packed format), indexed by the version
-                 of the blocks and the maximal version
+        :param chunk_dict: a dictionary containing previously (partially) built blocks, or None
+        :param counts: a dictionary from block version to the number of missing chunks
+        :return: a dictionary from block version to a list of block chunks, the maximum block version,
+                 a dictionary from version to count (where the count represents the number of missing chunks)
         """
-        new_blocks = {}
+        assert (chunk_dict and counts) or (not chunk_dict and not counts), "Must either provide both new_blocks " \
+                                                                           "and counter dicts or None for both"
+
+        if not chunk_dict:
+            chunk_dict = {}
+
+        if not counts:
+            counts = {}
+
         max_version = 0
 
-        for entry in block_chunks:
+        for entry in new_chunks:
             try:
                 package = self.serializer.unpack_to_serializables([DHTBlockPayload, ], entry)[0]
 
@@ -110,21 +120,19 @@ class DHTBlockEndpoint(BaseEndpoint, BlockListener):
                                                                     ('raw', package.payload)])[0]
 
                 if public_key.verify(package.signature, pre_signed_content):
-                    max_version = max_version if max_version > package.version else package.version
+                    max_version = max(max_version, package.version)
 
-                    if package.version not in new_blocks:
-                        new_blocks[package.version] = [b''] * package.block_count
+                    if package.version not in chunk_dict:
+                        chunk_dict[package.version] = [b''] * package.block_count
+                        counts[package.version] = package.block_count
 
-                    new_blocks[package.version][package.block_position] = package.payload
+                    chunk_dict[package.version][package.block_position] = package.payload
+                    counts[package.version] -= 1
             except PackError:
                 logging.error("PackError: Found a clandestine entry in the DHT when reconstructing TC blocks: %s",
                               entry)
 
-        # Concatenate the blocks
-        for version in new_blocks:
-            new_blocks[version] = b''.join(new_blocks[version])
-
-        return new_blocks, max_version
+        return chunk_dict, max_version, counts
 
     def publish_block(self, block, republish=False):
         """
@@ -182,7 +190,7 @@ class DHTBlockEndpoint(BaseEndpoint, BlockListener):
         Return the latest TC block of a peer, as identified in the request
 
         :param request: the request for retrieving the latest TC block of a peer. It must contain the peer's
-        public key of the peer
+                        public key of the peer
         :return: the latest block of the peer, if found
         """
         if not self.dht:
@@ -192,23 +200,6 @@ class DHTBlockEndpoint(BaseEndpoint, BlockListener):
         if not request.args or b'public_key' not in request.args:
             request.setResponseCode(http.BAD_REQUEST)
             return self.twisted_dumps({"error": "Must specify the peer's public key"})
-
-        def on_success(block_chunks):
-            if not block_chunks:
-                request.setResponseCode(http.NOT_FOUND)
-                request.write(self.twisted_dumps({
-                    "error": {
-                        "handled": True,
-                        "message": "Could not find any blocks for the specified key."
-                    }
-                }))
-            else:
-                target_public_key = LibNaCLPK(binarykey=raw_public_key[10:])
-                # Discard the 2nd half of the tuples retrieved as a result of the DHT query
-                new_blocks, max_version = self.reconstruct_all_blocks([x[0] for x in block_chunks], target_public_key)
-                request.write(self.twisted_dumps({"block": b64encode(new_blocks[max_version]).decode('utf-8')}))
-
-            request.finish()
 
         def on_failure(failure):
             request.setResponseCode(http.INTERNAL_SERVER_ERROR)
@@ -220,6 +211,66 @@ class DHTBlockEndpoint(BaseEndpoint, BlockListener):
                 }
             }))
             request.finish()
+
+        def deep_reconstruction(new_chunks, chunk_dict, counts, start_idx, target_public_key):
+            if not new_chunks:
+                # If we're here it means that there are no more chunks to be retrieved
+                max_version_block = None
+
+                # Try to find a complete block which has the greatest version
+                for version in sorted(list(chunk_dict.keys()), reverse=True):
+                    if version in counts and counts[version] == 0:
+                        max_version_block = b''.join(chunk_dict[version])
+                        break
+
+                if max_version_block:
+                    request.write(self.twisted_dumps({"block": b64encode(max_version_block).decode('utf-8')}))
+                else:
+                    request.setResponseCode(http.NOT_FOUND)
+                    request.write(self.twisted_dumps({
+                        u"error": {
+                            u"handled": True,
+                            u"message": "Could not reconstruct any block successfully."
+                        }
+                    }))
+
+                request.finish()
+            else:
+                # Given the new chunks, we will continue to build the blocks we have so far
+                chunk_dict, max_version, counts = self.reconstruct_all_blocks([x[0] for x in new_chunks],
+                                                                              target_public_key, chunk_dict, counts)
+
+                # If a block has been successfully constructed, we build and return it, otherwise we'll keep searching
+                if counts.get(max_version, -1) == 0:
+                    request.write(self.twisted_dumps(
+                        {"block": b64encode(b''.join(chunk_dict[max_version])).decode('utf-8')}))
+                    request.finish()
+                else:
+                    # Continue the search from the next blocks
+                    start_idx += MAX_VALUES_IN_FIND
+                    self.dht.find_values(hash_key, start_idx=start_idx).addCallback(
+                        deep_reconstruction, chunk_dict, counts, start_idx, target_public_key).addErrback(on_failure)
+
+        def on_success(block_chunks):
+            if not block_chunks:
+                request.setResponseCode(http.NOT_FOUND)
+                return self.twisted_dumps({"error": "Could not find any blocks for the specified key."})
+
+            target_public_key = LibNaCLPK(binarykey=raw_public_key[10:])
+
+            # Forward an initial query for the block chunks
+            new_blocks, max_version, counts = self.reconstruct_all_blocks([x[0] for x in block_chunks],
+                                                                          target_public_key)
+
+            # Check to see if the initial query constructed a block successfully; if so, return it, else query further
+            if counts.get(max_version, -1) == 0:
+                request.write(self.twisted_dumps({"block": b64encode(b''.join(new_blocks[max_version])).decode(
+                    'utf-8')}))
+                request.finish()
+            else:
+                self.dht.find_values(hash_key, start_idx=MAX_VALUES_IN_FIND).addCallback(
+                    deep_reconstruction, new_blocks, counts, MAX_VALUES_IN_FIND, target_public_key).addErrback(
+                        on_failure)
 
         raw_public_key = b64decode(request.args[b'public_key'][0])
         hash_key = sha1(raw_public_key + self.KEY_SUFFIX).digest()

--- a/ipv8/dht/community.py
+++ b/ipv8/dht/community.py
@@ -304,10 +304,10 @@ class DHTCommunity(Community):
         cache.on_complete()
         cache.deferred.callback(cache.node)
 
-    def _send_find_request(self, node, target, force_nodes):
+    def _send_find_request(self, node, target, force_nodes, start_idx=0):
         cache = self.request_cache.add(Request(self, u'find', node, [force_nodes]))
         self.send_message(node.address, MSG_FIND_REQUEST, FindRequestPayload,
-                          (cache.number, self.my_estimated_lan, target, force_nodes))
+                          (cache.number, self.my_estimated_lan, target, start_idx, force_nodes))
         return cache.deferred
 
     def _process_find_responses(self, responses, nodes_tried):
@@ -333,7 +333,9 @@ class DHTCommunity(Community):
         return values, nodes, to_puncture
 
     @inlineCallbacks
-    def _find(self, target, force_nodes=False):
+    def _find(self, target, force_nodes=False, start_idx=0):
+        assert start_idx >= 0, "The query cannot start from a negative index"
+
         nodes_closest = set(self.routing_table.closest_nodes(target, max_nodes=MAX_FIND_WALKS))
         if not nodes_closest:
             returnValue(Failure(RuntimeError('No nodes found in the routing table')))
@@ -347,7 +349,8 @@ class DHTCommunity(Community):
                 break
 
             # Send closest nodes a find-node-request
-            deferreds = [self._send_find_request(node, target, force_nodes) for node in nodes_closest]
+            deferreds = [self._send_find_request(node, target, force_nodes, start_idx=start_idx)
+                         for node in nodes_closest]
             responses = yield gatherResponses(deferreds, consumeErrors=True)
             recent = next((sender for sender, response in responses if 'nodes' in response), recent)
 
@@ -410,8 +413,8 @@ class DHTCommunity(Community):
 
         return results
 
-    def find_values(self, target):
-        return self._find(target, force_nodes=False)
+    def find_values(self, target, start_idx=0):
+        return self._find(target, force_nodes=False, start_idx=start_idx)
 
     def find_nodes(self, target):
         return self._find(target, force_nodes=True)
@@ -425,7 +428,8 @@ class DHTCommunity(Community):
             return
 
         nodes = []
-        values = self.storage.get(payload.target, limit=MAX_VALUES_IN_FIND) if not payload.force_nodes else []
+        values = self.storage.get(payload.target, starting_point=payload.start_idx, limit=MAX_VALUES_IN_FIND) \
+            if not payload.force_nodes else []
 
         if payload.force_nodes or not values:
             nodes = self.routing_table.closest_nodes(payload.target, exclude_node=node, max_nodes=MAX_NODES_IN_FIND)

--- a/ipv8/dht/community.py
+++ b/ipv8/dht/community.py
@@ -94,8 +94,8 @@ class DHTCommunity(Community):
     """
     Community for storing/finding key-value pairs.
     """
-    master_peer = Peer(unhexlify('4c69624e61434c504b3abd7e6ca06b2c2e5e4412eee20b5d07fab63b47ace82dc5a960407f5f0cff5c4'
-                                 '48781decbc77dcb8fb1792ba4ad91f254351b3d043cfd9db446cfcfe3539d4602'))
+    master_peer = Peer(unhexlify('4c69624e61434c504b3a4c99f04cef9ba4ca645401cd51b8ef634e63e2ad0d3209eca958ce0293d7cf668'
+                                 '2059469c1a253e66191bd3b96a082a8e11cc35962b9b6f8434e21518a0344af'))
 
     def __init__(self, *args, **kwargs):
         super(DHTCommunity, self).__init__(*args, **kwargs)

--- a/ipv8/dht/payload.py
+++ b/ipv8/dht/payload.py
@@ -97,26 +97,29 @@ class StoreResponsePayload(BasePayload):
 
 class FindRequestPayload(BasePayload):
 
-    format_list = BasePayload.format_list + ['varlenI', '20s', '?']
+    format_list = BasePayload.format_list + ['varlenI', '20s', 'I', '?']
 
-    def __init__(self, identifier, lan_address, target, force_nodes):
+    def __init__(self, identifier, lan_address, target, start_idx, force_nodes):
         super(FindRequestPayload, self).__init__(identifier)
         self.lan_address = lan_address
         self.target = target
+        self.start_idx = start_idx
         self.force_nodes = force_nodes
 
     def to_pack_list(self):
         data = super(FindRequestPayload, self).to_pack_list()
         data.append(('varlenI', inet_aton(self.lan_address[0]) + pack("!H", self.lan_address[1])))
         data.append(('20s', self.target))
+        data.append(('I', self.start_idx))
         data.append(('?', self.force_nodes))
         return data
 
     @classmethod
-    def from_unpack_list(cls, identifier, lan_address, target, force_nodes):
+    def from_unpack_list(cls, identifier, lan_address, target, start_idx, force_nodes):
         return FindRequestPayload(identifier,
                                   (inet_ntoa(lan_address[:4]), unpack('!H', lan_address[4:6])[0]),
                                   target,
+                                  start_idx,
                                   force_nodes)
 
 

--- a/ipv8/dht/payload.py
+++ b/ipv8/dht/payload.py
@@ -1,10 +1,10 @@
 from __future__ import absolute_import
 
-from struct import pack, unpack, unpack_from, calcsize
 from socket import inet_aton, inet_ntoa
+from struct import calcsize, pack, unpack, unpack_from
 
-from ..messaging.payload import Payload
 from .routing import Node
+from ..messaging.payload import Payload
 
 
 def encode_values(values):

--- a/ipv8/dht/storage.py
+++ b/ipv8/dht/storage.py
@@ -1,8 +1,7 @@
 from __future__ import absolute_import
 
-import time
 import hashlib
-
+import time
 from collections import defaultdict
 
 

--- a/ipv8/dht/storage.py
+++ b/ipv8/dht/storage.py
@@ -56,8 +56,9 @@ class Storage(object):
             self.items[key].insert(0, new_value)
             self.items[key].sort(key=lambda v: 1 if v.id == key else 0)
 
-    def get(self, key, limit=None):
-        return [value.data for value in self.items[key][:limit]] if key in self.items else []
+    def get(self, key, starting_point=0, limit=None):
+        upper_bound = (starting_point + limit) if limit else limit
+        return [value.data for value in self.items[key][starting_point:upper_bound]] if key in self.items else []
 
     def items_older_than(self, min_age):
         items = []

--- a/ipv8/test/REST/dht/test_dht_endpoint.py
+++ b/ipv8/test/REST/dht/test_dht_endpoint.py
@@ -35,7 +35,7 @@ class TestDHTEndpoint(RESTTestBase):
     @inlineCallbacks
     def publish_to_DHT(self, peer, key, data, numeric_version, omit_last_chunk=False):
         """
-        Publish data to the DHT via a peer
+        Publish data to the DHT via a peer.
 
         :param peer: the peer via which the data is published to the DHT
         :param key: the key of the added data
@@ -67,7 +67,7 @@ class TestDHTEndpoint(RESTTestBase):
 
     def deserialize_payload(self, serializables, data):
         """
-        Deserialize data
+        Deserialize data.
 
         :param serializables: the list of serializable formats
         :param data: the serialized data
@@ -86,7 +86,7 @@ class TestDHTEndpoint(RESTTestBase):
     @inlineCallbacks
     def test_added_block_explicit(self):
         """
-        Test the publication of a block which has been added by hand to the DHT
+        Test the publication of a block which has been added by hand to the DHT.
         """
         param_dict = {
             'port': self.nodes[0].port,
@@ -305,7 +305,7 @@ class TestDHTEndpoint(RESTTestBase):
     @inlineCallbacks
     def test_many_blocks_with_single_omission(self):
         """
-        Test the retrieval of large blocks when the latest block is incomplete
+        Test the retrieval of large blocks when the latest block is incomplete.
         """
         param_dict = {
             'port': self.nodes[1].port,
@@ -346,7 +346,7 @@ class TestDHTEndpoint(RESTTestBase):
     @inlineCallbacks
     def test_non_existent_block(self):
         """
-        Test the block retrieval operation when the block in question does not exist
+        Test the block retrieval operation when the block in question does not exist.
         """
         param_dict = {
             'port': self.nodes[1].port,
@@ -366,7 +366,7 @@ class TestDHTEndpoint(RESTTestBase):
     @inlineCallbacks
     def test_many_blocks_with_omissions(self):
         """
-        Test the retrieval of large blocks when all the blocks are incomplete
+        Test the retrieval of large blocks when all the blocks are incomplete.
         """
         param_dict = {
             'port': self.nodes[1].port,

--- a/ipv8/test/REST/dht/test_dht_endpoint.py
+++ b/ipv8/test/REST/dht/test_dht_endpoint.py
@@ -33,7 +33,7 @@ class TestDHTEndpoint(RESTTestBase):
         self._create_new_peer_inner(peer_cls, port, [TestDHTCommunity, TestTrustchainCommunity], *args, **kwargs)
 
     @inlineCallbacks
-    def publish_to_DHT(self, peer, key, data, numeric_version):
+    def publish_to_DHT(self, peer, key, data, numeric_version, omit_last_chunk=False):
         """
         Publish data to the DHT via a peer
 
@@ -41,25 +41,27 @@ class TestDHTEndpoint(RESTTestBase):
         :param key: the key of the added data
         :param data: the data itself; should be a string
         :param numeric_version: the version of the data
+        :param omit_last_chunk: boolean which indicates whether the last chunk of the block should not be published
         :return: None
         """
         my_private_key = peer.get_keys()['my_peer'].key
 
         # Get the total number of chunks in this blocks
-        total_blocks = len(data) // DHTBlockEndpoint.CHUNK_SIZE
-        total_blocks += 1 if len(data) % DHTBlockEndpoint.CHUNK_SIZE != 0 else 0
+        total_chunks = len(data) // DHTBlockEndpoint.CHUNK_SIZE
+        total_chunks += 1 if len(data) % DHTBlockEndpoint.CHUNK_SIZE != 0 else 0
+        published_chunks = total_chunks if not omit_last_chunk else (total_chunks - 1)
 
         # To make this faster we'll use addition instead of multiplication, and use a pointer
         slice_pointer = 0
 
-        for i in range(total_blocks):
+        for i in range(published_chunks):
             chunk = data[slice_pointer: slice_pointer + DHTBlockEndpoint.CHUNK_SIZE]
             slice_pointer += DHTBlockEndpoint.CHUNK_SIZE
-            pre_signed_content = self.serializer.pack_multiple([('H', numeric_version), ('H', i), ('H', total_blocks),
+            pre_signed_content = self.serializer.pack_multiple([('H', numeric_version), ('H', i), ('H', total_chunks),
                                                                 ('raw', chunk)])[0]
             signature = my_private_key.signature(pre_signed_content)
 
-            blob_chunk = self.serializer.pack_multiple(DHTBlockPayload(signature, numeric_version, i, total_blocks,
+            blob_chunk = self.serializer.pack_multiple(DHTBlockPayload(signature, numeric_version, i, total_chunks,
                                                                        chunk).to_pack_list())
             yield peer.get_overlay_by_class(DHTCommunity).store_value(key, blob_chunk[0])
 
@@ -260,9 +262,12 @@ class TestDHTEndpoint(RESTTestBase):
         self.assertEqual(len(result), chunk_number, "The contents of the DHT have been changed. This should not happen")
 
     @inlineCallbacks
-    def test_explicit_block_maintenance(self):
+    def test_many_blocks(self):
         """
-        Test the DHT block chunk republishing correctness, when the block is added manually to the database
+        Test the retrieval of large blocks, which do not fit into one DHT query frame. It should be noted that the
+        test does not actually retrieve the latest absolute block. It only tries to fetch the greatest block it has
+        heard of via its queries. Hence, it will not work past 9 blocks, as this is the limit after which it does
+        not hear about any new nodes.
         """
         param_dict = {
             'port': self.nodes[1].port,
@@ -271,50 +276,36 @@ class TestDHTEndpoint(RESTTestBase):
             'public_key': string_to_url(b64encode(self.nodes[0].get_keys()['my_peer'].public_key.key_to_bin()))
         }
 
-        def get_storage_entries(node, key):
-            return node.get_overlay_by_class(DHTCommunity).storage.get(key)
-
-        # Introduce the nodes
+        # Introduce the nodes and increase the size of the request queues
         yield self.introduce_nodes(DHTCommunity)
+        self._increase_request_limit(100)
 
-        # Compute the key under which the block will be published
         hash_key = sha1(self.nodes[0].get_keys()['my_peer'].public_key.key_to_bin()
                         + DHTBlockEndpoint.KEY_SUFFIX).digest()
 
-        # Create an initial block, and store it in the TrustChain DB the first node
-        original_block = TestBlock(transaction={1: 'asd'}, key=self.nodes[0].get_keys()['my_peer'].key)
-        self.nodes[0].get_overlay_by_class(TrustChainCommunity).persistence.add_block(original_block)
+        # Create some blocks
+        block_array = [(i, TestBlock(transaction={1: 'asd{}'.format(i)})) for i in range(5, 0, -1)]
 
-        self.assertEqual([], get_storage_entries(self.nodes[0], hash_key), "There should be no entries under this key")
-        self.assertEqual([], get_storage_entries(self.nodes[1], hash_key), "There should be no entries under this key")
+        # Publish the blocks, such that the latest block is last
+        for version, block in block_array:
+            yield self.publish_to_DHT(self.nodes[0], hash_key, block.pack(), version)
 
-        self.nodes[0]._rest_manager._root_endpoint.getStaticEntity(b'dht').getStaticEntity(b'block') \
-            .publish_latest_block()
-        yield self.deliver_messages()
-        yield self.sleep()
-
-        node_0_responses = get_storage_entries(self.nodes[0], hash_key)
-        node_1_responses = get_storage_entries(self.nodes[1], hash_key)
-
-        # Check that under this key, both nodes store the same content
-        self.assertEqual(sorted(node_0_responses), sorted(node_1_responses), "The contents of the two storages "
-                                                                             "should be equal")
-
-        # Fetch the latest block from one of the nodes
+        # Get the block through the REST API from the second peer
         response = yield self._get_style_requests.make_dht_block(param_dict)
         self.assertTrue('block' in response and response['block'], "Response is not as expected: %s" % response)
         response = b64decode(response['block'])
 
+        # Reconstruct the block from what was received in the response
         payload = self.deserialize_payload((HalfBlockPayload,), response)
         reconstructed_block = self.nodes[0].get_overlay_by_class(TrustChainCommunity).get_block_class(
             payload.type).from_payload(payload, self.serializer)
 
-        self.assertEqual(reconstructed_block, original_block, "The received block was not equal to the original block")
+        self.assertEqual(reconstructed_block, block_array[0][1], "The received block was not equal to the latest block")
 
     @inlineCallbacks
-    def test_block_implicit_maintenance(self):
+    def test_many_blocks_with_single_omission(self):
         """
-        Test the DHT block chunk republishing correctness when the block is added implicitly to the database
+        Test the retrieval of large blocks when the latest block is incomplete
         """
         param_dict = {
             'port': self.nodes[1].port,
@@ -322,42 +313,32 @@ class TestDHTEndpoint(RESTTestBase):
             'endpoint': 'dht/block',
             'public_key': string_to_url(b64encode(self.nodes[0].get_keys()['my_peer'].public_key.key_to_bin()))
         }
-
-        def get_storage_entries(node, key):
-            return node.get_overlay_by_class(DHTCommunity).storage.get(key)
-
-        # Introduce the nodes
+        # Introduce the nodes and increase the size of the request queues
         yield self.introduce_nodes(DHTCommunity)
 
-        # Compute the key under which the block will be published
-        publisher_pk = self.nodes[0].get_keys()['my_peer'].public_key.key_to_bin()
-        hash_key = sha1(publisher_pk + DHTBlockEndpoint.KEY_SUFFIX).digest()
+        self._increase_request_limit(100)
 
-        # Create an initial block, and store it in the TrustChain DB the first node
-        yield self.nodes[0].get_overlay_by_class(TrustChainCommunity).create_source_block(b'test', {})
-        original_block = self.nodes[0].get_overlay_by_class(TrustChainCommunity).persistence.get(publisher_pk, 1)
-        yield self.deliver_messages()
-        yield self.sleep()
+        hash_key = sha1(self.nodes[0].get_keys()['my_peer'].public_key.key_to_bin()
+                        + DHTBlockEndpoint.KEY_SUFFIX).digest()
 
-        self.assertEqual(3, len(get_storage_entries(self.nodes[0], hash_key)), "There should be 3 entries for node 0")
-        self.assertEqual(3, len(get_storage_entries(self.nodes[1], hash_key)), "There should be 3 entries for node 1")
+        # Create some blocks
+        block_array = [(i, TestBlock(transaction={1: 'asd{}'.format(i)})) for i in range(5, 0, -1)]
 
-        self.nodes[0]._rest_manager._root_endpoint.getStaticEntity(b'dht').getStaticEntity(b'block') \
-            .publish_latest_block()
-        yield self.deliver_messages()
-        yield self.sleep()
+        # Publish the blocks, such that the latest block is last
+        yield self.publish_to_DHT(self.nodes[0], hash_key, block_array[0][1].pack(), block_array[0][0],
+                                  omit_last_chunk=True)
+        block_array.pop(0)
+        for version, block in block_array:
+            yield self.publish_to_DHT(self.nodes[0], hash_key, block.pack(), version)
 
-        # Check that no chunks have been duplicated in the local storage after the refresh is done
-        self.assertEqual(3, len(get_storage_entries(self.nodes[0], hash_key)), "There should be 3 entries for node 0")
-        self.assertEqual(3, len(get_storage_entries(self.nodes[1], hash_key)), "There should be 3 entries for node 1")
-
-        # Fetch the block, and check that it matches the original block
+        # Get the block through the REST API from the second peer
         response = yield self._get_style_requests.make_dht_block(param_dict)
         self.assertTrue('block' in response and response['block'], "Response is not as expected: %s" % response)
         response = b64decode(response['block'])
 
+        # Reconstruct the block from what was received in the response
         payload = self.deserialize_payload((HalfBlockPayload,), response)
         reconstructed_block = self.nodes[0].get_overlay_by_class(TrustChainCommunity).get_block_class(
             payload.type).from_payload(payload, self.serializer)
 
-        self.assertEqual(reconstructed_block, original_block, "The received block was not equal to the original block")
+        self.assertEqual(reconstructed_block, block_array[0][1], "The received block was not equal to the latest block")


### PR DESCRIPTION
This PR attempts to address one of the improvements to the DHT flagged in issue #451. Added support for block entries in the DHT, whose chunks do not fit into a single response returned after a DHT block request. The implementation forwarded in this PR is able to return a block which is complete and has the maximal version, as long as it is within the scope of the query. The following high level description of the algorithm should hopefully make what this means more clear (*chunk* and *block* are interchangeably used):

1. Given the public key of a peer, forward a REST request via HTTP for the peer's latest block. 
1. The peer which receives this request will query its own DHT object for the entries under a special key for which the target peer's TC blocks are stored. Set `query_start = 0`.  
1. The query will return `MAX_VALUES_IN_FIND = 8` DHT entries  under the aforementioned key, starting from the index `query_start` in the absolute order of the DHT entries (i.e. from `query_start` to `query_start + MAX_VALUES_IN_FIND`, sorted by the distance to querying peer). 
1. Given the new set of entries, the algorithm will try to build new blocks. If we have already started to build blocks, then the algorithm will try to further build on top of those.
1. Each chunk has an associated version (its location in the chain). The algorithm keeps track of the maximal version which it has seen so far. 
1. If the maximal version block (seen so far) is complete, stop the process, and return the block. If there are no more blocks under this key, return the block which is complete and also has the greatest version. Otherwise, increment `query_start = query_start + MAX_VALUES_IN_FIND`, and forward another query for entries in the DHT. Go to step 3.

I'm not sure if this behavior generally suffices, but the alternative (for always returning the block with the guaranteed greatest version) to this would be to either retrieve all the chunks stored in the DHT under some peer's key, or hold the maximal version of a block in a trusted location which is accessible to any peer. Currently, this is a *best effort* approach.