### PR TITLE
Added REST endpoint for measuring core drift

### DIFF
--- a/ipv8/REST/health_endpoint.py
+++ b/ipv8/REST/health_endpoint.py
@@ -1,0 +1,114 @@
+import collections
+import time
+
+from aiohttp import web
+
+from aiohttp_apispec import docs, json_schema
+
+from marshmallow.fields import Boolean, Float
+
+from .base_endpoint import BaseEndpoint, HTTP_BAD_REQUEST, HTTP_NOT_FOUND, Response
+from .schema import DefaultResponseSchema, schema
+from ..peerdiscovery.discovery import DiscoveryStrategy
+
+
+class DriftMeasurementStrategy(DiscoveryStrategy):
+
+    def __init__(self, core_update_rate):
+        super(DriftMeasurementStrategy, self).__init__(None)
+        self.last_measurement = time.time()
+        self.history = collections.deque(maxlen=100)
+        self.core_update_rate = core_update_rate
+        self.overlay = type('FakeOverlay', (object,), {'get_peers': lambda: []})
+
+    def take_step(self):
+        with self.walk_lock:
+            this_time = time.time()
+            self.history.append((this_time, max(0.0, this_time - self.last_measurement - self.core_update_rate)))
+            self.last_measurement = this_time
+
+
+class HealthEndpoint(BaseEndpoint):
+    """
+    This endpoint manages measurements of non-functional requirements.
+    """
+
+    def __init__(self):
+        super(HealthEndpoint, self).__init__()
+        self.strategy = None
+        self.enabled = False
+
+    def setup_routes(self):
+        self.app.add_routes([web.get('/drift', self.retrieve_drift), web.put('/enable', self.enable_measurements)])
+
+    def enable(self):
+        if not self.session:
+            return False
+        if not self.enabled:
+            self.strategy = DriftMeasurementStrategy(self.session.walk_interval)
+            with self.session.overlay_lock:
+                self.session.strategies.append((self.strategy, -1))
+            return True
+        return True
+
+    def disable(self):
+        if not self.session:
+            return False
+        if self.enabled:
+            with self.session.overlay_lock:
+                self.session.strategies = [s for s in self.session.strategies
+                                           if not isinstance(s[0], DriftMeasurementStrategy)]
+            return True
+        return True
+
+    @docs(
+        tags=["Health"],
+        summary="Measure the core drift.",
+        responses={
+            200: {
+                "schema": schema(DriftResponse={"measurements": [
+                    schema(Measurement={
+                        "timestamp": Float,
+                        "drift": Float
+                    })
+                ]})
+            },
+            400: {
+                "schema": DefaultResponseSchema,
+                "example": {"success": False, "error": "Core drift disabled."}
+            }
+        }
+    )
+    async def retrieve_drift(self, _):
+        if self.strategy is None:
+            return Response({"success": False, "error": "Core drift disabled."}, status=HTTP_NOT_FOUND)
+        with self.strategy.walk_lock:
+            return Response({"measurements": [{"timestamp": e[0], "drift": e[1]} for e in self.strategy.history]})
+
+    @docs(
+        tags=["Health"],
+        summary="Enable or disable measurements.",
+        responses={
+            200: {
+                "schema": DefaultResponseSchema,
+                "example": {"success": True}
+            },
+            400: {
+                "schema": DefaultResponseSchema,
+                "examples": {'Enable value not specified': {"success": False, "error": "incorrect parameters"}}
+            }
+        }
+    )
+    @json_schema(schema(EnableHealthRequest={
+        'enable*': (Boolean, 'Whether to enable or disable measuring.'),
+    }))
+    async def enable_measurements(self, request):
+        parameters = await request.json()
+        if 'enable' not in parameters:
+            return Response({"error": "incorrect parameters"}, status=HTTP_BAD_REQUEST)
+
+        status = self.enable() if parameters.get('enable') else self.disable()
+        if status:
+            return Response({"success": True})
+        else:
+            return Response({"success": False, "error": "Session not initialized."})

--- a/ipv8/REST/root_endpoint.py
+++ b/ipv8/REST/root_endpoint.py
@@ -1,6 +1,7 @@
 from .attestation_endpoint import AttestationEndpoint
 from .base_endpoint import BaseEndpoint
 from .dht_endpoint import DHTEndpoint
+from .health_endpoint import HealthEndpoint
 from .isolation_endpoint import IsolationEndpoint
 from .network_endpoint import NetworkEndpoint
 from .noblock_dht_endpoint import NoBlockDHTEndpoint
@@ -18,6 +19,7 @@ class RootEndpoint(BaseEndpoint):
     def setup_routes(self):
         endpoints = {'/attestation': AttestationEndpoint,
                      '/dht': DHTEndpoint,
+                     '/health': HealthEndpoint,
                      '/isolation': IsolationEndpoint,
                      '/network': NetworkEndpoint,
                      '/noblockdht': NoBlockDHTEndpoint,


### PR DESCRIPTION
Related to #752

This adds an Endpoint that stores the last 100 core tick drift measurements.
It can be enabled and disabled with a put request (it starts off disabled).