### PR TITLE
Filter peers by community in RandomWalk strategy

### DIFF
--- a/ipv8/peerdiscovery/discovery.py
+++ b/ipv8/peerdiscovery/discovery.py
@@ -71,7 +71,7 @@ class RandomWalk(DiscoveryStrategy):
             if self.window_size and self.window_size > 0 and len(self.intro_timeouts) >= self.window_size:
                 return
             # Take step
-            known = self.overlay.network.get_walkable_addresses()
+            known = self.overlay.get_walkable_addresses()
             available = list(set(known) - set(self.intro_timeouts.keys()))
 
             # We can get stuck in an infinite loop of unreachable peers if we never contact the tracker again


### PR DESCRIPTION
Currently, the `RandomWalk` discovery strategy tries to send an introduction request to a random verified peer in each step, not considering if the requested community is actually supported by that peer. This PR introduces filtering, so only peers that are members of the community are contacted.