### PR TITLE
Automated Version Update

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     description='The Python implementation of the IPV8 library',
     long_description=long_description,
     long_description_content_type='text/markdown',
-    version='1.9.0',
+    version='1.10.0',
     url='https://github.com/Tribler/py-ipv8',
     package_data={'': ['*.*']},
     packages=find_packages(),


### PR DESCRIPTION
Fixes #616

Suggested release message
---
Tag version: 1.10
Release title: IPv8 v1.10.1167 release
Body:
Includes the first 1167 commits (+61 since v1.9) for IPv8, containing:

 - Added support for trackers on same subnet
 - Added utf-8 decoding for deprecated custom encoding
 - Added multiple attestation requesting
 - Fixed trustchain block iter returning offset
 - Fix puncture without DiscoveryCommunity
 - Made max crawl batch a setting
 - Converted md docs to rst
 - Fixed links in docs
 - Made docs Read the Docs compatible
 - Ported Android prototype docs
 - Added IPv8 configuration docs
 - Added keys documentation
 - Added serialization documentation
 - Minor fixes to documentation
 - Eliminated use of random.randint for IRMA
 - Added VariablePayload compilation decorator
 - Docs IPv8 features, Why does IPv8 exist?
 - Binding on_should_sign_outcome lambda variables at runtime
 - Fix dictionary changed size errors
 - Make TunnelCrypto compatible with libnacl 1.7
 - Fixed bootstrap test wrong assertion
 - Fix IRMA build_proofs test
 - Updated project requirements
 - Clarified half blocks in TrustChain documentation
 - Fixed peer inequality check in Python 2.7
 - Switched verified_peers to set datastructure
 - Fixed readthedocs links
 - Filter peers by community in RandomWalk strategy