### PR TITLE
Allocated more time for allow verify

### DIFF
--- a/ipv8/attestation/wallet/caches.py
+++ b/ipv8/attestation/wallet/caches.py
@@ -56,6 +56,10 @@ class ReceiveAttestationVerifyCache(HashCache):
     def on_timeout(self):
         logging.warning("ReceiveAttestationVerify timed out!")
 
+    @property
+    def timeout_delay(self):
+        return 120.0
+
 
 class ReceiveAttestationRequestCache(PeerCache):
     """
@@ -90,6 +94,10 @@ class ProvingAttestationCache(HashCache):
 
     def on_timeout(self):
         logging.warning("ProvingAttestation timed out!")
+
+    @property
+    def timeout_delay(self):
+        return 120.0
 
 
 class PendingChallengeCache(HashCache):


### PR DESCRIPTION
Fixes #513

This bumps up the time you have to allow verification of an attribute to two minutes (previously 10 seconds).

Note: We do not bump this up to two minutes for all HashCaches as suggested in #513, as this would also include the pending challenge-response pairs.