### PR TITLE
Fixed trustchain block iter returning offset

### DIFF
--- a/ipv8/attestation/trustchain/block.py
+++ b/ipv8/attestation/trustchain/block.py
@@ -512,7 +512,7 @@ class TrustChainBlock(object):
             if key == 'key' or key == 'serializer' or key == 'crypto' or key == '_transaction':
                 continue
             if key == 'transaction':
-                yield key, decode(self._transaction, cast_utf8=True)
+                yield key, decode(self._transaction, cast_utf8=True)[1]
             elif isinstance(value, binary_type) and key != "insert_time" and key != "type":
                 yield key, hexlify(value).decode('utf-8')
             else:

--- a/ipv8/test/attestation/trustchain/test_block.py
+++ b/ipv8/test/attestation/trustchain/test_block.py
@@ -797,6 +797,7 @@ class TestTrustChainBlock(unittest.TestCase):
         self.assertSetEqual(set(block_keys), expected_keys)
         # Check for duplicates
         self.assertEqual(len(block_keys), len(expected_keys))
+        self.assertEqual(dict(block)['transaction']['id'], 42)
 
     def test_hash_function(self):
         """


### PR DESCRIPTION
`decode` returns the current stream offset and the decoded object, we were sending both instead of just the output.