### PR TITLE
Automated Version Update

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from setuptools import find_packages, setup
+from setuptools import setup, find_packages
 
 with open("README.md", "r") as fh:
     long_description = fh.read()
@@ -11,7 +11,7 @@ setup(
     description='The Python implementation of the IPV8 library',
     long_description=long_description,
     long_description_content_type='text/markdown',
-    version='1.7.0',
+    version='1.8.0',
     url='https://github.com/Tribler/py-ipv8',
     package_data={'': ['*.*']},
     packages=find_packages(),


### PR DESCRIPTION
Suggested release message
---
Tag version: 1.8
Release title: IPv8 v1.8.1008 release
Body:
Includes the first 1008 commits (+114 since v1.7) for IPv8, containing:

 - Return connected peers
 - Update hidden services
 - Added endpoint adapter for pex communities
 - Introduce peer_flags + encrypt message_id
 - Retry mechanism for new TC block publishing to DHT
 - Tunnel fixes
 - Converted implements to implementer
 - Writing key file in binary mode
 - Reading key file in binary mode
 - removed bloom filter code
 - Allow anonymous communities
 - Made Attestation/Identity communities anonymous
 - Fix for anonymizing DiscoveryCommunity
 - Changed get_latest_blocks behaviour
 - Removed netifaces requirement
 - Extract libsodium installation tutorial and add it to README.md
 - Let anonymous communities only accept traffic from tunnels
 - Properly encoding to/from JSON in Python 3
 - Added network isolation endpoint
 - Made isolation ep use ip and port
 - Use str on Python 3 for isolated ep
 - Exitnode plugin
 - Added option to set exitnode listen port
 - Added automatic setup.py version incrementer
 - Immediately walk to new bootstrap node
 - Fixed non-existent call in rest manager
 - READY: Fixed import order in setup.py
 - READY: Added retry for busy REST test ports
 - Various fixes
 - Properly finish DHT endpoint requests
 - Added non-blocking DHT peer connect endpoint
 - Changed drop_identity to not drop permanent key data
 - Automatic DHT entry republishing for the latest stored TrustChain block chunks
 - Allocated more time for allow verify