### PR TITLE
Unite system path modifications as __scriptpath__.py files

### DIFF
--- a/scripts/__scriptpath__.py
+++ b/scripts/__scriptpath__.py
@@ -1,0 +1,4 @@
+import pathlib
+import sys
+
+sys.path.insert(1, pathlib.Path(__file__, "..").resolve())

--- a/scripts/exitnode_ipv8_only_plugin.py
+++ b/scripts/exitnode_ipv8_only_plugin.py
@@ -2,12 +2,18 @@
 This script enables to start IPv8 headless.
 """
 import argparse
-import os
 import signal
 import sys
 from asyncio import all_tasks, ensure_future, gather, get_event_loop, sleep
 
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+# Check if we are running from the root directory
+# If not, modify our path so that we can import IPv8
+try:
+    import ipv8
+    del ipv8
+except ImportError:
+    import __scriptpath__  # noqa: F401
+
 
 from ipv8.REST.rest_manager import RESTManager
 from ipv8.configuration import get_default_configuration

--- a/scripts/ipv8_plugin.py
+++ b/scripts/ipv8_plugin.py
@@ -2,12 +2,18 @@
 This script enables to start IPv8 headless.
 """
 import argparse
-import os
 import signal
 import sys
 from asyncio import all_tasks, ensure_future, gather, get_event_loop, sleep
 
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+# Check if we are running from the root directory
+# If not, modify our path so that we can import IPv8
+try:
+    import ipv8
+    del ipv8
+except ImportError:
+    import __scriptpath__  # noqa: F401
+
 
 from ipv8.REST.rest_manager import RESTManager
 from ipv8.configuration import get_default_configuration

--- a/scripts/tracker_plugin.py
+++ b/scripts/tracker_plugin.py
@@ -4,14 +4,20 @@ This script enables to start the tracker.
 Select the port you want to use by setting the `listen_port` command line argument.
 """
 import argparse
-import os
 import random
 import signal
 import sys
 import time
 from asyncio import ensure_future, get_event_loop, sleep
 
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+# Check if we are running from the root directory
+# If not, modify our path so that we can import IPv8
+try:
+    import ipv8
+    del ipv8
+except ImportError:
+    import __scriptpath__  # noqa: F401
+
 
 from ipv8.community import Community
 from ipv8.keyvault.crypto import default_eccrypto

--- a/scripts/trustchain_crawler_plugin.py
+++ b/scripts/trustchain_crawler_plugin.py
@@ -8,7 +8,14 @@ import signal
 import sys
 from asyncio import all_tasks, ensure_future, gather, get_event_loop, sleep
 
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+# Check if we are running from the root directory
+# If not, modify our path so that we can import IPv8
+try:
+    import ipv8
+    del ipv8
+except ImportError:
+    import __scriptpath__  # noqa: F401
+
 
 from ipv8.REST.rest_manager import RESTManager
 from ipv8.attestation.trustchain.settings import TrustChainSettings

--- a/stresstest/__scriptpath__.py
+++ b/stresstest/__scriptpath__.py
@@ -1,0 +1,4 @@
+import pathlib
+import sys
+
+sys.path.insert(1, pathlib.Path(__file__, "..").resolve())

--- a/stresstest/bootstrap_rtt.py
+++ b/stresstest/bootstrap_rtt.py
@@ -1,6 +1,5 @@
 import time
 from asyncio import ensure_future, get_event_loop
-from os import path
 from random import randint
 from socket import gethostbyname
 
@@ -10,8 +9,8 @@ try:
     import ipv8
     del ipv8
 except ImportError:
-    import sys
-    sys.path.append(path.abspath(path.join(path.dirname(__file__), "..")))
+    import __scriptpath__  # noqa: F401
+
 
 from ipv8.community import Community, _DEFAULT_ADDRESSES, _DNS_ADDRESSES
 from ipv8.configuration import get_default_configuration

--- a/stresstest/endpoint_stresstest.py
+++ b/stresstest/endpoint_stresstest.py
@@ -12,8 +12,8 @@ try:
     import ipv8
     del ipv8
 except ImportError:
-    import sys
-    sys.path.append(path.abspath(path.join(path.dirname(__file__), "..")))
+    import __scriptpath__  # noqa: F401
+
 
 from ipv8.configuration import get_default_configuration
 from ipv8.keyvault.crypto import default_eccrypto

--- a/stresstest/peer_discovery.py
+++ b/stresstest/peer_discovery.py
@@ -1,6 +1,5 @@
 import time
 from asyncio import ensure_future, get_event_loop
-from os import path
 from random import randint
 
 # Check if we are running from the root directory
@@ -9,8 +8,7 @@ try:
     import ipv8
     del ipv8
 except ImportError:
-    import sys
-    sys.path.append(path.abspath(path.join(path.dirname(__file__), "..")))
+    import __scriptpath__  # noqa: F401
 
 from ipv8.community import Community
 from ipv8.configuration import get_default_configuration

--- a/stresstest/peer_discovery_defaults.py
+++ b/stresstest/peer_discovery_defaults.py
@@ -1,3 +1,4 @@
+import sys
 import time
 from asyncio import ensure_future, get_event_loop, sleep
 from os import chdir, getcwd, mkdir, path
@@ -9,8 +10,8 @@ try:
     import ipv8
     del ipv8
 except ImportError:
-    import sys
-    sys.path.append(path.abspath(path.join(path.dirname(__file__), "..")))
+    import __scriptpath__  # noqa: F401
+
 
 from ipv8.configuration import get_default_configuration  # pylint: disable=ungrouped-imports
 from ipv8.keyvault.crypto import ECCrypto  # pylint: disable=ungrouped-imports
@@ -58,7 +59,7 @@ async def start_communities():
         configuration['logger']['level'] = "CRITICAL"
         for overlay in configuration['overlays']:
             overlay['walkers'] = [walker for walker in overlay['walkers'] if walker['strategy'] in _WALKERS]
-        workdir = path.abspath(path.join(path.dirname(__file__), "%d" % i))
+        workdir = path.abspath(path.join(path.dirname(__file__), str(i)))
         if not path.exists(workdir):
             mkdir(workdir)
         chdir(workdir)


### PR DESCRIPTION
Instead of modifying system path on a per-module basis it is instead modified in a __scriptpath__.py file that is imported into the desired module.

In addition instead of appending into the system path the modification inserts into it to prevent path overrides.

Fixes #642 