### PR TITLE
Fix sqlite text type

### DIFF
--- a/ipv8/attestation/trustchain/database.py
+++ b/ipv8/attestation/trustchain/database.py
@@ -17,7 +17,7 @@ class TrustChainDB(Database):
     Connection layer to SQLiteDB.
     Ensures a proper DB schema on startup.
     """
-    LATEST_DB_VERSION = 7
+    LATEST_DB_VERSION = 8
 
     def __init__(self, working_directory, db_name, my_pk=None):
         """
@@ -407,6 +407,13 @@ class TrustChainDB(Database):
             """
         elif current_version == 5:
             return self.get_sql_create_blocks_table("double_spends", "public_key, sequence_number, block_hash")
+        elif current_version == 7:
+            # Make sure that everything in the sqlite database is stored as BLOB.
+            return u"""
+            UPDATE blocks SET type=CAST(type AS BLOB), tx=CAST(tx AS BLOB), public_key=CAST(public_key AS BLOB),
+                              link_public_key=CAST(link_public_key AS BLOB), previous_hash=CAST(previous_hash AS BLOB),
+                              signature=CAST(signature AS BLOB), block_hash=CAST(block_hash AS BLOB);
+            """
 
     def open(self, initial_statements=True, prepare_visioning=True):
         return super(TrustChainDB, self).open(initial_statements, prepare_visioning)

--- a/ipv8/attestation/trustchain/database.py
+++ b/ipv8/attestation/trustchain/database.py
@@ -427,7 +427,7 @@ class TrustChainDB(Database):
         :param database_version: Current version of the database.
         :return:
         """
-        assert isinstance(database_version, str)
+        assert isinstance(database_version, bytes)
         assert database_version.isdigit()
         assert int(database_version) >= 0
         database_version = int(database_version)

--- a/ipv8/attestation/trustchain/database.py
+++ b/ipv8/attestation/trustchain/database.py
@@ -433,11 +433,12 @@ class TrustChainDB(Database):
         database_version = int(database_version)
 
         if database_version < self.LATEST_DB_VERSION:
-            while database_version < self.LATEST_DB_VERSION:
-                upgrade_script = self.get_upgrade_script(current_version=database_version)
-                if upgrade_script:
-                    self.executescript(upgrade_script)
-                database_version += 1
+            if database_version > 0:  # Only run the upgrade loop if there is something to upgrade.
+                while database_version < self.LATEST_DB_VERSION:
+                    upgrade_script = self.get_upgrade_script(current_version=database_version)
+                    if upgrade_script:
+                        self.executescript(upgrade_script)
+                    database_version += 1
             self.executescript(self.get_schema())
             self.commit()
 

--- a/ipv8/database.py
+++ b/ipv8/database.py
@@ -224,10 +224,10 @@ class Database(metaclass=ABCMeta):
                 version, = next(self.execute(u"SELECT value FROM option WHERE key == 'database_version' LIMIT 1"))
             except StopIteration:
                 # the 'database_version' key was not found
-                version = u"0"
+                version = b"0"
         else:
             # the 'option' table probably hasn't been created yet
-            version = u"0"
+            version = b"0"
 
         self._database_version = self.check_database(version)
         self._assert(isinstance(self._database_version, int),

--- a/ipv8/database.py
+++ b/ipv8/database.py
@@ -146,6 +146,7 @@ class Database(metaclass=ABCMeta):
 
     def _connect(self):
         self._connection = sqlite3.connect(self._file_path, check_same_thread=False)
+        self._connection.text_factory = bytes
         self._cursor = self._connection.cursor()
 
         assert self._cursor

--- a/ipv8/test/test_database.py
+++ b/ipv8/test/test_database.py
@@ -29,6 +29,6 @@ class TestDatabase(asynctest.TestCase):
         Check if an unloaded database returns None for queries.
         """
         self.database.open()
-        self.assertListEqual([(u'database_version', u'0')], list(self.database.execute("SELECT * FROM option")))
+        self.assertListEqual([(b'database_version', b'0')], list(self.database.execute("SELECT * FROM option")))
         self.database.close(True)
         self.assertIsNone(self.database.execute("SELECT * FROM option"))


### PR DESCRIPTION
When running IPv8 with Python 2.7, it stored several text element as `TEXT` type. In Python 3, however, we are using `bytes` to fetch from the database, causing SQL queries to return incorrect results.

This PR bumps the version of the TrustChain database and converts all `TEXT` elements to the `BLOB` type. This should fix the SQL queries that are using `bytes` in their queries, and requires no changes to the existing SQL queries.