### PR TITLE
Replace lambdas with functions

### DIFF
--- a/ipv8/attestation/trustchain/block.py
+++ b/ipv8/attestation/trustchain/block.py
@@ -8,7 +8,6 @@ from ...database import database_blob
 from ...keyvault.crypto import default_eccrypto
 from ...messaging.deprecated.encoding import decode, encode
 from ...messaging.serialization import default_serializer
-from ...util import old_round
 
 GENESIS_HASH = b'0' * 32  # ID of the first block of the chain.
 GENESIS_SEQ = 1
@@ -105,7 +104,7 @@ class TrustChainBlock(object):
             # validation
             self.previous_hash = GENESIS_HASH
             self.signature = EMPTY_SIG
-            self.timestamp = int(old_round(time.time() * 1000))
+            self.timestamp = int(time.time() * 1000)
             # debug stuff
             self.insert_time = None
         else:

--- a/ipv8/util.py
+++ b/ipv8/util.py
@@ -1,5 +1,4 @@
 import logging
-import math
 import operator
 import struct
 from asyncio import Future, iscoroutine
@@ -9,10 +8,24 @@ maximum_integer = 2147483647
 
 int2byte = struct.Struct(">B").pack
 byte2int = operator.itemgetter(0)
-cast_to_unicode = lambda x: "".join([chr(c) for c in x]) if isinstance(x, bytes) else str(x)
-cast_to_bin = lambda x: x if isinstance(x, bytes) else bytes([ord(c) for c in x])
-cast_to_chr = lambda x: "".join([chr(c) for c in x])
-old_round = lambda x: float(math.floor((x) + math.copysign(0.5, x)))
+
+
+def cast_to_unicode(obj):
+    if isinstance(obj, (bytes, bytearray)):
+        return "".join(chr(c) for c in obj)
+    if isinstance(obj, str):
+        return obj
+    return str(obj)
+
+
+def cast_to_bin(obj):
+    if isinstance(obj, bytes):
+        return obj
+    return bytes(ord(c) for c in obj)
+
+
+def cast_to_chr(obj):
+    return "".join(chr(c) for c in obj)
 
 
 def succeed(result):


### PR DESCRIPTION
Replace lambdas with functions. Remove a use of `old_round` (total removal depends on Tribler/tribler#5024 and Tribler/anydex-core#31). ~~Other minor refractoring: removing the redundant `u` prefix from strings; remove cast_to_* functions when it is immediately clear how to manipulate the data.~~

Fixes #651.