### PR TITLE
Various testing infrastructure improvements

### DIFF
--- a/create_test_coverage_report.py
+++ b/create_test_coverage_report.py
@@ -3,11 +3,10 @@ import os
 import shutil
 import sys
 from io import StringIO
+from unittest import TextTestRunner, defaultTestLoader
+from unittest.suite import TestSuite
 
 import coverage
-
-from twisted.trial.reporter import VerboseTextReporter
-from twisted.trial.runner import TestLoader
 
 if __name__ != '__main__':
     print(__file__, "should be run stand-alone! Instead, it is being imported!", file=sys.stderr)
@@ -42,13 +41,13 @@ with open('test_classes_list.txt', 'r') as test_class_file:
         output_stream = StringIO()
         formatted_line = line.replace('/', '.').replace('.py:', '.')
 
-        suite = TestLoader().loadTestsFromName(formatted_line)
-        reporter = VerboseTextReporter(stream=output_stream)
-        reporter.failfast = True
-        suite.run(reporter)
+        suite = TestSuite()
+        suite.addTest(defaultTestLoader.loadTestsFromName(formatted_line))
+        reporter = TextTestRunner(stream=output_stream, failfast=True)
+        test_result = reporter.run(suite)
 
-        assert len(reporter.errors) == 0,\
-            "ERROR: UNIT TESTS FAILED, PLEASE FIX BEFORE RUNNING COVERAGE:\n%s\n%s" % (output_stream.getvalue(), ''.join([repr(error) for error in reporter.errors]))
+        assert len(test_result.errors) == 0,\
+            "ERROR: UNIT TESTS FAILED, PLEASE FIX BEFORE RUNNING COVERAGE:\n%s\n%s" % (output_stream.getvalue(), ''.join([repr(error) for error in test_result.errors]))
         output_stream.close()
 
     cov.stop()

--- a/run_all_tests.py
+++ b/run_all_tests.py
@@ -1,0 +1,196 @@
+import argparse
+import importlib
+import inspect
+import io
+import multiprocessing
+import pathlib
+import sys
+import threading
+import time
+import unittest
+
+
+def programmer_distractor():
+    distraction = str(int(time.time() - programmer_distractor.starttime))
+    print('\033[u\033[K' + distraction + " seconds and counting "
+          + ("x" if int(time.time() * 10) % 2 else "+"), end="", flush=True)
+    programmer_distractor.t = threading.Timer(0.1, programmer_distractor)
+    programmer_distractor.t.start()
+
+
+class CustomTestResult(unittest.TextTestResult):
+
+    def __init__(self, stream, descriptions, verbosity):
+        super(CustomTestResult, self).__init__(stream, descriptions, verbosity)
+        self.start_time = 0
+        self.end_time = 0
+        self.last_test = 0
+
+    def getDescription(self, test):
+        return str(test)
+
+    def startTestRun(self) -> None:
+        super(CustomTestResult, self).startTestRun()
+        self.start_time = time.time()
+        self.end_time = self.start_time
+
+    def startTest(self, test: unittest.case.TestCase) -> None:
+        super(CustomTestResult, self).startTest(test)
+        self.last_test = time.time()
+
+    def stopTestRun(self) -> None:
+        super(CustomTestResult, self).stopTestRun()
+        self.end_time = time.time()
+
+
+class CustomLinePrint(io.StringIO):
+
+    def __init__(self, delegated, prefix):
+        super(CustomLinePrint, self).__init__()
+        self.prefix = prefix
+        self.delegated = delegated
+        self.raw_lines = []
+
+    def write(self, __text: str) -> int:
+        wtime = time.time()
+        self.raw_lines.append((wtime, self.prefix, __text))
+        return self.delegated.write(__text)
+
+
+def task_test(*test_names):
+    import logging
+
+    print_stream = io.StringIO()
+    output_stream = CustomLinePrint(print_stream, "OUT")
+    stdio_replacement = CustomLinePrint(print_stream, "OUT")
+    stderr_replacement = CustomLinePrint(print_stream, "ERR")
+    logging_replacement = CustomLinePrint(print_stream, "LOG")
+    sys.stdio = stdio_replacement
+    sys.stderr = stderr_replacement
+    logging.basicConfig(level="DEBUG", stream=logging_replacement,
+                        format="%(levelname)-7s %(created).2f %(module)18s:%(lineno)-4d (%(name)s)  %(message)s")
+
+    suite = unittest.TestSuite()
+    for test_name in test_names:
+        suite.addTest(unittest.defaultTestLoader.loadTestsFromName(test_name))
+    reporter = unittest.TextTestRunner(stream=output_stream, failfast=True, verbosity=2, resultclass=CustomTestResult)
+    test_result = reporter.run(suite)
+
+    failed = len(test_result.errors) > 0
+    event_log = []
+    event_log.extend(output_stream.raw_lines if failed else output_stream.raw_lines[:-9])
+    event_log.extend(stdio_replacement.raw_lines)
+    event_log.extend(stderr_replacement.raw_lines)
+    if failed and logging_replacement.raw_lines:
+        relevant_log = [line for line in logging_replacement.raw_lines if line[0] >= test_result.last_test]
+        event_log.append((relevant_log[0][0], "LOG", "\n"))
+        event_log.extend(relevant_log)
+
+    return (failed, test_result.testsRun, test_result.end_time - test_result.start_time,
+            event_log, print_stream.getvalue())
+
+
+def scan_for_test_files(directory=pathlib.Path('./ipv8/test')):
+    if not isinstance(directory, pathlib.Path):
+        directory = pathlib.Path(directory)
+    return directory.glob('**/test_*.py')
+
+
+def derive_test_class_names(test_file_path):
+    module_name = '.'.join(test_file_path.relative_to(pathlib.Path('.')).parts)[:-3]
+    module_instance = importlib.import_module(module_name)
+    test_class_names = []
+    for obj_name, obj in inspect.getmembers(module_instance):
+        if inspect.isclass(obj) and issubclass(obj, unittest.TestCase) and obj.__module__ == module_name:
+            test_class_names.append(f"{module_name}.{obj_name}")
+    return test_class_names
+
+
+def find_all_test_class_names(directory=pathlib.Path('./ipv8/test')):
+    if not isinstance(directory, pathlib.Path):
+        directory = pathlib.Path(directory)
+    test_class_names = []
+    for found_test in scan_for_test_files(directory):
+        test_class_names.extend(derive_test_class_names(found_test))
+    return test_class_names
+
+
+def make_buckets(path_list, groups):
+    bucket_size = len(path_list) // groups
+    bucket_rem = len(path_list) - bucket_size * groups
+    buckets = []
+    for i in range(groups):
+        buckets.append(tuple(path_list[(i * bucket_size + min(i, bucket_rem)):
+                                       ((i + 1) * bucket_size) + min(i + 1, bucket_rem)]))
+    return buckets
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description='Run the IPv8 tests.')
+    parser.add_argument('-p', '--processes', type=int, default=multiprocessing.cpu_count() * 2, required=False,
+                        help="The amount of processes to spawn.")
+    parser.add_argument('-q', '--quiet', action='store_true', required=False,
+                        help="Don't show succeeded tests.")
+    args = parser.parse_args()
+
+    process_count = args.processes
+    process_pool = multiprocessing.Pool(process_count)
+
+    test_class_names = find_all_test_class_names()
+    buckets = make_buckets(test_class_names, process_count)
+
+    print(f"Launching in {process_count} processes ... ", end="")
+    total_end_time = 0
+    total_start_time = time.time()
+    result = process_pool.starmap_async(task_test, buckets)
+    print(f"awaiting results ... \033[s", end="", flush=True)
+
+    programmer_distractor.starttime = time.time()
+    timer = threading.Timer(0.1, programmer_distractor)
+    programmer_distractor.t = timer
+    timer.start()
+
+    global_event_log = []
+    total_time_taken = 0
+    total_tests_run = 0
+    total_fail = False
+    print_output = ''
+
+    for process_output_handle in result.get():
+        if total_end_time == 0:
+            total_end_time = time.time()
+        failed, tests_run, time_taken, event_log, print_output = process_output_handle
+        total_fail |= failed
+        total_tests_run += tests_run
+        total_time_taken += time_taken
+        if failed:
+            global_event_log = event_log
+            break
+        global_event_log.extend(event_log)
+
+    process_pool.close()
+    process_pool.join()
+    programmer_distractor.t.cancel()
+
+    print(f"\033[u\033[Kdone!", end="\r\n\r\n", flush=True)
+
+    if total_fail or not args.quiet:
+        print(unittest.TextTestResult.separator1)
+        global_event_log.sort(key=lambda x: x[0])
+        for event in global_event_log:
+            print(('\033[91m' if event[1] == "ERR" else ('\033[33m' if event[1] == "LOG" else '\033[0m'))
+                  + event[2] + '\033[0m',
+                  end='')
+        print("\r\n" + unittest.TextTestResult.separator1)
+
+    print("Summary:")
+    if total_fail:
+        print("[\033[91mFAILED\033[0m", end="")
+    else:
+        print("[\033[32mSUCCESS\033[0m", end="")
+    print(f"] Ran {total_tests_run} tests "
+          f"in {round(total_end_time-total_start_time, 2)} seconds "
+          f"({round(total_time_taken, 2)} seconds total in tests).")
+
+    if total_fail:
+        sys.exit(1)

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
         'netifaces': ["netifaces"],
         'asynctest': ["asynctest"]
     },
+    tests_require=['coverage', 'asynctest'],
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",


### PR DESCRIPTION
- Removes unused endpoint tests.
- Fixes #744.
- Added test requirements to `setup.py`.
- Added universal Python-based test invocation script (to remove operating specific `run_all_tests_*` scripts).

The new universal test script is also multiprocessed, which brings the test time down from 54 seconds to 18 seconds.

I will follow up with another PR for the `run_all_tests.py` script, integrating it properly into the documentation. First I want to do some preliminary field testing (if it turns out it doesn't work *everywhere*, I'll remove it again).
