### PR TITLE
Refactored id formats into SchemaManager

### DIFF
--- a/ipv8/attestation/default_identity_formats.py
+++ b/ipv8/attestation/default_identity_formats.py
@@ -1,0 +1,60 @@
+from .wallet.irmaexact.keydump import nijmegen_pk_1568208470
+
+
+FORMATS = {
+    "id_metadata": {
+        "algorithm": "bonehexact",
+        "key_size": 32,  # Pairings over 1024 bit space
+        "hash": "sha256_4"  # 4 byte hash
+    },
+    "id_metadata_big": {
+        "algorithm": "bonehexact",
+        "key_size": 64,  # Pairings over 4096 bit space
+        "hash": "sha256"  # 32 byte hash
+    },
+    "id_metadata_huge": {
+        "algorithm": "bonehexact",
+        "key_size": 96,  # Pairings over 9216 bit space
+        "hash": "sha512"  # 64 byte hash
+    },
+    "id_metadata_range_18plus": {
+        "algorithm": "pengbaorange",
+        "key_size": 32,  # Pairings over 1024 bit space
+        "min": 18,
+        "max": 200
+    },
+    "id_irma_nijmegen_address_1568208470": {
+        "algorithm": "irmaexact",
+        "issuer_pk": nijmegen_pk_1568208470,  # Valid until Wednesday 11 September 2019 13:27:50 GMT
+        "order": [u"street", u"houseNumber", u"zipcode", u"municipality", u"city"],
+        "credential": u"pbdf.nijmegen.address",
+        "keyCounter": 0,
+        "validity": 13
+
+    },
+    "id_irma_nijmegen_personalData_1568208470": {
+        "algorithm": "irmaexact",
+        "issuer_pk": nijmegen_pk_1568208470,  # Valid until Wednesday 11 September 2019 13:27:50 GMT
+        "order": [u"initials", u"firstnames", u"prefix", u"familyname", u"surname",
+                  u"fullname", u"dateofbirth", u"gender", u"nationality"],
+        "credential": u"pbdf.nijmegen.personalData",
+        "keyCounter": 0,
+        "validity": 13
+    },
+    "id_irma_nijmegen_ageLimits_1568208470": {
+        "algorithm": "irmaexact",
+        "issuer_pk": nijmegen_pk_1568208470,  # Valid until Wednesday 11 September 2019 13:27:50 GMT
+        "order": [u"over12", u"over16", u"over18", u"over21", u"over65"],
+        "credential": u"pbdf.nijmegen.ageLimits",
+        "keyCounter": 0,
+        "validity": 13
+    },
+    "id_irma_nijmegen_bsn_1568208470": {
+        "algorithm": "irmaexact",
+        "issuer_pk": nijmegen_pk_1568208470,  # Valid until Wednesday 11 September 2019 13:27:50 GMT
+        "order": [u"bsn"],
+        "credential": u"pbdf.nijmegen.bsn",
+        "keyCounter": 0,
+        "validity": 13
+    }
+}

--- a/ipv8/attestation/identity/community.py
+++ b/ipv8/attestation/identity/community.py
@@ -1,7 +1,7 @@
 from binascii import unhexlify
 from time import time
 
-from ..identity_formats import FORMATS
+from ..default_identity_formats import FORMATS
 from ...attestation.trustchain.community import TrustChainCommunity
 from ...attestation.trustchain.listener import BlockListener
 from ...peer import Peer

--- a/ipv8/attestation/identity_formats.py
+++ b/ipv8/attestation/identity_formats.py
@@ -1,74 +1,14 @@
 import abc
 import hashlib
 
-from .wallet.irmaexact.keydump import nijmegen_pk_1568208470
-
-FORMATS = {
-    "id_metadata": {
-        "algorithm": "bonehexact",
-        "key_size": 32,  # Pairings over 1024 bit space
-        "hash": "sha256_4"  # 4 byte hash
-    },
-    "id_metadata_big": {
-        "algorithm": "bonehexact",
-        "key_size": 64,  # Pairings over 4096 bit space
-        "hash": "sha256"  # 32 byte hash
-    },
-    "id_metadata_huge": {
-        "algorithm": "bonehexact",
-        "key_size": 96,  # Pairings over 9216 bit space
-        "hash": "sha512"  # 64 byte hash
-    },
-    "id_metadata_range_18plus": {
-        "algorithm": "pengbaorange",
-        "key_size": 32,  # Pairings over 1024 bit space
-        "min": 18,
-        "max": 200
-    },
-    "id_irma_nijmegen_address_1568208470": {
-        "algorithm": "irmaexact",
-        "issuer_pk": nijmegen_pk_1568208470,  # Valid until Wednesday 11 September 2019 13:27:50 GMT
-        "order": [u"street", u"houseNumber", u"zipcode", u"municipality", u"city"],
-        "credential": u"pbdf.nijmegen.address",
-        "keyCounter": 0,
-        "validity": 13
-
-    },
-    "id_irma_nijmegen_personalData_1568208470": {
-        "algorithm": "irmaexact",
-        "issuer_pk": nijmegen_pk_1568208470,  # Valid until Wednesday 11 September 2019 13:27:50 GMT
-        "order": [u"initials", u"firstnames", u"prefix", u"familyname", u"surname",
-                  u"fullname", u"dateofbirth", u"gender", u"nationality"],
-        "credential": u"pbdf.nijmegen.personalData",
-        "keyCounter": 0,
-        "validity": 13
-    },
-    "id_irma_nijmegen_ageLimits_1568208470": {
-        "algorithm": "irmaexact",
-        "issuer_pk": nijmegen_pk_1568208470,  # Valid until Wednesday 11 September 2019 13:27:50 GMT
-        "order": [u"over12", u"over16", u"over18", u"over21", u"over65"],
-        "credential": u"pbdf.nijmegen.ageLimits",
-        "keyCounter": 0,
-        "validity": 13
-    },
-    "id_irma_nijmegen_bsn_1568208470": {
-        "algorithm": "irmaexact",
-        "issuer_pk": nijmegen_pk_1568208470,  # Valid until Wednesday 11 September 2019 13:27:50 GMT
-        "order": [u"bsn"],
-        "credential": u"pbdf.nijmegen.bsn",
-        "keyCounter": 0,
-        "validity": 13
-    }
-}
-
 
 class IdentityAlgorithm(metaclass=abc.ABCMeta):
 
-    def __init__(self, id_format):
+    def __init__(self, id_format, formats):
         self.id_format = id_format
         self.honesty_check = False
 
-        if id_format not in FORMATS:
+        if id_format not in formats:
             raise RuntimeError("Tried to initialize with illegal identity format")
 
     @abc.abstractmethod
@@ -279,4 +219,4 @@ class Attestation(metaclass=abc.ABCMeta):
         return hashlib.sha1(self.serialize()).digest()
 
 
-__all__ = ["FORMATS", "IdentityAlgorithm", "Attestation"]
+__all__ = ["IdentityAlgorithm", "Attestation"]

--- a/ipv8/attestation/schema/manager.py
+++ b/ipv8/attestation/schema/manager.py
@@ -1,0 +1,86 @@
+from typing import Type
+
+from ..identity_formats import IdentityAlgorithm
+
+
+class SchemaManager(object):
+    """
+    Manager for schemas: specifications of attribute disclosure algorithm parameterization.
+    """
+
+    def __init__(self) -> None:
+        """
+        Create a new SchemaManager: no algorithms are loaded initially.
+        """
+        super(SchemaManager, self).__init__()
+
+        self.formats = dict()
+        self.algorithms = dict()
+
+    def get_algorithm_class(self, algorithm_name: str) -> Type[IdentityAlgorithm]:
+        """
+        Get the implementation belonging to a certain algorithm name.
+        These are bound to either:
+
+         - bonehexact: for exact value matches using "Evaluating 2-DNF Formulas on Ciphertexts" by Boneh et al.
+         - pengbaorange: for range proofs using "An efficient range proof scheme." by K. Peng and F. Bao.
+         - irmaexact: for exact value matches using the IRMA protocol.
+
+        :param algorithm_name: the name of the algorithm.
+        """
+        if algorithm_name in self.algorithms:
+            return self.algorithms[algorithm_name]
+        # Lazy load
+        if algorithm_name == "bonehexact":
+            from ..wallet.bonehexact.algorithm import BonehExactAlgorithm
+            algorithm = BonehExactAlgorithm
+        elif algorithm_name == "pengbaorange":
+            from ..wallet.pengbaorange.algorithm import PengBaoRangeAlgorithm
+            algorithm = PengBaoRangeAlgorithm
+        elif algorithm_name == "irmaexact":
+            from ..wallet.irmaexact.algorithm import IRMAExactAlgorithm
+            algorithm = IRMAExactAlgorithm
+        else:
+            raise RuntimeError(f"Attempted to load unknown proof algorithm {algorithm_name}!")
+        self.algorithms[algorithm_name] = algorithm
+        return algorithm
+
+    def register_schema(self, schema_name: str, algorithm_name: str, parameters: dict) -> None:
+        """
+        Register a schema specification.
+        Each schema is defined by an algorithm and its parameterization.
+
+        :param schema_name: the new schema name to claim.
+        :param algorithm_name: the algorithm to use (see `get_algorithm_class()`).
+        :param parameters: the dictionary specifying the parameters for the algorithm.
+        """
+        schema = {"algorithm": algorithm_name}
+        schema.update(parameters)
+        self.formats[schema_name] = schema
+
+    def register_default_schemas(self) -> None:
+        """
+        Register all default formats to this SchemaManager.
+        You will load:
+
+            - id_metadata: 1024 bit space "exact" value match
+            - id_metadata_big: 4096 bit space "exact" value match
+            - id_metadata_huge: 9216 bit space "exact" value match
+            - id_metadata_range_18plus: NIZKP over a commitment, showing it lies within [0, 18]
+            - id_irma_nijmegen_address_1568208470: IRMA address data match, valid until 11 Sept 2019 13:27:50 GMT
+            - id_irma_nijmegen_personalData_1568208470: IRMA personal data match, valid until 11 Sept 2019 13:27:50 GMT
+            - id_irma_nijmegen_ageLimits_1568208470: IRMA age data match, valid until 11 Sept 2019 13:27:50 GMT
+            - id_irma_nijmegen_bsn_1568208470: IRMA bsn data match, valid until 11 Sept 2019 13:27:50 GMT
+        """
+        from ..default_identity_formats import FORMATS
+        for schema in FORMATS:
+            self.register_schema(schema, FORMATS[schema]["algorithm"], FORMATS[schema])
+
+    def get_algorithm_instance(self, schema_name: str):
+        """
+        Get an algorithm instance from a schema name.
+
+        :param schema_name: the schema to instantiate the algorithm from.
+        """
+        schema = self.formats[schema_name]
+        return self.get_algorithm_class(schema["algorithm"])(schema_name, self.formats)

--- a/ipv8/attestation/wallet/bonehexact/algorithm.py
+++ b/ipv8/attestation/wallet/bonehexact/algorithm.py
@@ -7,26 +7,26 @@ from .attestation import (attest_sha256, attest_sha256_4, attest_sha512, binary_
 from .structs import BonehAttestation
 from ..primitives.boneh import generate_keypair
 from ..primitives.structs import BonehPrivateKey, BonehPublicKey, pack_pair, unpack_pair
-from ...identity_formats import FORMATS, IdentityAlgorithm
+from ...identity_formats import IdentityAlgorithm
 
 
 class BonehExactAlgorithm(IdentityAlgorithm):
 
-    def __init__(self, id_format):
-        super(BonehExactAlgorithm, self).__init__(id_format)
+    def __init__(self, id_format, formats):
+        super(BonehExactAlgorithm, self).__init__(id_format, formats)
         self.honesty_check = True
 
         # Check algorithm match
-        if FORMATS[id_format]["algorithm"] != "bonehexact":
+        if formats[id_format]["algorithm"] != "bonehexact":
             raise RuntimeError("Identity format linked to wrong algorithm")
 
         # Check key size match
-        self.key_size = FORMATS[self.id_format]["key_size"]
+        self.key_size = formats[self.id_format]["key_size"]
         if self.key_size < 32 or self.key_size > 512:
             raise RuntimeError("Illegal key size specified")
 
         # Check hash mode match
-        hash_mode = FORMATS[self.id_format]["hash"]
+        hash_mode = formats[self.id_format]["hash"]
         if hash_mode == "sha256":
             self.attest_function = attest_sha256
             self.aggregate_reference = binary_relativity_sha256

--- a/ipv8/attestation/wallet/irmaexact/algorithm.py
+++ b/ipv8/attestation/wallet/irmaexact/algorithm.py
@@ -7,7 +7,7 @@ from .gabi.keys import DefaultSystemParameters
 from .gabi.proofs import createChallenge
 from .wrappers import challenge_response, serialize_proof_d, unserialize_proof_d
 from ..primitives.structs import ipack, iunpack
-from ...identity_formats import Attestation, FORMATS, IdentityAlgorithm
+from ...identity_formats import Attestation, IdentityAlgorithm
 
 
 class IRMAAttestation(Attestation):
@@ -50,21 +50,21 @@ class KeyStub(object):
 
 class IRMAExactAlgorithm(IdentityAlgorithm):
 
-    def __init__(self, id_format):
-        super(IRMAExactAlgorithm, self).__init__(id_format)
+    def __init__(self, id_format, formats):
+        super(IRMAExactAlgorithm, self).__init__(id_format, formats)
 
         # Check algorithm match
-        if FORMATS[id_format]["algorithm"] != "irmaexact":
+        if formats[id_format]["algorithm"] != "irmaexact":
             raise RuntimeError("Identity format linked to wrong algorithm")
 
-        self.issuer_pk = FORMATS[self.id_format]["issuer_pk"]
-        self.attribute_order = FORMATS[self.id_format]["order"]
-        self.validity = FORMATS[self.id_format]["validity"]
+        self.issuer_pk = formats[self.id_format]["issuer_pk"]
+        self.attribute_order = formats[self.id_format]["order"]
+        self.validity = formats[self.id_format]["validity"]
 
         self.base_meta = {
-            u"credential": FORMATS[self.id_format]["credential"],
-            u"keyCounter": FORMATS[self.id_format]["keyCounter"],
-            u"validity": FORMATS[self.id_format]["validity"]
+            u"credential": formats[self.id_format]["credential"],
+            u"keyCounter": formats[self.id_format]["keyCounter"],
+            u"validity": formats[self.id_format]["validity"]
         }
 
         self.system_parameters = DefaultSystemParameters[1024]

--- a/ipv8/attestation/wallet/pengbaorange/algorithm.py
+++ b/ipv8/attestation/wallet/pengbaorange/algorithm.py
@@ -6,7 +6,7 @@ from ..pengbaorange.attestation import create_attest_pair
 from ..pengbaorange.structs import PengBaoAttestation
 from ..primitives.boneh import generate_keypair
 from ..primitives.structs import BonehPrivateKey, BonehPublicKey, pack_pair, unpack_pair
-from ...identity_formats import FORMATS, IdentityAlgorithm
+from ...identity_formats import IdentityAlgorithm
 
 LARGE_INTEGER = 32765
 
@@ -28,20 +28,20 @@ def _safe_rndint(key_size, mod):
 
 class PengBaoRangeAlgorithm(IdentityAlgorithm):
 
-    def __init__(self, id_format):
-        super(PengBaoRangeAlgorithm, self).__init__(id_format)
+    def __init__(self, id_format, formats):
+        super(PengBaoRangeAlgorithm, self).__init__(id_format, formats)
 
         # Check algorithm match
-        if FORMATS[id_format]["algorithm"] != "pengbaorange":
+        if formats[id_format]["algorithm"] != "pengbaorange":
             raise RuntimeError("Identity format linked to wrong algorithm")
 
         # Check key size match
-        self.key_size = FORMATS[self.id_format]["key_size"]
+        self.key_size = formats[self.id_format]["key_size"]
         if self.key_size < 32 or self.key_size > 512:
             raise RuntimeError("Illegal key size specified")
 
-        self.a = FORMATS[self.id_format]["min"]
-        self.b = FORMATS[self.id_format]["max"]
+        self.a = formats[self.id_format]["min"]
+        self.b = formats[self.id_format]["max"]
 
     def generate_secret_key(self):
         """

--- a/ipv8/test/attestation/wallet/irmaexact/test_algorithm.py
+++ b/ipv8/test/attestation/wallet/irmaexact/test_algorithm.py
@@ -1,5 +1,6 @@
 import asynctest
 
+from .....attestation.default_identity_formats import FORMATS
 from .....attestation.wallet.irmaexact.algorithm import IRMAExactAlgorithm
 
 
@@ -16,7 +17,7 @@ class TestAlgorithm(asynctest.TestCase):
 
     def test_integration(self):
         id_format = "id_irma_nijmegen_ageLimits_1568208470"
-        algorithm = IRMAExactAlgorithm(id_format)
+        algorithm = IRMAExactAlgorithm(id_format, FORMATS)
         attestation_blob, _ = algorithm.import_blob(self.blob)
         attestation = algorithm.get_attestation_class().unserialize_private(None, attestation_blob, id_format)
         attestation_public = attestation.unserialize(attestation.serialize(), id_format)
@@ -32,7 +33,7 @@ class TestAlgorithm(asynctest.TestCase):
 
     def test_integration_incomplete(self):
         id_format = "id_irma_nijmegen_ageLimits_1568208470"
-        algorithm = IRMAExactAlgorithm(id_format)
+        algorithm = IRMAExactAlgorithm(id_format, FORMATS)
 
         attestation_blob, _ = algorithm.import_blob(self.blob)
         attestation = algorithm.get_attestation_class().unserialize_private(None, attestation_blob, id_format)
@@ -49,7 +50,7 @@ class TestAlgorithm(asynctest.TestCase):
 
     def test_integration_wrong(self):
         id_format = "id_irma_nijmegen_ageLimits_1568208470"
-        algorithm = IRMAExactAlgorithm(id_format)
+        algorithm = IRMAExactAlgorithm(id_format, FORMATS)
 
         attestation_blob, _ = algorithm.import_blob(self.blob)
         attestation = algorithm.get_attestation_class().unserialize_private(None, attestation_blob, id_format)

--- a/test_classes_list.txt
+++ b/test_classes_list.txt
@@ -28,6 +28,7 @@ ipv8/test/attestation/wallet/irmaexact/test_keys.py:TestKeys
 ipv8/test/attestation/wallet/irmaexact/test_proofs.py:TestProofs
 ipv8/test/attestation/wallet/irmaexact/test_builder.py:TestBuilder
 ipv8/test/attestation/wallet/irmaexact/test_credential.py:TestCredential
+ipv8/test/attestation/wallet/irmaexact/test_algorithm.py:TestAlgorithm
 ipv8/test/attestation/wallet/pengbaorange/test_boudot.py:TestBoudot
 ipv8/test/attestation/wallet/test_attestation_community.py:TestCommunity
 


### PR DESCRIPTION
Related to #733.

This PR:

 - Moves the default identity formats to the `default_identity_formats.py` file.
 - Makes `IdentityAlgorithm` load formats from an argument instead of a global variable.
 - Adds a `SchemaManager` to manage and lazy-load schemas and available algorithms.
 - Refactors `AttestationCommunity` to use the `SchemaManager`.
 - Adds missing IRMA test to `test_classes_list.txt`.

No changes were made to the protocol. This PR opens the way to load new schemas through the REST API.