### PR TITLE
Binary decoding in JSON

### DIFF
--- a/ipv8/REST/json_util.py
+++ b/ipv8/REST/json_util.py
@@ -5,7 +5,7 @@ from collections import Iterable
 
 from six import string_types
 
-__all__ = ['dumps', 'loads']
+__all__ = ['dumps', 'loads', 'ensure_serializable']
 
 
 def _is_undumpable(obj):
@@ -122,3 +122,25 @@ def load(fp, *args, **kwargs):
     :return: the Python object(s) extracted from the JSON input.
     """
     return json.load(fp, *args, **kwargs)
+
+
+def ensure_serializable(value):
+    """
+    Returns a serializable value.
+    """
+    if isinstance(value, bytes):
+        return value.decode('utf-8')
+    elif isinstance(value, (tuple, list, set)):
+        return [ensure_serializable(x) for x in value]
+    elif isinstance(value, dict):
+        output_dict = {}
+        for k, v in value.items():
+            if isinstance(k, bytes):
+                k = k.decode('utf-8')
+            if isinstance(v, bytes):
+                v = v.decode('utf-8')
+            if isinstance(v, (dict, tuple, list, set)):
+                v = ensure_serializable(v)
+            output_dict[k] = v
+        return output_dict
+    return value

--- a/ipv8/REST/trustchain_endpoint.py
+++ b/ipv8/REST/trustchain_endpoint.py
@@ -5,6 +5,7 @@ from binascii import unhexlify
 from twisted.web import http
 
 from .base_endpoint import BaseEndpoint
+from ..REST.json_util import ensure_serializable
 from ..attestation.trustchain.community import TrustChainCommunity
 
 
@@ -140,4 +141,4 @@ class TrustchainSpecificUserBlocksEndpoint(BaseEndpoint):
                 block_dict['linked'] = dict(linked_block)
             blocks_list.append(block_dict)
 
-        return self.twisted_dumps({"blocks": blocks_list})
+        return self.twisted_dumps(ensure_serializable({"blocks": blocks_list}))

--- a/ipv8/test/REST/test_json_util.py
+++ b/ipv8/test/REST/test_json_util.py
@@ -1,0 +1,21 @@
+from __future__ import absolute_import
+
+from twisted.trial import unittest
+
+from ....ipv8.REST import json_util as json
+
+
+class TestJson(unittest.TestCase):
+
+    def test_ensure_serialization(self):
+        """
+        Tests json.ensure_serializable() produces the result compatible with json.dumps().
+        """
+        test_dict = {
+            'key1': 'value1',
+            b'binary_key': b'binary_value',
+            'list1': [1, ['2', '3'], {'k1': 'v1', b'k2': b'v2'}],
+            'dict': {'k1': 'v1', b'k2': b'v2', 'list': [1, 2, 3]}
+        }
+
+        json.dumps(json.ensure_serializable(test_dict))


### PR DESCRIPTION
Adds a utility method  `ensure_serializable()` to json_util that decodes binary data sot that the result is compatible with json.dumps(). This utility is used to fix TypeError in `trustchain_endpoint`.

Fixes https://github.com/Tribler/tribler/issues/4845 (Tribler)