### PR TITLE
Fix decrementing TTL when received block broadcast

### DIFF
--- a/ipv8/attestation/trustchain/community.py
+++ b/ipv8/attestation/trustchain/community.py
@@ -301,11 +301,10 @@ class TrustChainCommunity(Community):
         """
         We received a half block, part of a broadcast. Disseminate it further.
         """
-        payload.ttl -= 1
         block = self.get_block_class(payload.type).from_payload(payload, self.serializer)
         self.validate_persist_block(block)
 
-        if block.block_id not in self.relayed_broadcasts and payload.ttl > 0:
+        if block.block_id not in self.relayed_broadcasts and payload.ttl > 1:
             self.send_block(block, ttl=payload.ttl - 1)
 
     @synchronized

--- a/ipv8/attestation/trustchain/community.py
+++ b/ipv8/attestation/trustchain/community.py
@@ -323,12 +323,11 @@ class TrustChainCommunity(Community):
         """
         We received a half block pair, part of a broadcast. Disseminate it further.
         """
-        payload.ttl -= 1
         block1, block2 = self.get_block_class(payload.type1).from_pair_payload(payload, self.serializer)
         self.validate_persist_block(block1)
         self.validate_persist_block(block2)
 
-        if block1.block_id not in self.relayed_broadcasts and payload.ttl > 0:
+        if block1.block_id not in self.relayed_broadcasts and payload.ttl > 1:
             self.send_block_pair(block1, block2, ttl=payload.ttl - 1)
 
     def validate_persist_block(self, block):

--- a/ipv8/test/attestation/trustchain/test_community.py
+++ b/ipv8/test/attestation/trustchain/test_community.py
@@ -344,6 +344,15 @@ class TestTrustChainCommunity(TestBase):
         self.assertIn(block1.block_id, self.nodes[1].overlay.relayed_broadcasts)
         self.assertNotIn(block1.block_id, node3.overlay.relayed_broadcasts)
 
+        # TTL=3 (should be relayed twice)
+        block1 = TestBlock()
+        block2 = TestBlock()
+        self.nodes[0].overlay.send_block_pair(block1, block2, ttl=3)
+        await self.deliver_messages()
+        self.assertIn(block1.block_id, self.nodes[0].overlay.relayed_broadcasts)
+        self.assertIn(block1.block_id, self.nodes[1].overlay.relayed_broadcasts)
+        self.assertIn(block1.block_id, node3.overlay.relayed_broadcasts)
+
     async def test_intro_response_crawl(self):
         """
         Test whether we crawl a node when receiving an introduction response

--- a/ipv8/test/attestation/trustchain/test_community.py
+++ b/ipv8/test/attestation/trustchain/test_community.py
@@ -308,6 +308,14 @@ class TestTrustChainCommunity(TestBase):
         self.assertIn(block.block_id, self.nodes[1].overlay.relayed_broadcasts)
         self.assertNotIn(block.block_id, node3.overlay.relayed_broadcasts)
 
+        # TTL=3 (should be relayed twice)
+        block = TestBlock()
+        self.nodes[0].overlay.send_block(block, ttl=3)
+        await self.deliver_messages()
+        self.assertIn(block.block_id, self.nodes[0].overlay.relayed_broadcasts)
+        self.assertIn(block.block_id, self.nodes[1].overlay.relayed_broadcasts)
+        self.assertIn(block.block_id, node3.overlay.relayed_broadcasts)
+
     async def test_broadcast_half_block_pair(self):
         """
         Test broadcasting a half block pair


### PR DESCRIPTION
Currently, TTL is decremented by 2 whenever a block is received. This PR fixes it and adds a test that fails before this change.