### PR TITLE
Made max crawl batch a setting

### DIFF
--- a/ipv8/attestation/trustchain/community.py
+++ b/ipv8/attestation/trustchain/community.py
@@ -543,7 +543,8 @@ class TrustChainCommunity(Community):
             end_seq_num = max(GENESIS_SEQ, last_block.sequence_number + end_seq_num + 1) \
                 if last_block else GENESIS_SEQ
 
-        blocks = self.persistence.crawl(payload.public_key, start_seq_num, end_seq_num, limit=10)
+        blocks = self.persistence.crawl(payload.public_key, start_seq_num, end_seq_num,
+                                        limit=self.settings.max_crawl_batch)
         total_count = len(blocks)
 
         if total_count == 0:

--- a/ipv8/attestation/trustchain/settings.py
+++ b/ipv8/attestation/trustchain/settings.py
@@ -18,3 +18,6 @@ class TrustChainSettings(object):
 
         # Whether we are a crawler (and fetching whole chains)
         self.crawler = False
+
+        # How many blocks at most we allow others to crawl in one batch
+        self.max_crawl_batch = 10


### PR DESCRIPTION
For experiments, we might want to increase this number. By default, it is still 10 but during an experiment, we can increase this number to allow for larger crawl batches.