### PR TITLE
Fix TrustChain genesis block invariant validation

### DIFF
--- a/ipv8/attestation/trustchain/block.py
+++ b/ipv8/attestation/trustchain/block.py
@@ -345,11 +345,10 @@ class TrustChainBlock(object):
         if self.public_key == self.link_public_key:
             # Blocks to self serve no purpose and are thus invalid.
             result.err("Self signed block")
-        if self.is_genesis:
-            if self.sequence_number == GENESIS_SEQ and self.previous_hash != GENESIS_HASH:
-                result.err("Sequence number implies previous hash should be Genesis ID")
-            if self.sequence_number != GENESIS_SEQ and self.previous_hash == GENESIS_HASH:
-                result.err("Sequence number implies previous hash should not be Genesis ID")
+        if self.sequence_number == GENESIS_SEQ and self.previous_hash != GENESIS_HASH:
+            result.err("Sequence number implies previous hash should be Genesis ID")
+        if self.sequence_number != GENESIS_SEQ and self.previous_hash == GENESIS_HASH:
+            result.err("Sequence number implies previous hash should not be Genesis ID")
 
     def update_block_consistency(self, blk, result, database):
         """

--- a/ipv8/test/attestation/trustchain/test_block.py
+++ b/ipv8/test/attestation/trustchain/test_block.py
@@ -418,6 +418,7 @@ class TestTrustChainBlock(asynctest.TestCase):
         block = TestBlock()
         block.sequence_number = GENESIS_SEQ
         block.previous_hash = b"abcdefg"
+        block.sign(block.key)
         block.update_block_invariant(None, result)
 
         self.assertEqual(ValidationResult.invalid, result.state)
@@ -430,6 +431,7 @@ class TestTrustChainBlock(asynctest.TestCase):
         block = TestBlock()
         block.sequence_number = 2
         block.previous_hash = GENESIS_HASH
+        block.sign(block.key)
         block.update_block_invariant(None, result)
 
         self.assertEqual(ValidationResult.invalid, result.state)


### PR DESCRIPTION
The `is_genesis` condition in `update_block_invariant` prevented the sub-conditions to ever be evaluated true.

The tests were not failing only because the validation result was still invalid due to an invalid signature.