### PR TITLE
Correct the fallback argument for 'id_metadata'

### DIFF
--- a/ipv8/REST/attestation_endpoint.py
+++ b/ipv8/REST/attestation_endpoint.py
@@ -278,7 +278,7 @@ class AttestationEndpoint(BaseEndpoint):
         if args['type'] == 'request':
             mid_b64 = args['mid']
             attribute_name = args['attribute_name']
-            id_format = args.get('id_format', ['id_metadata'])
+            id_format = args.get('id_format', 'id_metadata')
             peer = self.get_peer_from_mid(mid_b64)
             if peer:
                 key = self.attestation_overlay.get_id_algorithm(id_format).generate_secret_key()


### PR DESCRIPTION
## General
If the `id_metadata` argument is not given for the `/attestation` endpoint the default is now set to `['id_metadata']`. However, this causes a TypeError in https://github.com/Tribler/py-ipv8/blob/master/ipv8/attestation/wallet/community.py#L96 since a string is expected as key  to retreive the correct vale of the `FORMATS` list.

## How to test this PR
1. Follow the [Attestation Tutorial](https://py-ipv8.readthedocs.io/en/latest/basics/attestation_tutorial/#enrollment-attestation-flow) up to the first step, a POST to `/attestation`
2. Verify that the following error occures:
```
File "/home/niels/Documents/ipv8/pyipv8/ipv8/attestation/wallet/community.py", line 96, in get_id_algorithm
    return ID_ALGORITHMS[FORMATS[id_format]["algorithm"]](id_format)
TypeError: unhashable type: 'list'
```
3. Apply the PR and verify that the error is solved and the output is a success message:
```json
{
    "success": true
}
```