### PR TITLE
Properly encoding to/from JSON in Python 3

### DIFF
--- a/ipv8/REST/attestation_endpoint.py
+++ b/ipv8/REST/attestation_endpoint.py
@@ -1,11 +1,12 @@
 from __future__ import absolute_import
 
-import json
 from base64 import b64decode, b64encode
 from hashlib import sha1
 
 from twisted.internet.defer import Deferred, succeed
+from twisted.web import http
 
+from . import json_util as json
 from .base_endpoint import BaseEndpoint
 from ..attestation.identity.community import IdentityCommunity
 from ..attestation.wallet.community import AttestationCommunity
@@ -101,27 +102,27 @@ class AttestationEndpoint(BaseEndpoint):
         type=attributes&mid=mid_b64 -> [(attribute_name, attribute_hash)]
         """
         if not request.args or b'type' not in request.args:
-            return ""
+            request.setResponseCode(http.BAD_REQUEST)
+            return self.twisted_dumps({"error": "parameters or type missing"})
+
         if request.args[b'type'][0] == b'outstanding':
             formatted = []
             for k, v in self.attestation_requests.items():
                 formatted.append(k + (v[1], ))
-            return json.dumps([(x.decode('utf-8'), y.decode('utf-8'), z.decode('utf-8'))
-                               for x, y, z in formatted]).encode('utf-8')
-        if request.args[b'type'][0] == b'outstanding_verify':
-            formatted = []
-            for k, v in self.verify_requests.items():
-                formatted.append(k)
-            return json.dumps([(x.decode('utf-8'), y.decode('utf-8')) for x, y in formatted]).encode('utf-8')
-        if request.args[b'type'][0] == b'verification_output':
+            return self.twisted_dumps(
+                [(x.decode('utf-8'), y.decode('utf-8'), z.decode('utf-8')) for x, y, z in formatted])
+        elif request.args[b'type'][0] == b'outstanding_verify':
+            formatted = self.verify_requests.keys()
+            return self.twisted_dumps([(x.decode('utf-8'), y.decode('utf-8')) for x, y in formatted])
+        elif request.args[b'type'][0] == b'verification_output':
             formatted = {}
             for k, v in self.verification_output.items():
                 formatted[b64encode(k).decode('utf-8')] = [(b64encode(a).decode('utf-8'), m) for a, m in v]
-            return json.dumps(formatted).encode('utf-8')
-        if request.args[b'type'][0] == b'peers':
+            return self.twisted_dumps(formatted)
+        elif request.args[b'type'][0] == b'peers':
             peers = self.session.network.get_peers_for_service(self.identity_overlay.master_peer.mid)
-            return json.dumps([b64encode(p.mid).decode('utf-8') for p in peers]).encode('utf-8')
-        if request.args[b'type'][0] == b'attributes':
+            return self.twisted_dumps([b64encode(p.mid).decode('utf-8') for p in peers])
+        elif request.args[b'type'][0] == b'attributes':
             if b'mid' in request.args:
                 mid_b64 = request.args[b'mid'][0]
                 peer = self.get_peer_from_mid(mid_b64)
@@ -139,12 +140,11 @@ class AttestationEndpoint(BaseEndpoint):
                     previous = trimmed.get((attester, b.transaction[b"name"]), None)
                     if not previous or previous.sequence_number < b.sequence_number:
                         trimmed[(attester, b.transaction[b"name"])] = b
-                return json.dumps([(b.transaction[b"name"].decode('utf-8'),
-                                    b64encode(b.transaction[b"hash"]).decode('utf-8'),
-                                    {cast_to_unicode(k): cast_to_unicode(v)
-                                     for k, v in b.transaction[b"metadata"].items()},
-                                    b64encode(sha1(b.link_public_key).digest()).decode('utf-8'))
-                                   for b in trimmed.values()]).encode('utf-8')
+                return self.twisted_dumps([(
+                    b.transaction[b"name"].decode('utf-8'),
+                    b64encode(b.transaction[b"hash"]).decode('utf-8'),
+                    {cast_to_unicode(k): cast_to_unicode(v) for k, v in b.transaction[b"metadata"].items()},
+                    b64encode(sha1(b.link_public_key).digest()).decode('utf-8')) for b in trimmed.values()])
         if request.args[b'type'][0] == b'drop_identity':
             self.identity_overlay.persistence.execute('DELETE FROM blocks')
             self.identity_overlay.persistence.commit()
@@ -154,7 +154,8 @@ class AttestationEndpoint(BaseEndpoint):
             my_new_peer = Peer(default_eccrypto.generate_key(u"curve25519"))
             self.identity_overlay.my_peer = my_new_peer
             self.attestation_overlay.my_peer = my_new_peer
-        return b""
+
+        return self.twisted_dumps({"success": True})
 
     def render_POST(self, request):
         """
@@ -164,7 +165,9 @@ class AttestationEndpoint(BaseEndpoint):
         type=verify&mid=mid_b64&attribute_hash=attribute_hash_b64&attribute_values=attribute_value_b64,...
         """
         if not request.args or b'type' not in request.args:
-            return b""
+            request.setResponseCode(http.BAD_REQUEST)
+            return self.twisted_dumps({"error": "parameters or type missing"})
+
         if request.args[b'type'][0] == b'request':
             mid_b64 = request.args[b'mid'][0]
             attribute_name = request.args[b'attribute_name'][0]
@@ -178,21 +181,18 @@ class AttestationEndpoint(BaseEndpoint):
                         metadata[cast_to_bin(k)] = cast_to_bin(v)
                     self.attestation_metadata[(self.identity_overlay.my_peer, attribute_name)] = metadata
                 self.attestation_overlay.request_attestation(peer, attribute_name, key, metadata)
-            return b""
-        if request.args[b'type'][0] == b'attest':
+        elif request.args[b'type'][0] == b'attest':
             mid_b64 = request.args[b'mid'][0]
             attribute_name = request.args[b'attribute_name'][0]
             attribute_value_b64 = request.args[b'attribute_value'][0]
             outstanding = self.attestation_requests.pop((mid_b64, attribute_name))
             outstanding[0].callback(b64decode(attribute_value_b64))
-            return b""
-        if request.args[b'type'][0] == b'allow_verify':
+        elif request.args[b'type'][0] == b'allow_verify':
             mid_b64 = request.args[b'mid'][0]
             attribute_name = request.args[b'attribute_name'][0]
             outstanding = self.verify_requests.pop((mid_b64, attribute_name))
             outstanding.callback(True)
-            return b""
-        if request.args[b'type'][0] == b'verify':
+        elif request.args[b'type'][0] == b'verify':
             mid_b64 = request.args[b'mid'][0]
             attribute_hash = b64decode(request.args[b'attribute_hash'][0])
             reference_values = [binary_relativity_sha256_4(b64decode(v))
@@ -203,5 +203,5 @@ class AttestationEndpoint(BaseEndpoint):
                     [(b64decode(v), 0.0) for v in request.args[b'attribute_values'][0].split(b',')]
                 self.attestation_overlay.verify_attestation_values(peer.address, attribute_hash, reference_values,
                                                                    self.on_verification_results)
-            return b""
-        return b""
+
+        return self.twisted_dumps({"success": True})

--- a/ipv8/REST/base_endpoint.py
+++ b/ipv8/REST/base_endpoint.py
@@ -3,6 +3,8 @@ from __future__ import absolute_import
 from twisted.web import resource
 from twisted.web.resource import _computeAllowedMethods
 
+from . import json_util as json
+
 
 class BaseEndpoint(resource.Resource, object):
     """
@@ -12,6 +14,28 @@ class BaseEndpoint(resource.Resource, object):
     def __init__(self):
         resource.Resource.__init__(self)
         object.__init__(self)
+
+    @staticmethod
+    def twisted_dumps(obj, ensure_ascii=True):
+        """
+        Attempt to json.dumps() an object and encode it to convert it to bytes.
+        This method is helpful when returning JSON data in twisted REST calls.
+
+        :param obj: the object to serialize.
+        :param ensure_ascii: allow binary strings to be sent
+        :return: the JSON bytes representation of the object.
+        """
+        return json.dumps(obj, ensure_ascii).encode('utf-8')
+
+    @staticmethod
+    def twisted_loads(s, *args, **kwargs):
+        """
+        Attempt to json.loads() a bytes. This function wraps json.loads, to provide dumps and loads from the same file.
+
+        :param s: the JSON formatted bytes to load objects from.
+        :return: the Python object(s) extracted from the JSON input.
+        """
+        return json.loads(s.decode('utf-8'), *args, **kwargs)
 
     def render_OPTIONS(self, request):
         """

--- a/ipv8/REST/json_util.py
+++ b/ipv8/REST/json_util.py
@@ -1,0 +1,124 @@
+from __future__ import absolute_import
+
+import json
+from collections import Iterable
+
+from six import string_types
+
+__all__ = ['dumps', 'loads']
+
+
+def _is_undumpable(obj):
+    """
+    Check if JSON can dump an object.
+
+    :param obj: the object to check for dumpability
+    :return: the string safe version of the object if undumpable, '' otherwise
+    """
+    try:
+        json.dumps(obj)
+        return ''
+    except UnicodeDecodeError:
+        return repr(obj)
+
+
+def _scan_iterable(obj, context=None):
+    """
+    Scan an object for dumpable members if iterable or the dumpability of itself, given some context.
+
+    This recurses over the obj if it is iterable.
+    Otherwise, it performs an _is_undumpable() check.
+
+    If the object appears to be undumpable, it will extend the return value with its name added to the current context.
+
+    :param obj: the (possibly iterable) object to check for dumpability
+    :param context: the context to report the dumpability of this object for
+    :return: a list of undumpable objects in context, represented as lists
+    """
+    if context is None:
+        context = []
+    out = []
+    # First check if we need to recurse into the children of obj.
+    # Note that there is one type of object we don't want to step into, which is a string object.
+    if not isinstance(obj, string_types) and isinstance(obj, Iterable):
+        for sub in obj:
+            # If we are iterating over a dict, we are iterating over its keys.
+            # 1. We can then give a named trace instead of an anonymous trace
+            # 2. We need to check if the key itself is dumpable
+            if isinstance(obj, dict):
+                undumpable = _is_undumpable(sub)
+                if undumpable:
+                    # We cant dump the key, output "OBJ_CLASS::KEY_NAME"
+                    out += [context + [obj.__class__.__name__ + '::' + repr(sub)]]
+                else:
+                    # Step into this key's value, our context is expanded with "OBJ_CLASS[KEY_NAME]"
+                    out += _scan_iterable(obj[sub], context=context[:]
+                                          + [obj.__class__.__name__ + '[' + str(sub) + ']'])
+            else:
+                # Step into this value, our context is expanded with "OBJ_CLASS"
+                # In JSON the index of the tuple or list entry shouldn't matter much, so we also keep these anonymous
+                out += _scan_iterable(sub, context=context[:] + [obj.__class__.__name__])
+    else:
+        # We can't step into this object, so check if it is dumpable
+        # If it is not, output "OBJ_CLASS::VALUE"
+        undumpable = _is_undumpable(obj)
+        if undumpable:
+            out += [context + [obj.__class__.__name__ + '::' + undumpable]]
+    return out
+
+
+def dump(obj, fp, ensure_ascii=True):
+    """
+    Attempt to json.dump() an object to a 'file'. This function provides additional info if the object can't
+    be serialized.
+
+    :param obj: the object to serialize.
+    :param fp: the file-like object to write to.
+    :param ensure_ascii: allow binary strings to be sent
+    """
+    try:
+        json.dump(obj, fp, ensure_ascii=ensure_ascii)
+    except UnicodeDecodeError as e:
+        undumpables = _scan_iterable(obj)
+        traces = '\n\t'.join(['->'.join(u) for u in undumpables])
+        error = UnicodeDecodeError(e.encoding, str(obj), e.start, e.end, "could not dump:\n\t%s" % traces)
+        error.message = str(error)
+        raise error
+
+
+def dumps(obj, ensure_ascii=True):
+    """
+    Attempt to json.dumps() an object. This function provides additional info if the object can't be serialized.
+
+    :param obj: the object to serialize.
+    :param ensure_ascii: allow binary strings to be sent
+    :return: the JSON str representation of the object.
+    """
+    try:
+        return json.dumps(obj, ensure_ascii=ensure_ascii)
+    except UnicodeDecodeError as e:
+        undumpables = _scan_iterable(obj)
+        traces = '\n\t'.join(['->'.join(u) for u in undumpables])
+        error = UnicodeDecodeError(e.encoding, str(obj), e.start, e.end, "could not dump:\n\t%s" % traces)
+        error.message = str(error)
+        raise error
+
+
+def loads(s, *args, **kwargs):
+    """
+    Attempt to json.loads() a string. This function wraps json.loads, to provide dumps and loads from the same file.
+
+    :param s: the JSON formatted string to load objects from.
+    :return: the Python object(s) extracted from the JSON input.
+    """
+    return json.loads(s, *args, **kwargs)
+
+
+def load(fp, *args, **kwargs):
+    """
+    Attempt to json.load() from a 'file'. This function wraps json.load, to provide dump and load from the same file.
+
+    :param s: the JSON formatted file-like object to load objects from.
+    :return: the Python object(s) extracted from the JSON input.
+    """
+    return json.load(fp, *args, **kwargs)

--- a/ipv8/REST/network_endpoint.py
+++ b/ipv8/REST/network_endpoint.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import
 
 from base64 import b64encode
-import json
 
 from .base_endpoint import BaseEndpoint
 
@@ -29,4 +28,4 @@ class NetworkEndpoint(BaseEndpoint):
         }
 
     def render_GET(self, request):
-        return json.dumps({"peers": self.retrieve_peers()})
+        return self.twisted_dumps({"peers": self.retrieve_peers()})

--- a/ipv8/REST/overlays_endpoint.py
+++ b/ipv8/REST/overlays_endpoint.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import
 
 from binascii import hexlify
-import json
 
 from twisted.web import http
 
@@ -36,7 +35,7 @@ class OverlaysEndpoint(BaseEndpoint):
         return overlay_stats
 
     def render_GET(self, request):
-        return json.dumps({"overlays": self.get_overlays()})
+        return self.twisted_dumps({"overlays": self.get_overlays()})
 
 
 class OverlayStatisticsEndpoint(BaseEndpoint):
@@ -70,7 +69,7 @@ class OverlayStatisticsEndpoint(BaseEndpoint):
         return named_statistics
 
     def render_GET(self, _):
-        return json.dumps({"statistics": self.get_statistics()})
+        return self.twisted_dumps({"statistics": self.get_statistics()})
 
     def render_POST(self, request):
         """
@@ -97,14 +96,14 @@ class OverlayStatisticsEndpoint(BaseEndpoint):
 
         if not self.statistics_supported:
             request.setResponseCode(http.PRECONDITION_FAILED)
-            return json.dumps({"success": False, "error": "StatisticsEndpoint is not enabled."})
+            return self.twisted_dumps({"success": False, "error": "StatisticsEndpoint is not enabled."})
 
         all_overlays = False
         overlay_name = None
 
         if 'enable' not in request.args or not request.args['enable']:
             request.setResponseCode(http.BAD_REQUEST)
-            return json.dumps({"success": False, "error": "Parameter 'enable' is required"})
+            return self.twisted_dumps({"success": False, "error": "Parameter 'enable' is required"})
         else:
             enable = request.args['enable'][0] == 'True'
 
@@ -114,10 +113,10 @@ class OverlayStatisticsEndpoint(BaseEndpoint):
             overlay_name = request.args['overlay_name'][0]
         else:
             request.setResponseCode(http.PRECONDITION_FAILED)
-            return json.dumps({"success": False, "error": "Parameter 'all' or 'overlay_name' is required"})
+            return self.twisted_dumps({"success": False, "error": "Parameter 'all' or 'overlay_name' is required"})
 
         self.enable_overlay_statistics(enable=enable, class_name=overlay_name, all_overlays=all_overlays)
-        return json.dumps({"success": True})
+        return self.twisted_dumps({"success": True})
 
     def enable_overlay_statistics(self, enable=False, class_name=None, all_overlays=False):
         if all_overlays:

--- a/ipv8/REST/rest_manager.py
+++ b/ipv8/REST/rest_manager.py
@@ -1,12 +1,12 @@
 from __future__ import absolute_import
 
-import json
 import logging
 from traceback import format_tb
+
 from twisted.internet import reactor
 from twisted.internet.defer import maybeDeferred
 from twisted.python.compat import intToBytes
-from twisted.web import server, http
+from twisted.web import http, server
 
 from .root_endpoint import RootEndpoint
 from ..taskmanager import TaskManager
@@ -65,7 +65,7 @@ class RESTRequest(server.Request):
         if self.site.displayTracebacks:
             response[u"error"][u"trace"] = format_tb(failure.getTracebackObject())
 
-        body = json.dumps(response)
+        body = self.twisted_dumps(response)
         self.setResponseCode(http.INTERNAL_SERVER_ERROR)
         self.setHeader(b'Content-Type', self.defaultContentType)
         self.setHeader(b'Content-Length', intToBytes(len(body)))

--- a/ipv8/REST/trustchain_endpoint.py
+++ b/ipv8/REST/trustchain_endpoint.py
@@ -1,12 +1,11 @@
 from __future__ import absolute_import
 
 from binascii import unhexlify
-import json
 
 from twisted.web import http
 
-from ..attestation.trustchain.community import TrustChainCommunity
 from .base_endpoint import BaseEndpoint
+from ..attestation.trustchain.community import TrustChainCommunity
 
 
 class TrustchainEndpoint(BaseEndpoint):
@@ -39,8 +38,10 @@ class TrustchainRecentEndpoint(BaseEndpoint):
         if request.args and 'offset' in request.args:
             offset = int(request.args['offset'][0])
 
-        return json.dumps({"blocks": [dict(block) for block in
-                                      self.trustchain.persistence.get_recent_blocks(limit=limit, offset=offset)]})
+        return self.twisted_dumps({
+            "blocks": [dict(block) for block in
+                       self.trustchain.persistence.get_recent_blocks(limit=limit, offset=offset)]
+        })
 
 
 class TrustchainBlocksEndpoint(BaseEndpoint):
@@ -66,12 +67,12 @@ class TrustchainSpecificBlockEndpoint(BaseEndpoint):
     def render_GET(self, request):
         if not self.block_hash:
             request.setResponseCode(http.NOT_FOUND)
-            return json.dumps({"error": "the block with the provided hash could not be found"})
+            return self.twisted_dumps({"error": "the block with the provided hash could not be found"})
 
         block = self.trustchain.persistence.get_block_with_hash(self.block_hash)
         if not block:
             request.setResponseCode(http.NOT_FOUND)
-            return json.dumps({"error": "the block with the provided hash could not be found"})
+            return self.twisted_dumps({"error": "the block with the provided hash could not be found"})
 
         block_dict = dict(block)
 
@@ -80,7 +81,7 @@ class TrustchainSpecificBlockEndpoint(BaseEndpoint):
         if linked_block:
             block_dict["linked"] = dict(linked_block)
 
-        return json.dumps({"block": block_dict})
+        return self.twisted_dumps({"block": block_dict})
 
 
 class TrustchainUsersEndpoint(BaseEndpoint):
@@ -98,7 +99,7 @@ class TrustchainUsersEndpoint(BaseEndpoint):
             limit = int(request.args['limit'][0])
 
         users_info = self.trustchain.persistence.get_users(limit=limit)
-        return json.dumps({"users": users_info})
+        return self.twisted_dumps({"users": users_info})
 
 
 class TrustchainSpecificUserEndpoint(BaseEndpoint):
@@ -124,7 +125,7 @@ class TrustchainSpecificUserBlocksEndpoint(BaseEndpoint):
     def render_GET(self, request):
         if not self.pub_key:
             request.setResponseCode(http.NOT_FOUND)
-            return json.dumps({"error": "the user with the provided public key could not be found"})
+            return self.twisted_dumps({"error": "the user with the provided public key could not be found"})
 
         limit = 100
         if 'limit' in request.args:
@@ -139,4 +140,4 @@ class TrustchainSpecificUserBlocksEndpoint(BaseEndpoint):
                 block_dict['linked'] = dict(linked_block)
             blocks_list.append(block_dict)
 
-        return json.dumps({"blocks": blocks_list})
+        return self.twisted_dumps({"blocks": blocks_list})

--- a/ipv8/REST/tunnel_endpoint.py
+++ b/ipv8/REST/tunnel_endpoint.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import
 
-import json
 from binascii import hexlify
 
 from twisted.web import http
@@ -37,9 +36,9 @@ class TunnelCircuitsEndpoint(BaseEndpoint):
     def render_GET(self, request):
         if not self.tunnels:
             request.setResponseCode(http.NOT_FOUND)
-            return json.dumps({"error": "tunnel community not found"})
+            return self.twisted_dumps({"error": "tunnel community not found"})
 
-        return json.dumps({"circuits": [
+        return self.twisted_dumps({"circuits": [
             {
                 "circuit_id": circuit.circuit_id,
                 "goal_hops": circuit.goal_hops,
@@ -51,7 +50,7 @@ class TunnelCircuitsEndpoint(BaseEndpoint):
                 "bytes_up": circuit.bytes_up,
                 "bytes_down": circuit.bytes_down,
                 "creation_time": circuit.creation_time
-            } for circuit in self.tunnels.circuits.itervalues()]})
+            } for circuit in self.tunnels.circuits.values()]})
 
 
 class TunnelRelaysEndpoint(BaseEndpoint):
@@ -66,9 +65,9 @@ class TunnelRelaysEndpoint(BaseEndpoint):
     def render_GET(self, request):
         if not self.tunnels:
             request.setResponseCode(http.NOT_FOUND)
-            return json.dumps({"error": "tunnel community not found"})
+            return self.twisted_dumps({"error": "tunnel community not found"})
 
-        return json.dumps({"relays": [
+        return self.twisted_dumps({"relays": [
             {
                 "circuit_from": circuit_from,
                 "circuit_to": relay.circuit_id,
@@ -76,7 +75,7 @@ class TunnelRelaysEndpoint(BaseEndpoint):
                 "bytes_up": relay.bytes_up,
                 "bytes_down": relay.bytes_down,
                 "creation_time": relay.creation_time
-            } for circuit_from, relay in self.tunnels.relay_from_to.iteritems()]})
+            } for circuit_from, relay in self.tunnels.relay_from_to.items()]})
 
 
 class TunnelExitsEndpoint(BaseEndpoint):
@@ -91,16 +90,16 @@ class TunnelExitsEndpoint(BaseEndpoint):
     def render_GET(self, request):
         if not self.tunnels:
             request.setResponseCode(http.NOT_FOUND)
-            return json.dumps({"error": "tunnel community not found"})
+            return self.twisted_dumps({"error": "tunnel community not found"})
 
-        return json.dumps({"exits": [
+        return self.twisted_dumps({"exits": [
             {
                 "circuit_from": circuit_from,
                 "enabled": exit_socket.enabled,
                 "bytes_up": exit_socket.bytes_up,
                 "bytes_down": exit_socket.bytes_down,
                 "creation_time": exit_socket.creation_time
-            } for circuit_from, exit_socket in self.tunnels.exit_sockets.iteritems()]})
+            } for circuit_from, exit_socket in self.tunnels.exit_sockets.items()]})
 
 
 class TunnelSwarmsEndpoint(BaseEndpoint):
@@ -115,16 +114,15 @@ class TunnelSwarmsEndpoint(BaseEndpoint):
     def render_GET(self, request):
         if not self.tunnels:
             request.setResponseCode(http.NOT_FOUND)
-            return json.dumps({"error": "tunnel community not found"})
+            return self.twisted_dumps({"error": "tunnel community not found"})
 
-        return json.dumps({"swarms": [
-            {
-                "info_hash": hexlify(swarm.info_hash),
-                "num_seeders": swarm.get_num_seeders(),
-                "num_connections": swarm.get_num_connections(),
-                "num_connections_incomplete": swarm.get_num_connections_incomplete(),
-                "seeding": swarm.seeding,
-                "last_lookup": swarm.last_lookup,
-                "bytes_up": swarm.get_total_up(),
-                "bytes_down": swarm.get_total_down()
-            } for swarm in self.tunnels.swarms.values()]})
+        return self.twisted_dumps({"swarms": [{
+            "info_hash": hexlify(swarm.info_hash),
+            "num_seeders": swarm.get_num_seeders(),
+            "num_connections": swarm.get_num_connections(),
+            "num_connections_incomplete": swarm.get_num_connections_incomplete(),
+            "seeding": swarm.seeding,
+            "last_lookup": swarm.last_lookup,
+            "bytes_up": swarm.get_total_up(),
+            "bytes_down": swarm.get_total_down()
+        } for swarm in self.tunnels.swarms.values()]})


### PR DESCRIPTION
In this commit, I copied the json_util.py file over from Tribler. These methods are used in the IPv8 REST API to encode to/from JSON, in a Python 3-compatible way. I also fixed a few inconsistencies and code style errors.