### PR TITLE
Fix REST test teardown

### DIFF
--- a/ipv8/test/REST/attestationendpoint/test_attestation_endpoint.py
+++ b/ipv8/test/REST/attestationendpoint/test_attestation_endpoint.py
@@ -23,7 +23,7 @@ class TestAttestationEndpoint(RESTTestBase):
 
     def setUp(self):
         super(TestAttestationEndpoint, self).setUp()
-        self.initialize([(1, RestTestPeer)], HTTPGetRequesterAE(), HTTPPostRequesterAE())
+        self.initialize_configurations([(1, RestTestPeer)], HTTPGetRequesterAE(), HTTPPostRequesterAE())
 
     def create_new_peer(self, peer_cls, port, *args, **kwargs):
         self._create_new_peer_inner(peer_cls, port, [TestAttestationCommunity, TestIdentityCommunity], *args, **kwargs)

--- a/ipv8/test/REST/dht/test_dht_endpoint.py
+++ b/ipv8/test/REST/dht/test_dht_endpoint.py
@@ -26,7 +26,7 @@ class TestDHTEndpoint(RESTTestBase):
 
     def setUp(self):
         super(TestDHTEndpoint, self).setUp()
-        self.initialize([(2, RestTestPeer)], HTTPGetRequesterDHT(), None)
+        self.initialize_configurations([(2, RestTestPeer)], HTTPGetRequesterDHT(), None)
         self.serializer = Serializer()
 
     def create_new_peer(self, peer_cls, port, *args, **kwargs):

--- a/ipv8/test/base.py
+++ b/ipv8/test/base.py
@@ -103,6 +103,9 @@ class TestBase(unittest.TestCase):
             # If we were to hard exit here (through os._exit) we would lose this additional information.
             import signal
             os.kill(os.getpid(), signal.SIGINT)
+            # But sometimes it just flat out refuses to die (sys.exit will also not work in this case).
+            # So we double kill ourselves:
+            os._exit(1)  # pylint: disable=W0212
         t = threading.Thread(target=check_twisted)
         t.daemon = True
         t.start()

--- a/ipv8/test/mocking/rest/rest_api_peer.py
+++ b/ipv8/test/mocking/rest/rest_api_peer.py
@@ -87,7 +87,7 @@ class RestTestPeer(object):
         self._port = port
         self._interface = interface
 
-        self._ipv8 = TestRestIPv8(u'curve25519', port, interface, overlay_classes, memory_dbs)
+        self._ipv8 = TestRestIPv8(u'curve25519', overlay_classes, memory_dbs)
 
         self._rest_manager = RestAPITestWrapper(self._ipv8, self._port, self._interface)
         self._rest_manager.start()
@@ -99,7 +99,7 @@ class RestTestPeer(object):
 
         :return: A tuple[str, int] representing the address of this peer (i.e. the interface and port)
         """
-        return self._ipv8.endpoint.get_address()
+        return self._ipv8.endpoint.wan_address
 
     def add_and_verify_peers(self, peers, replace_default_interface=True):
         """
@@ -160,7 +160,8 @@ class RestTestPeer(object):
         """
         self._ipv8.network.discover_address(peer, (interface, port))
 
-    def close(self):
+    @inlineCallbacks
+    def unload(self):
         """
         Stop the peer
 
@@ -171,7 +172,7 @@ class RestTestPeer(object):
         self._rest_manager.stop()
         self._rest_manager.shutdown_task_manager()
 
-        self._ipv8.unload()
+        yield self._ipv8.unload()
 
     def get_keys(self):
         """


### PR DESCRIPTION
Fixes #583

Additionally:
 - Avoids using the wild bootstrap servers.
 - Uses `TestBase` for unit test management to avoid leaking tests and removing duplicate code.
