### PR TITLE
Automated Version Update

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     description='The Python implementation of the IPV8 library',
     long_description=long_description,
     long_description_content_type='text/markdown',
-    version='1.8.0',
+    version='1.9.0',
     url='https://github.com/Tribler/py-ipv8',
     package_data={'': ['*.*']},
     packages=find_packages(),


### PR DESCRIPTION
Suggested release message
---
Tag version: 1.9
Release title: IPv8 v1.9.1106 release
Body:
Includes the first 1106 commits (+73 since v1.8) for IPv8, containing:

 - Fixed version incrementer one-off
 - Python 3 fixes
 - IPs/hostnames should always be str
 - Added option to disable broadcast for specific blocks
 - Fix boneh exact 0-vector certainty calculation
 - Fixed block type loading from database
 - Copied ensure_* methods from six 1.12
 - Fix hidden services peer discovery
 - Added ping measurements for peers
 - Fixed peer ping median calculation
 - Fixed tracker on same subnet connectability
 - Fixed sleeping on main thread in event loop
 - Fixed references to failure.value.message
 - Added convenience struct for TrustChainBlock creation
 - Updated doc structure for mkdocs
 - Fix loop cancel in strategy LoopingCall
 - Wrapping result of should_sign in maybeDeferred
 - Fixed error when pinging in tunnel community
 - Add irma proof import
 - Changed twistd path in systemd files
 - If a hidden services DHT lookup fails, retry in the next round
 - Support for large block retrieval in DHTs
 - Fix threading issue in create_circuit
 - Network optimizations
 - Fixed blockcache using unwritable buffer name
 - Fix REST test teardown
 - Fixed service cache not checking for verified peers
 - Fixed README.md links