### PR TITLE
Automated Version Update

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     description='The Python implementation of the IPV8 library',
     long_description=long_description,
     long_description_content_type='text/markdown',
-    version='1.7.0',
+    version='1.8.0',
     url='https://github.com/Tribler/py-ipv8',
     package_data={'': ['*.*']},
     packages=find_packages(),


### PR DESCRIPTION
Suggested release message
---
Tag version: 1.8Release title: IPv8 v1.8.990 releaseBody:
Includes the first 990 commits (+96 since v1.7) for IPv8, containing:

Added option in Trustchain database to return connected peers
 - Added TrustchainDB tests in the list of tests file
 - Merge pull request #469 from xoriole/connected_peers

Return connected peers
 - Refactored hidden services
 - Update tunnel community ID
 - Added creation_time in TunnelEndpoint
 - Added find_circuits
 - Cleanup tunnel payloads a bit
 - Use VariablePayload when possible
 - Return locally stored values from DHT when using the ValuesEndpoint
 - Decrease hidden swarm lookup interval
 - Increase DHT value size limit
 - Shorten public keys before announcing introduction points
 - Various fixes for hidden services
 - More hidden services fixes
 - Added source flag to IntroductionPoint
 - Limit number of peers in peers-response + fix circuit cleanup
 - Drop create-e2e messages for unknown seeder keys
 - Ping e2e circuits
 - Fix for unloading PEXCommunity
 - Fix pinging e2e circuits + remove old introduction points from PEXCommunity
 - Some flake8/pylint/python3 fixes
 - Preserve order while gathering DHT results
 - Update DHTCommunity ID
 - Fix incorrect seed counter
 - Enabled long-lived introduction points
 - Small fix for PEXCommunity
 - Lower loglevel for DHT timeouts
 - Isolate PEX peers
 - Added hidden swarm size estimator
 - Slow down PexCommunity walker
 - Performance improvement for tunnel crypto
 - TunnelExitSocket should only resolve the IP address when needed
 - Bypass IPv8 serializer to increase tunnel performance
 - Remove useless code from increase_bytes_sent/received
 - Merge pull request #465 from egbertbouman/hs

Update hidden services
 - Added endpoint adapter for pex communities
 - Merge pull request #470 from qstokkink/mappedep

Added endpoint adapter for pex communities
 - Added more flags to tunnel introduction-request/response
 - Move message_id to the encrypted part of CellPayload
 - Merge pull request #471 from egbertbouman/hs

Introduce peer_flags + encrypt message_id
 - Blocks are now added as a sequence of chunks. A retry mechanism has been written in an effort to ensure that a single failure during a chunk publishing operation will not solely lead to an unpublished block.
 - Made some improvements to the DHT Endpoint code.
 - Changed the render_GET's on_success method such that it uses the request to pass back an error when it doesn't find anything for a specified key. Also renamed the total_blocks variable to total_chunks.
 - The IPv8 serializer is now used to construct the data used for signatures in publishing DHT blocks. The changes affect the dht_endpoint and test_dht_endpoint modules.
 - Removed the redundant use of a find_values call in publish_latest_block. Additionally fixed a small bug in reconstruct_all_blocks, which refers to instantiating an entry in the new_blocks dictionary with an array of empty unicode strings, rather than empty byte strings.
 - Merge pull request #468 from DanGraur/dht_endpoint_improvement_multiple_notifications

Retry mechanism for new TC block publishing to DHT
 - Fix for including public keys of exit nodes in create messages
 - Attempt to speedup circuit creation
 - Fix for create_circuit
 - Merge pull request #472 from egbertbouman/tunnel_fixes

Tunnel fixes
 - Converted implements to implementer
 - Merge pull request #474 from devos50/py3_implementer

Converted implements to implementer
 - Writing key file in binary mode
 - Pylint fixes for ipv8_service.py
 - Merge pull request #475 from devos50/key_file_bytes

Writing key file in binary mode
 - Reading key file in binary mode
 - Merge pull request #476 from devos50/read_keyfile_bytes

Reading key file in binary mode
 - removed bloom filter code
 - Merge pull request #477 from jonay2000/bloomfilter

removed bloom filter code
 - Allow anonymous communities
 - Merge pull request #478 from egbertbouman/anon_communities

Allow anonymous communities
 - Made Attestation/Identity communities anonymous
 - Merge pull request #479 from Tribler/qstokkink-patch-1

Made Attestation/Identity communities anonymous
 - Fix for anonymizing DiscoveryCommunity
 - Merge pull request #480 from egbertbouman/small_fix

Fix for anonymizing DiscoveryCommunity
 - Extract libsodium installation tutorial and add it to README.md
 - Changed get_latest_blocks behaviour

You can now pass a list of block types instead of a single block type.
 - Merge pull request #484 from devos50/changed_get_latest_blocks

Changed get_latest_blocks behaviour
 - Improve libsodium documentation
 - Removed netifaces requirement
 - Merge pull request #487 from qstokkink/remove_netifaces_hard_dependency

Removed netifaces requirement
 - Merge pull request #483 from TimSpeelman/fix_docs_libsodium

Extract libsodium installation tutorial and add it to README.md
 - Ensure anonymized communities ignore traffic received from the socket
 - Properly encoding to/from JSON in Python 3

In this commit, I copied the json_util.py file over from Tribler. These methods are used in the IPv8 REST API to encode to/from JSON, in a Python 3-compatible way. I also fixed a few inconsistencies and code style errors.
 - Merge pull request #488 from egbertbouman/anon_communities

Let anonymous communities only accept traffic from tunnels
 - Merge pull request #481 from devos50/json_twisted

Properly encoding to/from JSON in Python 3
 - Added network isolation endpoint
 - Merge pull request #490 from qstokkink/network_isolation_ep

Added network isolation endpoint
 - Remove python2 specifics from docs and unix tests (#486)

* Remove python2 specifics from docs and unix tests

* Restore test
 - Made isolation ep use ip and port
 - Merge pull request #491 from qstokkink/fix_isolation_colon

Made isolation ep use ip and port
 - Use str on Python 3 for isolated ep
 - Merge pull request #492 from qstokkink/fix_bytes_isolated_addr

Use str on Python 3 for isolated ep
 - Use only one identity by default
 - Addex IPv8 exitnode plugin
 - Merge pull request #493 from qstokkink/exitnode_plugin

Exitnode plugin
 - Added automatic setup.py version incrementer
 - Added option to set exitnode listen port
 - Merge pull request #496 from qstokkink/add_exitnode_port_opt

Added option to set exitnode listen port
 - Merge pull request #495 from qstokkink/add_release_script

Added automatic setup.py version incrementer
 - Immediately walk to new bootstrap node
 - Merge pull request #497 from qstokkink/immediate_bsnode_add

Immediately walk to new bootstrap node
 - Fixed non-existent call in rest manager
 - Merge pull request #499 from qstokkink/fix_twistd_dumps

Fixed non-existent call in rest manager