### PR TITLE
READY: Automatic DHT entry republishing for stored TrustChain block chunks 

### DIFF
--- a/ipv8/REST/dht_endpoint.py
+++ b/ipv8/REST/dht_endpoint.py
@@ -44,6 +44,15 @@ class DHTBlockEndpoint(BaseEndpoint, BlockListener):
     this peer's latest TC block is available
     """
 
+    # A special suffix added after a public key in order to obtain the DHT under which the TC blocks are sored
+    KEY_SUFFIX = b'_BLOCK'
+
+    # The maximal size of a TC block chunk which can be stored in a DHT entry
+    CHUNK_SIZE = MAX_ENTRY_SIZE - DHTBlockPayload.PREAMBLE_OVERHEAD - 1
+
+    # The maximal number of attempts per chunk allowed when publishing a new block
+    ATTEMPT_LIMIT = 3
+    
     def received_block(self, block):
         """
         Wrapper callback method, inherited from the BlockListener abstract class, which will publish the latest
@@ -57,10 +66,6 @@ class DHTBlockEndpoint(BaseEndpoint, BlockListener):
 
     def should_sign(self, block):
         pass
-
-    KEY_SUFFIX = b'_BLOCK'
-    CHUNK_SIZE = MAX_ENTRY_SIZE - DHTBlockPayload.PREAMBLE_OVERHEAD - 1
-    ATTEMPT_LIMIT = 3
 
     def __init__(self, dht, trustchain):
         super(DHTBlockEndpoint, self).__init__()

--- a/ipv8/dht/community.py
+++ b/ipv8/dht/community.py
@@ -467,9 +467,8 @@ class DHTCommunity(Community):
         """
         Republish any TrustChain block chunks which are about to expire in the DHT
         """
-        from ..REST.dht_endpoint import DHTBlockEndpoint
-
-        hashed_dht_key = hashlib.sha1(self.my_peer.public_key.key_to_bin() + DHTBlockEndpoint.KEY_SUFFIX).digest()
+        from ..REST.dht_endpoint import TC_KEY_SUFFIX
+        hashed_dht_key = hashlib.sha1(self.my_peer.public_key.key_to_bin() + TC_KEY_SUFFIX).digest()
 
         # for value in self.storage.get(hashed_dht_key):
         for value in self.storage.items[hashed_dht_key]:

--- a/ipv8/dht/community.py
+++ b/ipv8/dht/community.py
@@ -467,8 +467,9 @@ class DHTCommunity(Community):
         """
         Republish any TrustChain block chunks which are about to expire in the DHT
         """
-        key_suffix = b'_BLOCK'
-        hashed_dht_key = hashlib.sha1(self.my_peer.public_key.key_to_bin() + key_suffix).digest()
+        from ..REST.dht_endpoint import DHTBlockEndpoint
+
+        hashed_dht_key = hashlib.sha1(self.my_peer.public_key.key_to_bin() + DHTBlockEndpoint.KEY_SUFFIX).digest()
 
         # for value in self.storage.get(hashed_dht_key):
         for value in self.storage.items[hashed_dht_key]:

--- a/ipv8/test/REST/dht/test_dht_endpoint.py
+++ b/ipv8/test/REST/dht/test_dht_endpoint.py
@@ -12,7 +12,7 @@ from ...mocking.rest.base import RESTTestBase
 from ...mocking.rest.comunities import TestDHTCommunity, TestTrustchainCommunity
 from ...mocking.rest.rest_api_peer import RestTestPeer
 from ...mocking.rest.rest_peer_communication import string_to_url
-from ....REST.dht_endpoint import DHTBlockEndpoint
+from ....REST.dht_endpoint import DHTBlockEndpoint, TC_KEY_SUFFIX
 from ....attestation.trustchain.community import TrustChainCommunity
 from ....attestation.trustchain.payload import DHTBlockPayload, HalfBlockPayload
 from ....dht.community import DHTCommunity
@@ -98,7 +98,7 @@ class TestDHTEndpoint(RESTTestBase):
         # Manually add a block to the Trustchain
         original_block = TestBlock()
         hash_key = sha1(self.nodes[0].get_keys()['my_peer'].public_key.key_to_bin()
-                        + DHTBlockEndpoint.KEY_SUFFIX).digest()
+                        + TC_KEY_SUFFIX).digest()
 
         yield self.publish_to_DHT(self.nodes[0], hash_key, original_block.pack(), 4536)
 
@@ -167,7 +167,7 @@ class TestDHTEndpoint(RESTTestBase):
         original_block_1 = TestBlock(transaction={1: 'asd'})
         original_block_2 = TestBlock(transaction={1: 'mmm'})
         hash_key = sha1(self.nodes[0].get_keys()['my_peer'].public_key.key_to_bin()
-                        + DHTBlockEndpoint.KEY_SUFFIX).digest()
+                        + TC_KEY_SUFFIX).digest()
 
         # Publish the two blocks under the same key in the first peer
         yield self.publish_to_DHT(self.nodes[0], hash_key, original_block_1.pack(), 4536)
@@ -201,7 +201,7 @@ class TestDHTEndpoint(RESTTestBase):
 
         # Publish the node to the DHT
         hash_key = sha1(self.nodes[0].get_keys()['my_peer'].public_key.key_to_bin()
-                        + DHTBlockEndpoint.KEY_SUFFIX).digest()
+                        + TC_KEY_SUFFIX).digest()
 
         result = yield self.nodes[1].get_overlay_by_class(DHTCommunity).find_values(hash_key)
         self.assertEqual(result, [], "There shouldn't be any blocks for this key")
@@ -234,7 +234,7 @@ class TestDHTEndpoint(RESTTestBase):
 
         # Publish the node to the DHT
         hash_key = sha1(self.nodes[0].get_keys()['my_peer'].public_key.key_to_bin()
-                        + DHTBlockEndpoint.KEY_SUFFIX).digest()
+                        + TC_KEY_SUFFIX).digest()
 
         result = yield self.nodes[1].get_overlay_by_class(DHTCommunity).find_values(hash_key)
         self.assertEqual(result, [], "There shouldn't be any blocks for this key")
@@ -274,7 +274,7 @@ class TestDHTEndpoint(RESTTestBase):
         stored_package = self.nodes[0].get_overlay_by_class(DHTCommunity).serialize_value(raw_data, sign=False)
 
         hash_key = sha1(self.nodes[0].get_keys()['my_peer'].public_key.key_to_bin()
-                        + DHTBlockEndpoint.KEY_SUFFIX).digest()
+                        + TC_KEY_SUFFIX).digest()
         self.nodes[0].get_overlay_by_class(DHTCommunity).add_value(hash_key, stored_package, max_age=0)
 
         # Check the contents under each node
@@ -318,7 +318,7 @@ class TestDHTEndpoint(RESTTestBase):
         stored_package = self.nodes[0].get_overlay_by_class(DHTCommunity).serialize_value(raw_data, sign=False)
 
         hash_key = sha1(self.nodes[0].get_keys()['my_peer'].public_key.key_to_bin()
-                        + DHTBlockEndpoint.KEY_SUFFIX).digest()
+                        + TC_KEY_SUFFIX).digest()
         self.nodes[0].get_overlay_by_class(DHTCommunity).add_value(hash_key, stored_package, max_age=10000)
 
         # Check the contents under each node


### PR DESCRIPTION
This PR addresses one of the issues flagged in #451. TrustChain (TC) block chunks stored in the DHT are now automatically republished when they are close to expiry. To enable this behavior, a `LoopingCall` has been added to `DHTCommunity` which periodically calls the new method `block_chunk_refresh`. The method `block_chunk_refresh` is actually tasked with refreshing the blocks by inspecting the expiry time of each chunk under the node's DHT TC block entries. If `entry.age + TC_BLOCK_DELTA > entry.max_age`, where `TC_BLOCK_DELTA` represents some delta before expiry after which a refresh is eligible, then a refresh is executed on that chunk by calling `_store` on it (the refresh will extend to other nodes as well, which is intended behavior). The current value of `TC_BLOCK_DELTA` is set to `310`. This is just a random value that I chose, and it can be easily changed. The `LoopingCall`'s period is `TC_BLOCK_DELTA - 10 = 300`.