### PR TITLE
Fix removing inactive peers from tracker

### DIFF
--- a/scripts/tracker_plugin.py
+++ b/scripts/tracker_plugin.py
@@ -36,9 +36,12 @@ class SimpleChurn(DiscoveryStrategy):
     def take_step(self):
         with self.walk_lock:
             with self.overlay.network.graph_lock:
-                for peer in self.overlay.network.verified_peers.copy():
+                to_remove = []
+                for peer in self.overlay.network.verified_peers:
                     if time.time() - peer.last_response > 120:
-                        self.overlay.network.remove_peer(peer)
+                        to_remove.append(peer)
+                for peer in to_remove:
+                    self.overlay.network.remove_peer(peer)
 
 
 class EndpointServer(Community):

--- a/scripts/tracker_plugin.py
+++ b/scripts/tracker_plugin.py
@@ -36,7 +36,7 @@ class SimpleChurn(DiscoveryStrategy):
     def take_step(self):
         with self.walk_lock:
             with self.overlay.network.graph_lock:
-                for peer in self.overlay.network.verified_peers:
+                for peer in self.overlay.network.verified_peers.copy():
                     if time.time() - peer.last_response > 120:
                         self.overlay.network.remove_peer(peer)
 


### PR DESCRIPTION
Inactive peers are currently not being removed from the tracker due to a bug in `SimpleChurn` strategy. The churn task crashes when the first peer is removed. This results in very inefficient peer discovery and a memory leak.

```
Exception in callback TaskManager.register_task.<locals>.done_cb(<Task finishe...g iteration')>) at /Users/matt/Development/Projects/py-ipv8/ipv8/taskmanager.py:101
handle: <Handle TaskManager.register_task.<locals>.done_cb(<Task finishe...g iteration')>) at /Users/matt/Development/Projects/py-ipv8/ipv8/taskmanager.py:101>
Traceback (most recent call last):
  File "/usr/local/Cellar/python/3.7.5/Frameworks/Python.framework/Versions/3.7/lib/python3.7/asyncio/events.py", line 88, in _run
    self._context.run(self._callback, *self._args)
  File "/Users/matt/Development/Projects/py-ipv8/ipv8/taskmanager.py", line 104, in done_cb
    future.result()
  File "/Users/matt/Development/Projects/py-ipv8/ipv8/taskmanager.py", line 13, in interval_runner
    await task(*args)
  File "/usr/local/Cellar/python/3.7.5/Frameworks/Python.framework/Versions/3.7/lib/python3.7/asyncio/coroutines.py", line 120, in coro
    res = func(*args, **kw)
  File "scripts/tracker_plugin.py", line 40, in take_step
    for peer in self.overlay.network.verified_peers:
RuntimeError: Set changed size during iteration
```
