### PR TITLE
Automated Version Update

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     description='The Python implementation of the IPV8 library',
     long_description=long_description,
     long_description_content_type='text/markdown',
-    version='1.7.0',
+    version='1.8.0',
     url='https://github.com/Tribler/py-ipv8',
     package_data={'': ['*.*']},
     packages=find_packages(),


### PR DESCRIPTION
Suggested release message
---
Tag version: 1.8
Release title: IPv8 v1.8.990 release
Body:
Includes the first 990 commits (+96 since v1.7) for IPv8, containing:

Added option in Trustchain database to return connected peers
 - Added TrustchainDB tests in the list of tests file
 - Refactored hidden services
 - Update tunnel community ID
 - Added creation_time in TunnelEndpoint
 - Added find_circuits
 - Cleanup tunnel payloads a bit
 - Use VariablePayload when possible
 - Return locally stored values from DHT when using the ValuesEndpoint
 - Decrease hidden swarm lookup interval
 - Increase DHT value size limit
 - Shorten public keys before announcing introduction points
 - Various fixes for hidden services
 - More hidden services fixes
 - Added source flag to IntroductionPoint
 - Limit number of peers in peers-response + fix circuit cleanup
 - Drop create-e2e messages for unknown seeder keys
 - Ping e2e circuits
 - Fix for unloading PEXCommunity
 - Fix pinging e2e circuits + remove old introduction points from PEXCommunity
 - Some flake8/pylint/python3 fixes
 - Preserve order while gathering DHT results
 - Update DHTCommunity ID
 - Fix incorrect seed counter
 - Enabled long-lived introduction points
 - Small fix for PEXCommunity
 - Lower loglevel for DHT timeouts
 - Isolate PEX peers
 - Added hidden swarm size estimator
 - Slow down PexCommunity walker
 - Performance improvement for tunnel crypto
 - TunnelExitSocket should only resolve the IP address when needed
 - Bypass IPv8 serializer to increase tunnel performance
 - Remove useless code from increase_bytes_sent/received
 - Added endpoint adapter for pex communities
 - Added more flags to tunnel introduction-request/response
 - Move message_id to the encrypted part of CellPayload
 - Blocks are now added as a sequence of chunks. A retry mechanism has been written in an effort to ensure that a single failure during a chunk publishing operation will not solely lead to an unpublished block.
 - Made some improvements to the DHT Endpoint code.
 - Changed the render_GET's on_success method such that it uses the request to pass back an error when it doesn't find anything for a specified key. Also renamed the total_blocks variable to total_chunks.
 - The IPv8 serializer is now used to construct the data used for signatures in publishing DHT blocks. The changes affect the dht_endpoint and test_dht_endpoint modules.
 - Removed the redundant use of a find_values call in publish_latest_block. Additionally fixed a small bug in reconstruct_all_blocks, which refers to instantiating an entry in the new_blocks dictionary with an array of empty unicode strings, rather than empty byte strings.
 - Fix for including public keys of exit nodes in create messages
 - Attempt to speedup circuit creation
 - Fix for create_circuit
 - Converted implements to implementer
 - Writing key file in binary mode
 - Pylint fixes for ipv8_service.py
 - Reading key file in binary mode
 - removed bloom filter code
 - Allow anonymous communities
 - Made Attestation/Identity communities anonymous
 - Fix for anonymizing DiscoveryCommunity
 - Extract libsodium installation tutorial and add it to README.md
 - Changed get_latest_blocks behaviour

You can now pass a list of block types instead of a single block type.
 - Improve libsodium documentation
 - Removed netifaces requirement
 - Ensure anonymized communities ignore traffic received from the socket
 - Properly encoding to/from JSON in Python 3

In this commit, I copied the json_util.py file over from Tribler. These methods are used in the IPv8 REST API to encode to/from JSON, in a Python 3-compatible way. I also fixed a few inconsistencies and code style errors.
 - Added network isolation endpoint
 - Remove python2 specifics from docs and unix tests (#486)

* Remove python2 specifics from docs and unix tests

* Restore test
 - Made isolation ep use ip and port
 - Use str on Python 3 for isolated ep
 - Use only one identity by default
 - Addex IPv8 exitnode plugin
 - Added automatic setup.py version incrementer
 - Added option to set exitnode listen port
 - Immediately walk to new bootstrap node
 - Fixed non-existent call in rest manager