### PR TITLE
Fixed peer inequality check in Python 2.7

### DIFF
--- a/ipv8/peer.py
+++ b/ipv8/peer.py
@@ -80,7 +80,12 @@ class Peer(object):
     def __eq__(self, other):
         if not isinstance(other, Peer):
             return False
-        return (self.public_key.key_to_bin() == other.public_key.key_to_bin())
+        return self.public_key.key_to_bin() == other.public_key.key_to_bin()
+
+    def __ne__(self, other):
+        if not isinstance(other, Peer):
+            return True
+        return self.public_key.key_to_bin() != other.public_key.key_to_bin()
 
     def __str__(self):
         return 'Peer<%s:%d, %s>' % (self.address[0], self.address[1], b64encode(self.mid).decode('utf-8'))

--- a/ipv8/test/test_peer.py
+++ b/ipv8/test/test_peer.py
@@ -52,7 +52,8 @@ class TestPeer(unittest.TestCase):
         """
         other = Peer(self.peer.key, self.peer.address)
 
-        self.assertEqual(self.peer, other)
+        self.assertTrue(self.peer == other)
+        self.assertFalse(self.peer != other)
 
     def test_peer_inequality_key(self):
         """


### PR DESCRIPTION
In Python 2.7, there is a slightly different behaviour of the not equal operation (!=) compared to Python 3. In particular, in Python 2.7, statements like peerA == peerB would evaluate to True but statements like peerA != peerB would not evaluate to False, due to the absence of a __ne__ method in the Peer class. This PR fixes this issue and modifies an existing test to test this change.