### PR TITLE
Added get_overlay(s) method to MockIPv8

### DIFF
--- a/ipv8/test/mocking/ipv8.py
+++ b/ipv8/test/mocking/ipv8.py
@@ -45,6 +45,12 @@ class MockIPv8(object):
         if enable_statistics:
             self.endpoint.enable_community_statistics(self.overlay.get_prefix(), True)
 
+    def get_overlay(self, overlay_cls):
+        return next(self.get_overlays(overlay_cls), None)
+
+    def get_overlays(self, overlay_cls):
+        return (o for o in [self.trustchain, self.dht, self.overlay] if isinstance(o, overlay_cls))
+
     async def unload(self):
         self.endpoint.close()
         await self.overlay.unload()


### PR DESCRIPTION
This is required for the REST API tests in AnyDex, that rely on this method in the MockIPv8 class.