### PR TITLE
Fix block broadcast in TrustChain

### DIFF
--- a/ipv8/attestation/trustchain/community.py
+++ b/ipv8/attestation/trustchain/community.py
@@ -143,8 +143,8 @@ class TrustChainCommunity(Community):
             self.logger.debug("Broadcasting block %s", block)
             payload = HalfBlockBroadcastPayload.from_half_block(block, ttl).to_pack_list()
             packet = self._ez_pack(self._prefix, 5, [dist, payload], False)
-            for peer in random.sample(self.network.verified_peers, min(len(self.network.verified_peers),
-                                                                       self.settings.broadcast_fanout)):
+            peers = self.get_peers()
+            for peer in random.sample(peers, min(len(peers), self.settings.broadcast_fanout)):
                 self.endpoint.send(peer.address, packet)
             self.relayed_broadcasts.append(block.block_id)
 
@@ -164,8 +164,8 @@ class TrustChainCommunity(Community):
             self.logger.debug("Broadcasting blocks %s and %s", block1, block2)
             payload = HalfBlockPairBroadcastPayload.from_half_blocks(block1, block2, ttl).to_pack_list()
             packet = self._ez_pack(self._prefix, 6, [dist, payload], False)
-            for peer in random.sample(self.network.verified_peers, min(len(self.network.verified_peers),
-                                                                       self.settings.broadcast_fanout)):
+            peers = self.get_peers()
+            for peer in random.sample(peers, min(len(peers), self.settings.broadcast_fanout)):
                 self.endpoint.send(peer.address, packet)
             self.relayed_broadcasts.append(block1.block_id)
 

--- a/ipv8/test/base.py
+++ b/ipv8/test/base.py
@@ -43,7 +43,7 @@ class TestBase(asynctest.TestCase):
                 private_peer = other.my_peer
                 public_peer = Peer(private_peer.public_key, private_peer.address)
                 node.network.add_verified_peer(public_peer)
-                node.network.discover_services(public_peer, overlay_class.master_peer.mid)
+                node.network.discover_services(public_peer, [overlay_class.master_peer.mid])
 
     def setUp(self):
         super(TestBase, self).setUp()


### PR DESCRIPTION
Currently, the block is being broadcasted to random peers in the network. This PR filters only peers participating in TrustChain community.

Additionally, service discovery was broken in tests due to a type error, which originally caused some tests to fail after this change.