### PR TITLE
Added basic tests for the DataChecker class

### DIFF
--- a/ipv8/test/messaging/anonymization/test_datachecker.py
+++ b/ipv8/test/messaging/anonymization/test_datachecker.py
@@ -1,0 +1,28 @@
+from binascii import unhexlify
+
+from ...base import TestBase
+from ....messaging.anonymization.tunnel import DataChecker
+
+
+class TestDataChecker(TestBase):
+
+    def setUp(self):
+        super(TestDataChecker, self).setUp()
+
+    def test_could_be_dht_correct(self):
+        """
+        Check if a valid DHT packet is correctly identified.
+        """
+        pkt = b"64313a6164323a696432303a3b2cb14348257b7a481f7010ca7c519b8bef5086393a696e666f5f6861736832303af84b51" \
+              b"f0d2c3455ab5dabb6643b4340234cd036e65313a71393a6765745f7065657273313a74323ae037313a76343a4c54010131" \
+              b"3a79313a7165"
+        self.assertTrue(DataChecker.is_allowed(unhexlify(pkt)))
+
+    def test_could_be_dht_incorrect(self):
+        """
+        Check if an invalid DHT packet is correctly identified.
+        """
+        pkt = b"63313a6164323a696432303a3b2cb14348257b7a481f7010ca7c519b8bef5086393a696e666f5f6861736832303af84b51" \
+              b"f0d2c3455ab5dabb6643b4340234cd036e65313a71393a6765745f7065657273313a74323ae037313a76343a4c54010131" \
+              b"3a79313a7165"
+        self.assertFalse(DataChecker.is_allowed(unhexlify(pkt)))

--- a/test_classes_list.txt
+++ b/test_classes_list.txt
@@ -38,6 +38,7 @@ ipv8/test/messaging/deprecated/test_encoding.py:TestEncoding
 ipv8/test/messaging/interfaces/udp/test_endpoint.py:TestUDPEndpoint
 ipv8/test/messaging/anonymization/test_community.py:TestTunnelCommunity
 ipv8/test/messaging/anonymization/test_hiddenservices.py:TestHiddenServices
+ipv8/test/messaging/anonymization/test_datachecker.py:TestDataChecker
 
 ipv8/test/dht/test_community.py:TestDHTCommunity
 ipv8/test/dht/test_discovery.py:TestDHTDiscoveryCommunity


### PR DESCRIPTION
While I was debugging the libtorrent data checker, I wrote this basic test, so I thought I could as well add it to the IPv8 code base 👍 

Note that these tests only verify libtorrent DHT packets. We should probably also add some tests for UTP data later.