### PR TITLE
Fix memory leak in TaskManager by using weak references

### DIFF
--- a/ipv8/taskmanager.py
+++ b/ipv8/taskmanager.py
@@ -3,6 +3,7 @@ from asyncio import CancelledError, Future, Task, coroutine, ensure_future, gath
 from contextlib import suppress
 from functools import wraps
 from threading import RLock
+from weakref import WeakValueDictionary
 
 from .util import succeed
 
@@ -43,7 +44,7 @@ class TaskManager(object):
     """
 
     def __init__(self):
-        self._pending_tasks = {}
+        self._pending_tasks = WeakValueDictionary()
         self._task_lock = RLock()
         self._shutdown = False
         self._counter = 0


### PR DESCRIPTION
Leaving Tribler Core running over a night subscribed for 300 channels (constantly trying to download these, but unable to) shows a memory leak of about 40 Mb per hour. Printing memory usage stats regularly with `mem_top` package shows the leak is caused by `weakref`s for  `_asyncio.Task`s accumulating in a set. What probably happens is `_pending_tasks` keeping the references and not releasing them in some cases, such as timeouts, etc.

By making `TaskManager` use `WeakValueDictionary` the accumulation stops. `mem_top` shows no signs of `weakref` leak. Over the night, the total memory usage stabilises at 260Mb, that is only 120 Mb more than the starting RAM usage.