### PR TITLE
Fixed tracker on same subnet connectability

### DIFF
--- a/ipv8/community.py
+++ b/ipv8/community.py
@@ -286,6 +286,9 @@ class Community(EZPackOverlay):
 
         if (payload.wan_introduction_address != ("0.0.0.0", 0)
                 and payload.wan_introduction_address[0] != self.my_estimated_wan[0]):
+            if (payload.lan_introduction_address != ("0.0.0.0", 0)
+                    and self.my_estimated_wan[0] == self.my_estimated_lan[0]):
+                self.network.discover_address(peer, payload.lan_introduction_address, self.master_peer.mid)
             self.network.discover_address(peer, payload.wan_introduction_address, self.master_peer.mid)
         elif (payload.lan_introduction_address != ("0.0.0.0", 0)
               and payload.wan_introduction_address[0] == self.my_estimated_wan[0]):


### PR DESCRIPTION
This PR allows peers to connect to each other if the tracker is running on the same subnet. This is particularly useful for the DAS-5 experiments.