### PR TITLE
WIP: Used bytearray for packets internally

### DIFF
--- a/ipv8/lazy_community.py
+++ b/ipv8/lazy_community.py
@@ -29,7 +29,7 @@ def lazy_wrapper(*payloads):
         def wrapper(self, source_address, data):
             # UNPACK
             auth, remainder = self.serializer.unpack_to_serializables([BinMemberAuthenticationPayload, ], data[23:])
-            signature_valid, remainder = self._verify_signature(auth, data)
+            signature_valid, remainder = self._verify_signature(auth, bytes(data))
             unpacked = self.serializer.ez_unpack_serializables(payloads, remainder[23:])
             # ASSERT
             if not signature_valid:
@@ -64,7 +64,7 @@ def lazy_wrapper_wd(*payloads):
         def wrapper(self, source_address, data):
             # UNPACK
             auth, remainder = self.serializer.unpack_to_serializables([BinMemberAuthenticationPayload, ], data[23:])
-            signature_valid, remainder = self._verify_signature(auth, data)
+            signature_valid, remainder = self._verify_signature(auth, bytes(data))
             unpacked = self.serializer.ez_unpack_serializables(payloads, remainder[23:])
             # ASSERT
             if not signature_valid:
@@ -204,12 +204,12 @@ class EZPackOverlay(Overlay):
         signature_length = ec.get_signature_length(public_key)
         remainder = data[2 + len(auth.public_key_bin):-signature_length]
         signature = data[-signature_length:]
-        return ec.is_valid_signature(public_key, data[:-signature_length], signature), remainder
+        return ec.is_valid_signature(public_key, bytes(data[:-signature_length]), bytes(signature)), remainder
 
     def _ez_unpack_auth(self, payload_class, data):
         # UNPACK
         auth, remainder = self.serializer.unpack_to_serializables([BinMemberAuthenticationPayload, ], data[23:])
-        signature_valid, remainder = self._verify_signature(auth, data)
+        signature_valid, remainder = self._verify_signature(auth, bytes(data))
         format = [GlobalTimeDistributionPayload, payload_class]
         dist, payload = self.serializer.ez_unpack_serializables(format, remainder[23:])
         # ASSERT

--- a/ipv8/messaging/anonymization/payload.py
+++ b/ipv8/messaging/anonymization/payload.py
@@ -172,7 +172,7 @@ class CellPayload(object):
     @classmethod
     def from_bin(cls, packet):
         circuit_id, plaintext = unpack_from('!I?', packet, 23)
-        return cls(circuit_id, packet[28:], plaintext)
+        return cls(circuit_id, bytes(packet[28:]), plaintext)
 
 
 class CreatePayload(VariablePayload):

--- a/ipv8/messaging/interfaces/endpoint.py
+++ b/ipv8/messaging/interfaces/endpoint.py
@@ -69,7 +69,7 @@ class Endpoint(metaclass=abc.ABCMeta):
         Ensure that the listener is still loaded when delivering the packet later.
         """
 
-        if self.is_open() and (packet[1][:self.prefixlen] in self._prefix_map or listener in self._listeners):
+        if self.is_open() and (bytes(packet[1][:self.prefixlen]) in self._prefix_map or listener in self._listeners):
             listener.on_packet(packet)
 
     def notify_listeners(self, packet):
@@ -78,7 +78,7 @@ class Endpoint(metaclass=abc.ABCMeta):
 
         :param data: the data to send to all listeners.
         """
-        prefix = packet[1][:self.prefixlen]
+        prefix = bytes(packet[1][:self.prefixlen])
         listeners = self._prefix_map.get(prefix, self._listeners)
         for listener in listeners:
             # TODO: Respect listener.use_main_thread:

--- a/ipv8/messaging/interfaces/statistics_endpoint.py
+++ b/ipv8/messaging/interfaces/statistics_endpoint.py
@@ -52,7 +52,7 @@ class StatisticsEndpoint(EndpointListener):
     def on_packet(self, packet):
         _, data = packet
 
-        prefix = data[:22]
+        prefix = bytes(data[:22])
         if prefix not in list(self.statistics.keys()) or len(data) < 22:
             return
 

--- a/ipv8/messaging/interfaces/udp/endpoint.py
+++ b/ipv8/messaging/interfaces/udp/endpoint.py
@@ -25,7 +25,7 @@ class UDPEndpoint(Endpoint, asyncio.DatagramProtocol):
         # If the endpoint is still running, accept incoming requests, otherwise drop them
         if self._running:
             self.bytes_down += len(datagram)
-            self.notify_listeners((addr, datagram))
+            self.notify_listeners((addr, bytearray(datagram)))
 
     def send(self, socket_address, packet):
         """

--- a/ipv8/messaging/serialization.py
+++ b/ipv8/messaging/serialization.py
@@ -129,7 +129,7 @@ class Raw(object):
 
     def unpack_from(self, data, offset=0):
         out = data[offset:]
-        return out, len(out)
+        return bytes(out), len(out)
 
 
 class VarLen(object):


### PR DESCRIPTION
This is *probably* faster.

This will need extensive profiling to see whether the overhead of converting to and from `bytearray` to `bytes` is worth it.