### PR TITLE
Used prefix mapping for endpoint

### DIFF
--- a/ipv8/community.py
+++ b/ipv8/community.py
@@ -71,6 +71,8 @@ class Community(EZPackOverlay):
         super(Community, self).__init__(self.master_peer, my_peer, endpoint, network)
 
         self._prefix = b'\x00' + self.version + self.master_peer.mid
+        self.endpoint.remove_listener(self)
+        self.endpoint.add_prefix_listener(self, self._prefix)
         self.logger.debug("Launching %s with prefix %s.", self.__class__.__name__, hexlify(self._prefix))
 
         self.max_peers = max_peers

--- a/ipv8/messaging/anonymization/hidden_services.py
+++ b/ipv8/messaging/anonymization/hidden_services.py
@@ -17,7 +17,7 @@ from .tunnel import (CIRCUIT_ID_PORT, CIRCUIT_TYPE_IP_SEEDER, CIRCUIT_TYPE_RP_DO
                      EXIT_NODE, EXIT_NODE_SALT, Hop, IntroductionPoint, PEER_SOURCE_DHT, PEER_SOURCE_PEX, RelayRoute,
                      RendezvousPoint, Swarm, TunnelExitSocket)
 from ...keyvault.public.libnaclkey import LibNaCLPK
-from ...messaging.anonymization.pex import PexCommunity, PexEndpointAdapter
+from ...messaging.anonymization.pex import PexCommunity
 from ...messaging.deprecated.encoding import decode, encode
 from ...peer import Peer
 from ...peerdiscovery.discovery import RandomWalk
@@ -34,7 +34,6 @@ class HiddenTunnelCommunity(TunnelCommunity):
 
         self.swarms = {}
         self.pex = {}
-        self.pex_ep_adapter = PexEndpointAdapter(self.ipv8.endpoint) if self.ipv8 else None
 
         super(HiddenTunnelCommunity, self).__init__(*args, **kwargs)
 
@@ -481,9 +480,7 @@ class HiddenTunnelCommunity(TunnelCommunity):
         if not self.ipv8:
             self.logger.error('No IPv8 service object available, cannot start PEXCommunity')
         elif payload.info_hash not in self.pex:
-            if not self.pex_ep_adapter:
-                self.pex_ep_adapter = PexEndpointAdapter(self.ipv8.endpoint)
-            community = PexCommunity(self.my_peer, self.pex_ep_adapter, Network(), info_hash=payload.info_hash)
+            community = PexCommunity(self.my_peer, self.endpoint, Network(), info_hash=payload.info_hash)
             self.ipv8.overlays.append(community)
             # Since IPv8 takes a step every .5s until we have 10 peers, the PexCommunity will generate
             # a lot of traffic in case there are <10 peers in existence. Therefore, we slow the walk down to a 5s/step.

--- a/ipv8/messaging/anonymization/pex.py
+++ b/ipv8/messaging/anonymization/pex.py
@@ -5,50 +5,7 @@ from collections import deque
 from ...community import Community
 from ...messaging.anonymization.tunnel import IntroductionPoint, PEER_SOURCE_PEX
 from ...messaging.deprecated.encoding import decode, encode
-from ...messaging.interfaces.endpoint import Endpoint, EndpointListener
 from ...peer import Peer
-
-
-class PexEndpointAdapter(Endpoint, EndpointListener):
-
-    def __init__(self, master):
-        Endpoint.__init__(self)
-        EndpointListener.__init__(self, master)
-        self.master = master
-        self.master.add_listener(self)
-        self._listeners = {}
-        self._port = 0
-
-    def add_listener(self, listener):
-        self._listeners[listener.get_prefix()] = listener
-
-    def remove_listener(self, listener):
-        self._listeners.pop(listener.get_prefix(), None)
-
-    def on_packet(self, packet):
-        listener = self._listeners.get(packet[1][:22], None)
-        if listener:
-            listener.on_packet(packet)
-
-    def assert_open(self):
-        self.master.assert_open()
-
-    def is_open(self):
-        return self.master.is_open()
-
-    def get_address(self):
-        return self.master.get_address()
-
-    def send(self, socket_address, packet):
-        self.master.send(socket_address, packet)
-
-    def open(self):
-        out = self.master.open()
-        self._port = self.master._port
-        return out
-
-    def close(self):
-        return self.master.close()
 
 
 class PexMasterPeer(object):

--- a/ipv8/test/mocking/endpoint.py
+++ b/ipv8/test/mocking/endpoint.py
@@ -34,8 +34,7 @@ class MockEndpoint(Endpoint):
         if socket_address in internet:
             # For the unit tests we handle messages in separate asyncio tasks to prevent infinite recursion.
             ep = internet[socket_address]
-            for listener in ep._listeners:
-                get_event_loop().call_soon(ep._deliver_later, listener, (self.wan_address, packet))
+            get_event_loop().call_soon(ep.notify_listeners, (self.wan_address, packet))
         else:
             raise AssertionError("Received data from unregistered address %s" % repr(socket_address))
 


### PR DESCRIPTION
This prefers to use prefix mapping instead of always looping through all listeners.

Also fixed a bug where the `AttestationCommunity` had a module-level lock instead of an instance-level lock.