### PR TITLE
Make the host binding for the REST api configurable

### DIFF
--- a/ipv8/REST/rest_manager.py
+++ b/ipv8/REST/rest_manager.py
@@ -32,7 +32,7 @@ class RESTManager:
         self.session = session
         self.site = None
 
-    async def start(self, port=8085):
+    async def start(self, port=8085, host='127.0.0.1'):
         """
         Starts the HTTP API with the listen port as specified in the session configuration.
         """
@@ -53,7 +53,7 @@ class RESTManager:
         runner = web.AppRunner(root_endpoint.app, access_log=None)
         await runner.setup()
         # If localhost is used as hostname, it will randomly either use 127.0.0.1 or ::1
-        self.site = web.TCPSite(runner, '127.0.0.1', port)
+        self.site = web.TCPSite(runner, host, port)
         await self.site.start()
 
     async def stop(self):


### PR DESCRIPTION
## General
Currently the `port` for the REST API is configurable but the host is not. This causes issues when you like to bind the REST API to a specific interface or IP. For example, when using IPv8 inside a Docker container the host must be set to `0.0.0.0` in order to make communication possible. When bind to `127.0.0.1` (the current default) communication with the outside world is not possible.

## Changes
This PR adds a seconds parameter `host` to the `start()` method of `rest_manager.py`. The default value is still `127.0.0.1`.