### PR TITLE
Added identity datatypes

### DIFF
--- a/ipv8/attestation/identity/attestation.py
+++ b/ipv8/attestation/identity/attestation.py
@@ -1,0 +1,42 @@
+import binascii
+import struct
+import typing
+
+from .metadata import Metadata
+from ..signed_object import AbstractSignedObject
+from ...keyvault.keys import PrivateKey
+
+
+AttestationType = typing.TypeVar('AttestationType', bound='Attestation')
+
+
+class Attestation(AbstractSignedObject):
+    """
+    A pointer to Metadata.
+
+    An Attestation does not and should not contain an index.
+    An Attestation does not and should not contain a reference to the public key (directly).
+    """
+
+    def __init__(self,
+                 metadata_pointer: bytes,
+                 private_key: typing.Optional[PrivateKey] = None,
+                 signature: typing.Optional[bytes] = None):
+        self.metadata_pointer = metadata_pointer
+        super(Attestation, self).__init__(private_key, signature)
+
+    def get_plaintext(self) -> bytes:
+        return self.metadata_pointer
+
+    @classmethod
+    def unserialize(cls, data, public_key, offset=0) -> AttestationType:
+        sig_len = public_key.get_signature_length()
+        metadata_pointer, signature = struct.unpack_from(f">32s{sig_len}s", data, offset=offset)
+        return Attestation(metadata_pointer, signature=signature)
+
+    @classmethod
+    def create(cls, metadata: Metadata, private_key: PrivateKey) -> AttestationType:
+        return Attestation(metadata.get_hash(), private_key=private_key)
+
+    def __str__(self) -> str:
+        return f"Attestation({binascii.hexlify(self.metadata_pointer).decode()})"

--- a/ipv8/attestation/identity/metadata.py
+++ b/ipv8/attestation/identity/metadata.py
@@ -1,0 +1,84 @@
+import binascii
+import json
+import typing
+
+from ..signed_object import AbstractSignedObject
+from ..tokenchain.token import Token
+from ...keyvault.keys import PrivateKey
+
+
+MetadataType = typing.TypeVar('MetadataType', bound='Metadata')
+
+
+class Metadata(AbstractSignedObject):
+    """
+    A JSON dictionary and a pointer to a Token.
+
+    Metadata does not and should not contain an index.
+    Metadata does not and should not contain a reference to the public key (but is signed by one).
+    """
+
+    def __init__(self,
+                 token_pointer: bytes,
+                 serialized_json_dict: bytes,
+                 private_key: typing.Optional[PrivateKey] = None,
+                 signature: typing.Optional[bytes] = None):
+        """
+        Create a new Metadata object, always specify the token it belongs to and its contents as a JSON dictionary.
+
+        For Metadata belonging to yourself, give the token pointer, the JSON dictionary and private key and the content
+        hash and signature will be automatically created.
+        For Metadata of someone else or your own reloaded Metadata, give the token pointer, the JSON dictionary and
+        the signature.
+
+        :param token_pointer: a string pointing to the hash of the Token.
+        :param serialized_json_dict: the JSON dictionary of metadata to tokenize.
+        :param private_key: the private key of the current user, creating this new Token.
+        :param signature: the signature for this Token.
+        """
+        self.token_pointer = token_pointer
+        self.serialized_json_dict = serialized_json_dict
+        super(Metadata, self).__init__(private_key, signature)
+
+    def get_plaintext(self) -> bytes:
+        """
+        Serialized Metadata consists of a token pointer and serialized JSON.
+        """
+        return self.token_pointer + self.serialized_json_dict
+
+    @classmethod
+    def unserialize(cls, data, public_key, offset=0) -> MetadataType:
+        if offset != 0:
+            raise RuntimeError("Offset is not supported for Metadata!")
+        sig_len = public_key.get_signature_length()
+        return Metadata(data[:32], data[32:-sig_len], signature=data[-sig_len:])
+
+    @classmethod
+    def create(cls, token: Token, json_dict: dict, private_key: PrivateKey) -> MetadataType:
+        return Metadata(token.get_hash(), json.dumps(json_dict).encode(), private_key=private_key)
+
+    def to_database_tuple(self) -> typing.Tuple[bytes, bytes, bytes]:
+        """
+        Get a representation of this Metadata as three byte strings (token hash, signature and json dictionary).
+
+        :returns: the three byte strings for database insertion.
+        """
+        return self.token_pointer, self.signature, self.serialized_json_dict
+
+    @classmethod
+    def from_database_tuple(cls,
+                            token_pointer: bytes,
+                            signature: bytes,
+                            serialized_json_dict: bytes) -> MetadataType:
+        """
+        Create a Token from a three-byte-string representation (token hash, signature and json dictionary).
+
+        :param token_pointer: the hash of the Token.
+        :param signature: the signature over the plaintext Metadata.
+        :param serialized_json_dict: the serialized json dictionary of this Metadata.
+        """
+        return Metadata(token_pointer, serialized_json_dict, signature=signature)
+
+    def __str__(self) -> str:
+        return (f"Metadata({binascii.hexlify(self.token_pointer).decode()},\n"
+                f"{self.serialized_json_dict.decode()})")

--- a/ipv8/attestation/signed_object.py
+++ b/ipv8/attestation/signed_object.py
@@ -1,0 +1,92 @@
+import abc
+import hashlib
+import struct
+import typing
+
+from ..keyvault.crypto import ECCrypto
+from ..keyvault.keys import PrivateKey, PublicKey
+
+T = typing.TypeVar('T')
+
+
+class AbstractSignedObject(metaclass=abc.ABCMeta):
+    """
+    To reach immutability different objects will have to be signed to reach non-repudiation.
+    Examples are Tokens, Metadata and Attestation objects.
+
+    This class handles many of the commonly required interactions for this type of signed data.
+    """
+
+    def __init__(self,
+                 private_key: typing.Optional[PrivateKey] = None,
+                 signature: typing.Optional[bytes] = None):
+        """
+        Create a new object that can be serialized and signed.
+        Call this after the data has been established for the `get_plaintext()` method.
+        """
+        self._hash = b''
+        self.crypto = ECCrypto()
+        self._sign(private_key, signature)
+
+    def get_hash(self) -> bytes:
+        """
+        Return the hash of this object itself.
+        """
+        return self._hash
+
+    def verify(self, public_key: PublicKey) -> bool:
+        """
+        Verify if a public key belongs to this object.
+
+        :returns: whether the given public key has signed for this object.
+        """
+        return self.crypto.is_valid_signature(public_key, self.get_plaintext(), self.signature)
+
+    def _sign(self,
+              private_key: typing.Optional[PrivateKey] = None,
+              signature: typing.Optional[bytes] = None) -> None:
+        """
+        Add a signature to this data.
+        Supply either your private key for signing or pass an existing signature.
+
+        :param private_key: the private key to sign with.
+        :param signature: the signature to adapt.
+        """
+        if private_key is not None and signature is None:
+            self.signature = private_key.signature(self.get_plaintext())
+        elif private_key is None and signature is not None:
+            self.signature = signature
+        else:
+            raise RuntimeError("Specify either private_key or signature!")
+        self._hash = hashlib.sha3_256(self.get_plaintext_signed()).digest()
+
+    @abc.abstractmethod
+    def get_plaintext(self) -> bytes:
+        """
+        Retrieve the content that needs to be signed, in serialized form (bytes).
+        """
+        pass
+
+    def get_plaintext_signed(self) -> bytes:
+        """
+        Concatenate the signature to the plaintext.
+        """
+        return self.get_plaintext() + self.signature
+
+    @classmethod
+    @abc.abstractmethod
+    def unserialize(cls: T, data: bytes, public_key: PublicKey, offset: int = 0) -> T:
+        pass
+
+    def __hash__(self) -> int:
+        return struct.unpack(">Q", self._hash[:8])[0]
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, self.__class__):
+            return False
+        return self.get_plaintext_signed() == other.get_plaintext_signed()
+
+    def __ne__(self, other: object) -> bool:
+        if not isinstance(other, self.__class__):
+            return True
+        return self.get_plaintext_signed() != other.get_plaintext_signed()

--- a/ipv8/attestation/tokenchain/token.py
+++ b/ipv8/attestation/tokenchain/token.py
@@ -1,16 +1,16 @@
-from binascii import hexlify
-from hashlib import sha3_256
-from struct import unpack
-from typing import Optional, Tuple, TypeVar
+import binascii
+import hashlib
+import struct
+import typing
 
-from ...keyvault.crypto import ECCrypto
-from ...keyvault.keys import PrivateKey, PublicKey
-
-
-TokenType = TypeVar('TokenType', bound='Token')
+from ..signed_object import AbstractSignedObject
+from ...keyvault.keys import PrivateKey
 
 
-class Token(object):
+TokenType = typing.TypeVar('TokenType', bound='Token')
+
+
+class Token(AbstractSignedObject):
     """
     A double pointer, pointing to a previous token and content.
     The contents belonging to the content pointer can be added to a Token object.
@@ -21,10 +21,10 @@ class Token(object):
 
     def __init__(self,
                  previous_token_hash: bytes,
-                 content: Optional[bytes] = None,
-                 content_hash: Optional[bytes] = None,
-                 private_key: Optional[PrivateKey] = None,
-                 signature: Optional[bytes] = None) -> None:
+                 content: typing.Optional[bytes] = None,
+                 content_hash: typing.Optional[bytes] = None,
+                 private_key: typing.Optional[PrivateKey] = None,
+                 signature: typing.Optional[bytes] = None) -> None:
         """
         Create a new Token object, always specify the hash of the preceding Token.
 
@@ -38,11 +38,9 @@ class Token(object):
         :param private_key: the private key of the current user, creating this new Token.
         :param signature: the signature for this Token.
         """
-        super(Token, self).__init__()
-
         if content is not None and content_hash is None:
             self.content = content
-            self.content_hash = sha3_256(content).digest()
+            self.content_hash = hashlib.sha3_256(content).digest()
         elif content is None and content_hash is not None:
             self.content = None
             self.content_hash = content_hash
@@ -51,10 +49,7 @@ class Token(object):
 
         self.previous_token_hash = previous_token_hash
 
-        self._hash = b''
-        self._sign(private_key, signature)
-
-        self.crypto = ECCrypto()
+        super(Token, self).__init__(private_key, signature)
 
     def get_plaintext(self) -> bytes:
         """
@@ -62,33 +57,11 @@ class Token(object):
         """
         return self.previous_token_hash + self.content_hash
 
-    def get_plaintext_signed(self) -> bytes:
-        """
-        Return the double pointer and the signature in plain text format, being the concatenation of the three items.
-        """
-        return self.get_plaintext() + self.signature
-
-    def get_hash(self) -> bytes:
-        """
-        Return the hash of this Token itself.
-        """
-        return self._hash
-
-    def _sign(self, private_key: Optional[PrivateKey] = None, signature: Optional[bytes] = None) -> None:
-        """
-        Add a signature to this Token.
-        Supply either your private key for signing or pass an existing signature.
-
-        :param private_key: the private key to sign with.
-        :param signature: the signature to adapt.
-        """
-        if private_key is not None and signature is None:
-            self.signature = private_key.signature(self.get_plaintext())
-        elif private_key is None and signature is not None:
-            self.signature = signature
-        else:
-            raise RuntimeError("Specify either private_key or signature!")
-        self._hash = sha3_256(self.get_plaintext_signed()).digest()
+    @classmethod
+    def unserialize(cls, data, public_key, offset=0) -> TokenType:
+        sig_len = public_key.get_signature_length()
+        previous_token_hash, content_hash, signature = struct.unpack_from(f">32s32s{sig_len}s", data, offset=offset)
+        return Token(previous_token_hash, content_hash=content_hash, signature=signature)
 
     def receive_content(self, content: bytes) -> bool:
         """
@@ -97,21 +70,17 @@ class Token(object):
         :param content: the content potentially belonging to the hash pointed to by this Token.
         :returns: whether we accepted the content.
         """
-        content_hash = sha3_256(content).digest()
+        content_hash = hashlib.sha3_256(content).digest()
         if content_hash == self.content_hash:
             self.content = content
             return True
         return False
 
-    def verify(self, public_key: PublicKey) -> bool:
-        """
-        Verify if a public key belongs to this Token.
+    @classmethod
+    def create(cls, previous_token: TokenType, content: bytes, private_key: PrivateKey) -> TokenType:
+        return Token(previous_token.get_hash(), content, private_key=private_key)
 
-        :returns: whether the given public key has signed for this Token.
-        """
-        return self.crypto.is_valid_signature(public_key, self.get_plaintext(), self.signature)
-
-    def to_database_tuple(self) -> Tuple[bytes, bytes, bytes, bytes]:
+    def to_database_tuple(self) -> typing.Tuple[bytes, bytes, bytes, bytes]:
         """
         Get a representation of this Token as four byte strings (previous hash, signature, content hash and content).
 
@@ -124,7 +93,7 @@ class Token(object):
                             previous_token_hash: bytes,
                             signature: bytes,
                             content_hash: bytes,
-                            content: Optional[bytes]) -> TokenType:
+                            content: typing.Optional[bytes]) -> TokenType:
         """
         Create a Token from a four-byte-string representation (previous hash, signature, content hash and content).
 
@@ -139,17 +108,5 @@ class Token(object):
         return token
 
     def __str__(self) -> str:
-        return f"Token({hexlify(self.previous_token_hash).decode()}, {hexlify(self.content_hash).decode()})"
-
-    def __hash__(self) -> int:
-        return unpack(">Q", self._hash[:8])[0]
-
-    def __eq__(self, other: object) -> bool:
-        if not isinstance(other, Token):
-            return False
-        return self.get_plaintext_signed() == other.get_plaintext_signed()
-
-    def __ne__(self, other: object) -> bool:
-        if not isinstance(other, Token):
-            return True
-        return self.get_plaintext_signed() != other.get_plaintext_signed()
+        return (f"Token({binascii.hexlify(self.previous_token_hash).decode()}, "
+                f"{binascii.hexlify(self.content_hash).decode()})")


### PR DESCRIPTION
This is the next step for #733. This PR adds two primitives (explicitly*) for identities:

 - Metadata: a signed combination of a JSON dictionary and a pointer to a Token.
 - Attestations; a signed pointer to Metadata.

As they are highly similar to the way Token objects are signed and serialized I extracted a common base class: the `AbstractSignedObject`.

This PR does not add any new logic - only data classes and moving code into an abstract class. This reduces clutter in following PRs.

*Formerly this was(/in the current implementation this is) inside of Trustchain implicitly.