### PR TITLE
Copied ensure_* methods from six 1.12

### DIFF
--- a/ipv8/messaging/anonymization/payload.py
+++ b/ipv8/messaging/anonymization/payload.py
@@ -5,14 +5,12 @@ from struct import pack, unpack_from
 
 from cryptography.exceptions import InvalidTag
 
-from six import ensure_str
-
 from ...messaging.anonymization.tunnel import (CIRCUIT_TYPE_RP_DOWNLOADER, CIRCUIT_TYPE_RP_SEEDER, EXIT_NODE,
                                                EXIT_NODE_SALT, ORIGINATOR, ORIGINATOR_SALT)
 from ...messaging.anonymization.tunnelcrypto import CryptoException
 from ...messaging.lazy_payload import VariablePayload
 from ...messaging.payload import Payload
-from ...util import cast_to_bin, cast_to_chr
+from ...util import cast_to_bin, cast_to_chr, ensure_str
 
 ADDRESS_TYPE_IPV4 = 0x01
 ADDRESS_TYPE_DOMAIN_NAME = 0x02

--- a/ipv8/util.py
+++ b/ipv8/util.py
@@ -3,9 +3,10 @@ from __future__ import absolute_import
 import logging
 import traceback
 
-from six import PY3
+from six import PY2, PY3, binary_type, text_type
 from six.moves.queue import Queue
-from twisted.internet import reactor, defer
+
+from twisted.internet import defer, reactor
 from twisted.python.failure import Failure
 from twisted.python.threadable import isInIOThread
 
@@ -73,3 +74,64 @@ def addCallback(deferred, callback, errback=defaultErrback):
     If no errback is provided, it uses the default errback, which simply logs the failure.
     """
     return deferred.addCallbacks(callback, errback)
+
+
+def ensure_binary(s, encoding='utf-8', errors='strict'):
+    """
+    Copied from six 1.12 source code! Used as (temporary) workaround so we can still use six 1.11.
+
+    Coerce **s** to six.binary_type.
+    For Python 2:
+      - `unicode` -> encoded to `str`
+      - `str` -> `str`
+    For Python 3:
+      - `str` -> encoded to `bytes`
+      - `bytes` -> `bytes`
+    """
+    if isinstance(s, text_type):
+        return s.encode(encoding, errors)
+    elif isinstance(s, binary_type):
+        return s
+    else:
+        raise TypeError("not expecting type '%s'" % type(s))
+
+
+def ensure_str(s, encoding='utf-8', errors='strict'):
+    """
+    Copied from six 1.12 source code! Used as (temporary) workaround so we can still use six 1.11.
+
+    Coerce *s* to `str`.
+    For Python 2:
+      - `unicode` -> encoded to `str`
+      - `str` -> `str`
+    For Python 3:
+      - `str` -> `str`
+      - `bytes` -> decoded to `str`
+    """
+    if not isinstance(s, (text_type, binary_type)):
+        raise TypeError("not expecting type '%s'" % type(s))
+    if PY2 and isinstance(s, text_type):
+        s = s.encode(encoding, errors)
+    elif PY3 and isinstance(s, binary_type):
+        s = s.decode(encoding, errors)
+    return s
+
+
+def ensure_text(s, encoding='utf-8', errors='strict'):
+    """
+    Copied from six 1.12 source code! Used as (temporary) workaround so we can still use six 1.11.
+
+    Coerce *s* to six.text_type.
+    For Python 2:
+      - `unicode` -> `unicode`
+      - `str` -> `unicode`
+    For Python 3:
+      - `str` -> `str`
+      - `bytes` -> decoded to `str`
+    """
+    if isinstance(s, binary_type):
+        return s.decode(encoding, errors)
+    elif isinstance(s, text_type):
+        return s
+    else:
+        raise TypeError("not expecting type '%s'" % type(s))


### PR DESCRIPTION
In this PR, I propose to copy the `ensure_str`, `ensure_binary` and `ensure_text` methods from the six 1.12 source code. By doing so, we are not dependant anymore on six 1.12, which apparently is not propagated sufficiently yet in all package managers. I don't consider this a permanent solution but at least until we get our dependencies in Tribler in order (e.g., `cherrypy`), I think it is the best we can do.