### PR TITLE
Integrated ID 2.0 pseudonym management

### DIFF
--- a/doc/basics/attestation_tutorial.rst
+++ b/doc/basics/attestation_tutorial.rst
@@ -64,7 +64,6 @@ Fill your ``main.py`` file with the following code (runnable with ``python3 main
            configuration['logger']['level'] = "ERROR"
            configuration['keys'] = [
                {'alias': "anonymous id", 'generation': u"curve25519", 'file': u"ec%d_multichain.pem" % i},
-               {'alias': "my peer", 'generation': u"medium", 'file': u"ec%d.pem" % i}
            ]
 
            # Only load the basic communities
@@ -192,7 +191,7 @@ Peer 2 will now attest to some attribute value of Peer 1 (\ ``dmFsdWU%3D`` is th
 .. code-block:: bash
 
    $ curl http://localhost:14411/attestation?type=attributes
-   [["my_attribute", "oEkkmxqu0Hd/aMVpSOdyP0SIlUM=", {}, "bPyWPyswqXMhbW8+0RS6xUtNJrs="]]
+   [["my_attribute", "oEkkmxqu0Hd/aMVpSOdyP0SIlUM=", {"name": "my_attribute", "schema": "id_metadata", "date": 1592227939.021873}, "bPyWPyswqXMhbW8+0RS6xUtNJrs="]]
    $ curl http://localhost:14412/attestation?type=attributes
    []
 

--- a/ipv8/attestation/identity/community.py
+++ b/ipv8/attestation/identity/community.py
@@ -1,69 +1,190 @@
+import json
+import os
+import typing
 from binascii import unhexlify
 from time import time
 
-from ..default_identity_formats import FORMATS
-from ...attestation.trustchain.community import TrustChainCommunity
-from ...attestation.trustchain.listener import BlockListener
+from .attestation import Attestation
+from .database import Credential
+from .manager import IdentityManager, PseudonymManager
+from .metadata import Metadata
+from .payload import AttestPayload, DiclosePayload, MissingResponsePayload, RequestMissingPayload
+from ...community import Community, DEFAULT_MAX_PEERS
+from ...keyvault.keys import PrivateKey, PublicKey
+from ...lazy_community import lazy_wrapper
 from ...peer import Peer
+from ...peerdiscovery.discovery import RandomWalk
+from ...peerdiscovery.network import Network
 
 
-class IdentityCommunity(TrustChainCommunity, BlockListener):
+SAFE_UDP_PACKET_LENGTH = 1296
 
-    master_peer = Peer(unhexlify("307e301006072a8648ce3d020106052b81040024036a000400c9104b573ea18b795cb23b1defe6e5b7"
-                                 "41afa4b2b5edfe7d211c9342dfb753a22e850fb1bff01d5ca66cfe0b1a845fa3e333d200b6d742151f"
-                                 "3e4db3fe8b8508720744c70afe692c73264f789aa36a8c219acebeaa2b6ba652743d6580300fa1d98d"
-                                 "96b766dfcd"))
 
-    DB_NAME = 'identity'
+class IdentityCommunity(Community):
 
-    def __init__(self, *args, **kwargs):
-        TrustChainCommunity.__init__(self, *args, **kwargs)
-        BlockListener.__init__(self)
+    master_peer = Peer(unhexlify("4c69624e61434c504b3aabacc18bacd5abd4c93dc867759474f619e24b460fede1668a880297b19"
+                                 "4a0433324a0902192e7b853bda54b6e1b18e670d9ad4bd8f7e7e1dac71723989add3a"))
 
-        self.add_listener(self, [identity_format.encode('utf-8') for identity_format in FORMATS])
+    def __init__(self, my_peer, endpoint, network=Network(), max_peers=DEFAULT_MAX_PEERS,
+                 anonymize=True, identity_manager=None, working_directory="."):
+        super(IdentityCommunity, self).__init__(my_peer, endpoint, network, max_peers, anonymize)
+        if identity_manager is None:
+            dbpath = ":memory:" if working_directory == ":memory:" else os.path.join(working_directory, "identity.db")
+            identity_manager = IdentityManager(database_path=dbpath)
 
         # Dict of hash -> (attribute_name, date, public_key)
         self.known_attestation_hashes = {}
 
-    def add_known_hash(self, attribute_hash, name, public_key, metadata=None):
+        self.identity_manager = identity_manager
+        self.pseudonym_manager = identity_manager.get_pseudonym(self.my_peer.key)
+
+        # We assume other people try to cheat us with trees.
+        # We don't attack ourselves though and just maintain a chain of attributes per pseudonym.
+        self.token_chain = []
+        self.metadata_chain = []
+        self.attestation_chain = []
+        self.permissions = {}  # Map of peer to highest index
+
+        # Pick the longest chain in case of bugs or malicious behavior.. hello Bitcoin.
+        for token in self.pseudonym_manager.tree.elements.values():
+            chain = self.pseudonym_manager.tree.get_root_path(token)
+            if len(chain) > len(self.token_chain):
+                self.token_chain = chain
+        for credential in self.pseudonym_manager.get_credentials():
+            for token in self.token_chain:
+                if credential.metadata.token_pointer == token.get_hash():
+                    self.metadata_chain.append(credential.metadata)
+                    self.attestation_chain.append(credential.attestations)
+                    break
+
+        # Register messages
+        self.add_message_handler(DiclosePayload, self.on_disclosure)
+        self.add_message_handler(AttestPayload, self.on_attest)
+        self.add_message_handler(RequestMissingPayload, self.on_request_missing)
+        self.add_message_handler(MissingResponsePayload, self.on_missing_response)
+
+    def pad_hash(self, attribute_hash):
+        """
+        Pad an old-style SHA-1 hash into the new 32 byte SHA3-256 space.
+        """
+        self.logger.debug("Padding deprecated SHA-1 hash to 32 bytes, use SHA3-256 instead!")
+        return b'SHA-1\x00\x00\x00\x00\x00\x00\x00' + attribute_hash
+
+    def add_known_hash(self,
+                       attribute_hash: bytes,
+                       name: str,
+                       public_key: PublicKey,
+                       metadata: typing.Optional[dict] = None) -> None:
         """
         We know about this hash+peer combination. Thus we can handle sign requests for it.
         """
+        if len(attribute_hash) == 20:
+            attribute_hash = self.pad_hash(attribute_hash)
         self.known_attestation_hashes[attribute_hash] = (name, time(), public_key, metadata)
 
-    def get_attestation_by_hash(self, attribute_hash):
-        blocks = self.persistence.get_all_blocks()
-        for block in blocks:
-            if block.transaction and block.transaction.get(b"hash", None) == attribute_hash:
-                return block
+    def get_attestation_by_hash(self, attribute_hash: bytes) -> typing.Optional[Metadata]:
+        """
+        Get the Metadata object for a particular attribute hash, if it exists.
+        """
+        if len(attribute_hash) == 20:
+            attribute_hash = self.pad_hash(attribute_hash)
+        for credential in self.pseudonym_manager.get_credentials():
+            token = self.pseudonym_manager.tree.elements[credential.metadata.token_pointer]
+            if token.content_hash == attribute_hash:
+                return credential.metadata
         return None
 
-    def received_block(self, block):
-        pass
-
-    def should_sign(self, block):
-        transaction = block.transaction
+    def should_sign(self,
+                    pseudonym: PseudonymManager,
+                    metadata: Metadata) -> bool:
+        """
+        Has the user asked us to sign for some metadata and is it still valid?
+        """
+        transaction = json.loads(metadata.serialized_json_dict)
         requested_keys = set(transaction.keys())
-        if requested_keys - {b"hash", b"name", b"date", b"metadata"} != set():
+        if metadata.token_pointer not in pseudonym.tree.elements:
             return False
-        if requested_keys - {b"metadata"} != {b"hash", b"name", b"date"}:
+        attribute_hash = pseudonym.tree.elements[metadata.token_pointer].content_hash
+        if "name" not in requested_keys or "date" not in requested_keys or "schema" not in requested_keys:
+            self.logger.debug(f"Not signing {str(metadata)}, it doesn't include the required fields!")
             return False
-        attribute_hash = transaction[b'hash']
         if attribute_hash not in self.known_attestation_hashes:
+            self.logger.debug(f"Not signing {str(metadata)}, it doesn't point to known content!")
             return False
-        if block.public_key != self.known_attestation_hashes[attribute_hash][2]:
+        if pseudonym.public_key.key_to_bin() != self.known_attestation_hashes[attribute_hash][2]:
+            self.logger.debug(f"Not signing {str(metadata)}, attribute doesn't belong to key!")
             return False
         # Refuse to sign blocks older than 5 minutes
         if time() > self.known_attestation_hashes[attribute_hash][1] + 300:
+            self.logger.debug(f"Not signing {str(metadata)}, timed out!")
             return False
-        if transaction[b'name'] != self.known_attestation_hashes[attribute_hash][0]:
+        if transaction['name'] != self.known_attestation_hashes[attribute_hash][0]:
+            self.logger.debug(f"Not signing {str(metadata)}, name does not match!")
             return False
-        if (self.known_attestation_hashes[attribute_hash][3]
-                and transaction.get(b'metadata', None) != self.known_attestation_hashes[attribute_hash][3]):
+        if (self.known_attestation_hashes[attribute_hash][3] is not None
+                and ({k: v for k, v in transaction.items() if k not in ["name", "date", "schema"]}
+                     != self.known_attestation_hashes[attribute_hash][3])):
+            self.logger.debug(f"Not signing {str(metadata)}, metadata does not match!")
             return False
+        for attestation in pseudonym.database.get_attestations_over(metadata):
+            if any(authority == self.my_peer.public_key.key_to_bin()
+                   for authority in pseudonym.database.get_authority(attestation)):
+                self.logger.debug(f"Not signing {str(metadata)}, already attested!")
+                return False
         return True
 
-    def request_attestation_advertisement(self, peer, attribute_hash, name, block_type="id_metadata", metadata=None):
+    def _fit_disclosure(self, disclosure: typing.Tuple[bytes, bytes, bytes, bytes])\
+            -> typing.Tuple[bytes, bytes, bytes, bytes]:
+        """
+        Fit a disclosure (metadata, tokens, attestations and authorities) to a UDP packet.
+
+        This comes down to stripping tokens until the serialization fits in a UDP packet, as tokens can be shown
+        to be missing from a disclosure and will be retrieved on demand
+        """
+        token_size = 64 + self.crypto.get_signature_length(self.my_peer.key)
+        metadata, tokens, attestations, authorities = disclosure
+        meta_len = len(metadata) + len(attestations) + len(authorities)
+        if meta_len + len(tokens) > SAFE_UDP_PACKET_LENGTH:
+            packet_space = SAFE_UDP_PACKET_LENGTH - meta_len
+            if packet_space < 0:
+                self.logger.warning(f"Attempting to disclose with packet of length {meta_len}, hoping for the best!")
+            packet_space = max(0, packet_space)
+            trim_len = packet_space // token_size
+            tokens = tokens[-trim_len * token_size:]
+        return metadata, tokens, attestations, authorities
+
+    def _received_disclosure_for_attest(self,
+                                        peer: Peer,
+                                        disclosure: typing.Tuple[bytes, bytes, bytes, bytes]) -> None:
+        """
+        Attempt to insert a disclosure into our database and request more if we are still missing tokens.
+        """
+        solicited = any(t[2] == peer.public_key.key_to_bin() for t in self.known_attestation_hashes.values())
+        if solicited:
+            correct, pseudonym = self.identity_manager.substantiate(peer.public_key, *disclosure)
+            required_attributes = [attribute_hash for attribute_hash in self.known_attestation_hashes
+                                   if self.known_attestation_hashes[attribute_hash][2] == peer.public_key.key_to_bin()]
+            known_attributes = [token.content_hash for token in pseudonym.tree.elements.values()]
+            if correct and any(attribute_hash in known_attributes for attribute_hash in required_attributes):
+                for credential in pseudonym.get_credentials():
+                    if self.should_sign(pseudonym, credential.metadata):
+                        self.logger.info(f"Attesting to {str(credential.metadata)}")
+                        attestation = pseudonym.create_attestation(credential.metadata, self.my_peer.key)
+                        pseudonym.add_attestation(self.my_peer.public_key, attestation)
+                        self.ez_send(peer, AttestPayload(attestation.get_plaintext_signed()))
+            for attribute_hash in required_attributes:
+                if attribute_hash not in known_attributes:
+                    self.logger.info(f"Missing information for attestation {attribute_hash}, requesting more!")
+                    self.ez_send(peer, RequestMissingPayload(len(pseudonym.tree.elements)))
+        else:
+            self.logger.warning(f"Received unsolicited disclosure from {str(peer)}, dropping!")
+
+    def request_attestation_advertisement(self,
+                                          peer: Peer,
+                                          attribute_hash: bytes,
+                                          name: str,
+                                          block_type: str = "id_metadata",
+                                          metadata: typing.Optional[dict] = None):
         """
         Request a peer to sign for our attestation advertisement.
         :param peer: the attestor of our block
@@ -72,29 +193,98 @@ class IdentityCommunity(TrustChainCommunity, BlockListener):
         :param block_type: the type of block (from identity_foromats.py)
         :param metadata: custom additional metadata
         """
-        self.sign_block(peer,
-                        public_key=peer.public_key.key_to_bin(),
-                        block_type=block_type.encode('utf-8'),
-                        transaction={
-                            b"hash": attribute_hash,
-                            b"name": name,
-                            b"date": time(),
-                            b"metadata": metadata or {}
-                        })
+        credential = self.self_advertise(attribute_hash, name, block_type, metadata)
+        self.permissions[peer] = len(self.token_chain)
+        disclosure = self.pseudonym_manager.disclose_credentials([credential], set())
+        self.ez_send(peer, DiclosePayload(*self._fit_disclosure(disclosure)))
 
-    def self_advertise(self, attribute_hash, name, block_type="id_metadata", metadata=None):
+    def self_advertise(self,
+                       attribute_hash: bytes,
+                       name: str,
+                       block_type: str = "id_metadata",
+                       metadata: typing.Optional[dict] = None) -> Credential:
         """
         Self-sign an attribute.
 
         :param attribute_hash: he hash of the attestation
         :param name: the name of the attribute (metadata)
-        :param block_type: the type of block (from identity_foromats.py)
+        :param block_type: the type of block (from identity_formats.py)
         :param metadata: custom additional metadata
         """
-        self.create_source_block(block_type=block_type.encode('utf-8'),
-                                 transaction={
-                                     b"hash": attribute_hash,
-                                     b"name": name,
-                                     b"date": time(),
-                                     b"metadata": metadata or {}
-                                 })  # noqa: E126
+        if len(attribute_hash) == 20:
+            attribute_hash = self.pad_hash(attribute_hash)
+
+        # Construct metadata fields
+        extended_metadata = {
+            "name": name,
+            "schema": block_type,
+            "date": time()
+        }
+        if metadata:
+            extended_metadata.update(metadata)
+
+        # Create credential
+        credential = self.pseudonym_manager.create_credential(attribute_hash, extended_metadata,
+                                                              self.metadata_chain[-1] if self.metadata_chain else None)
+
+        # Construct chain data view
+        self.attestation_chain.append(credential.attestations)
+        self.metadata_chain.append(credential.metadata)
+        self.token_chain.append(self.pseudonym_manager.tree.elements[credential.metadata.token_pointer])
+
+        return credential
+
+    @lazy_wrapper(DiclosePayload)
+    def on_disclosure(self, peer: Peer, disclosure: DiclosePayload) -> None:
+        """
+        Someone disclosed their attributes to us.
+        Attempt to insert them into our database and check if we are still missing some.
+        """
+        self._received_disclosure_for_attest(peer, (disclosure.metadata, disclosure.tokens, disclosure.attestations,
+                                                    disclosure.authorities))
+
+    @lazy_wrapper(AttestPayload)
+    def on_attest(self, peer: Peer, payload: AttestPayload) -> None:
+        """
+        Someone made an attestation for us, try to insert it into our database.
+        """
+        attestation = Attestation.unserialize(payload.attestation, peer.public_key)
+        if self.pseudonym_manager.add_attestation(peer.public_key, attestation):
+            self.logger.info(f"Received attestation from {str(peer)}!")
+        else:
+            self.logger.warning(f"Received invalid attestation from {str(peer)}!")
+
+    @lazy_wrapper(RequestMissingPayload)
+    def on_request_missing(self, peer: Peer, request: RequestMissingPayload) -> None:
+        """
+        Someone requested tokens from us. If they are permitted to see them, send them over.
+
+        Note that tokens do not have indices publicly, so instead of sending missing tokens one at a time,
+        we send a range, starting from the lowest index that is missing.
+        """
+        out = b''
+        permitted = self.token_chain[:self.permissions.get(peer, 0)]
+        for index, token in enumerate(permitted):
+            if index >= request.known:
+                serialized = token.get_plaintext_signed()
+                if len(out) + len(serialized) > SAFE_UDP_PACKET_LENGTH:
+                    break
+                out += serialized
+        self.ez_send(peer, MissingResponsePayload(out))
+
+    @lazy_wrapper(MissingResponsePayload)
+    def on_missing_response(self, peer: Peer, response: MissingResponsePayload) -> None:
+        """
+        We received tokens, attempt to insert them into our database and check if we are still missing some.
+        """
+        self._received_disclosure_for_attest(peer, (b'', response.tokens, b'', b''))
+
+
+def create_community(private_key: PrivateKey, ipv8, identity_manager: IdentityManager) -> IdentityCommunity:
+    my_peer = Peer(private_key)
+    community = IdentityCommunity(my_peer, ipv8.endpoint, identity_manager=identity_manager)
+    strategy = RandomWalk(community, target_interval=30)
+    with ipv8.overlay_lock:
+        ipv8.strategies.append(strategy)
+        ipv8.overlays.append(community)
+    return community

--- a/ipv8/attestation/identity/database.py
+++ b/ipv8/attestation/identity/database.py
@@ -134,6 +134,16 @@ class IdentityDatabase(Database):
         return [Credential(metadata, self.get_attestations_over(metadata))
                 for metadata in self.get_metadata_for(public_key)]
 
+    def get_known_identities(self):
+        """
+        List the public keys of all known identity owners.
+        """
+        out = []
+        for result in self.execute("SELECT public_key FROM Tokens", fetch_all=True):
+            # These are single item tuples
+            out.append(result[0])
+        return out
+
     def get_schema(self, version: int) -> str:
         """
         Return the schema for the database.

--- a/ipv8/attestation/identity/manager.py
+++ b/ipv8/attestation/identity/manager.py
@@ -32,8 +32,7 @@ class PseudonymManager(object):
 
         logging.info(f"Loading public key {binascii.hexlify(self.public_key.key_to_hash()).decode()} from database")
         for token in self.database.get_tokens_for(self.public_key):
-            if self.tree.gather_token(token) is None:
-                logging.error(f"Failed to insert {str(token)} loaded from database!")
+            self.tree.elements[token.get_hash()] = token
         self.credentials = self.database.get_credentials_for(self.public_key)
 
     @property
@@ -172,7 +171,7 @@ class PseudonymManager(object):
             tokens.add(root_token)
             current_token = root_token
             while current_token.previous_token_hash != self.tree.genesis_hash:
-                current_token = self.tree.elements.get[current_token.previous_token_hash]
+                current_token = self.tree.elements[current_token.previous_token_hash]
                 tokens.add(current_token)
         return s_metadata, b''.join(token.get_plaintext_signed() for token in tokens), attestations, authorities
 

--- a/ipv8/attestation/identity/payload.py
+++ b/ipv8/attestation/identity/payload.py
@@ -1,0 +1,29 @@
+from ...messaging.lazy_payload import VariablePayload, vp_compile
+
+
+@vp_compile
+class DiclosePayload(VariablePayload):
+    msg_id = 1
+    format_list = ['varlenH', 'varlenH', 'varlenH', 'varlenH']
+    names = ['metadata', 'tokens', 'attestations', 'authorities']
+
+
+@vp_compile
+class AttestPayload(VariablePayload):
+    msg_id = 2
+    format_list = ['varlenH']
+    names = ['attestation']
+
+
+@vp_compile
+class RequestMissingPayload(VariablePayload):
+    msg_id = 3
+    format_list = ['I']
+    names = ['known']
+
+
+@vp_compile
+class MissingResponsePayload(VariablePayload):
+    msg_id = 4
+    format_list = ['raw']
+    names = ['tokens']

--- a/ipv8/test/attestation/identity/test_identity.py
+++ b/ipv8/test/attestation/identity/test_identity.py
@@ -1,139 +1,197 @@
+import json
+
 from ...base import MockIPv8, TestBase
 from ....attestation.identity.community import IdentityCommunity
+from ....attestation.identity.manager import IdentityManager
 from ....peer import Peer
 
 
 class TestIdentityCommunity(TestBase):
+
+    FAKE_HASH = b'a' * 32
 
     def setUp(self):
         super(TestIdentityCommunity, self).setUp()
         self.initialize(IdentityCommunity, 2)
 
     def create_node(self):
-        return MockIPv8(u"curve25519", IdentityCommunity, working_directory=u":memory:")
+        identity_manager = IdentityManager(u":memory:")
+        return MockIPv8(u"curve25519", IdentityCommunity, identity_manager=identity_manager)
+
+    def peer(self, i):
+        return Peer(self.nodes[i].my_peer.public_key.key_to_bin(), self.nodes[i].endpoint.wan_address)
+
+    def key_bin(self, i):
+        return self.nodes[i].my_peer.public_key.key_to_bin()
+
+    def overlay(self, i):
+        return self.nodes[i].overlay
 
     async def test_advertise(self):
         """
         Check if a node can construct an advertisement for his attested attribute.
         """
-        pk_1 = self.nodes[1].my_peer.public_key.key_to_bin()
-        public_peer_1 = Peer(pk_1, self.nodes[1].endpoint.wan_address)
-
         await self.introduce_nodes()
 
-        self.nodes[1].overlay.add_known_hash(b"a" * 20, b"attribute", self.nodes[0].my_peer.public_key.key_to_bin())
-        self.nodes[0].overlay.request_attestation_advertisement(public_peer_1, b"a" * 20, b"attribute")
+        self.overlay(1).add_known_hash(self.FAKE_HASH, "attribute", self.key_bin(0))
+        self.overlay(0).request_attestation_advertisement(self.peer(1), self.FAKE_HASH, "attribute")
 
         await self.deliver_messages()
 
         for node_nr in [0, 1]:
-            self.assertIsNotNone(self.nodes[node_nr].overlay.persistence.get(pk_1, 1))
-            self.assertEqual(self.nodes[node_nr].overlay.persistence.get(pk_1, 1).link_sequence_number, 1)
+            pseudonym = self.overlay(node_nr).identity_manager.get_pseudonym(self.peer(0).public_key)
+
+            self.assertEqual(1, len(pseudonym.get_credentials()))
+            self.assertEqual(1, len(pseudonym.get_credentials()[0].attestations))
+
+    async def test_advertise_twice(self):
+        """
+        Check if a node can construct two attributes.
+        """
+        await self.introduce_nodes()
+
+        self.overlay(1).add_known_hash(self.FAKE_HASH, "attribute", self.key_bin(0))
+        self.overlay(0).request_attestation_advertisement(self.peer(1), self.FAKE_HASH, "attribute")
+
+        await self.deliver_messages()
+
+        self.overlay(1).add_known_hash(self.FAKE_HASH[:-1] + b'b', "attribute", self.key_bin(0))
+        self.overlay(0).request_attestation_advertisement(self.peer(1), self.FAKE_HASH, "attribute")
+
+        await self.deliver_messages()
+
+        for node_nr in [0, 1]:
+            pseudonym = self.overlay(node_nr).identity_manager.get_pseudonym(self.peer(0).public_key)
+
+            self.assertEqual(2, len(pseudonym.get_credentials()))
+            self.assertEqual(1, len(pseudonym.get_credentials()[0].attestations))
+            self.assertEqual(1, len(pseudonym.get_credentials()[1].attestations))
+
+    async def test_advertise_big(self):
+        """
+        Check if a node can construct an advertisement for his attested attribute, having more than 32 attributes.
+        """
+        await self.introduce_nodes()
+
+        for i in range(39):
+            self.overlay(0).self_advertise(self.FAKE_HASH[:-1] + bytes([i]), "attribute" + str(i))
+        self.overlay(1).add_known_hash(self.FAKE_HASH[:-1] + bytes([39]), "attribute" + str(39), self.key_bin(0))
+        self.overlay(0).request_attestation_advertisement(self.peer(1), self.FAKE_HASH[:-1] + bytes([39]),
+                                                          "attribute" + str(39))
+
+        await self.deliver_messages()
+        from asyncio import sleep
+        await sleep(.5)
+
+        for node_nr in [0, 1]:
+            pseudonym = self.overlay(node_nr).identity_manager.get_pseudonym(self.peer(0).public_key)
+
+            self.assertEqual(40, len(pseudonym.tree.elements))
+            self.assertEqual(40 if node_nr == 0 else 1, len(pseudonym.get_credentials()))
 
     async def test_advertise_metadata(self):
         """
         Check if a node can construct an advertisement for his attested attribute with metadata.
         """
-        pk_1 = self.nodes[1].my_peer.public_key.key_to_bin()
-        public_peer_1 = Peer(pk_1, self.nodes[1].endpoint.wan_address)
-
         await self.introduce_nodes()
 
-        self.nodes[1].overlay.add_known_hash(b"a" * 20, b"attribute", self.nodes[0].my_peer.public_key.key_to_bin(),
-                                             {b"a": b"b"})
-        self.nodes[0].overlay.request_attestation_advertisement(public_peer_1, b"a" * 20, b"attribute", "id_metadata",
-                                                                {b"a": b"b"})
+        self.overlay(1).add_known_hash(self.FAKE_HASH, "attribute", self.key_bin(0), {"a": "b"})
+        self.overlay(0).request_attestation_advertisement(self.peer(1), self.FAKE_HASH, "attribute", "id_metadata",
+                                                          {"a": "b"})
 
         await self.deliver_messages()
 
         for node_nr in [0, 1]:
-            self.assertIsNotNone(self.nodes[node_nr].overlay.persistence.get(pk_1, 1))
-            self.assertEqual(self.nodes[node_nr].overlay.persistence.get(pk_1, 1).link_sequence_number, 1)
-            self.assertDictEqual(self.nodes[node_nr].overlay.persistence.get(pk_1, 1).transaction[b'metadata'],
-                                 {b"a": b"b"})
+            pseudonym = self.overlay(node_nr).identity_manager.get_pseudonym(self.peer(0).public_key)
+
+            self.assertEqual(1, len(pseudonym.get_credentials()))
+            self.assertEqual(1, len(pseudonym.get_credentials()[0].attestations))
+            self.assertIn("a", json.loads(pseudonym.get_credentials()[0].metadata.serialized_json_dict))
+            self.assertEqual("b", json.loads(pseudonym.get_credentials()[0].metadata.serialized_json_dict)["a"])
 
     async def test_advertise_metadata_reject(self):
         """
         Check if a node cannot construct an advertisement for his attested attribute with wrong metadata.
         """
-        pk_1 = self.nodes[1].my_peer.public_key.key_to_bin()
-        public_peer_1 = Peer(pk_1, self.nodes[1].endpoint.wan_address)
-
         await self.introduce_nodes()
 
-        self.nodes[1].overlay.add_known_hash(b"a" * 20, b"attribute", self.nodes[0].my_peer.public_key.key_to_bin(),
-                                             {b"c": b"d"})
-        self.nodes[0].overlay.request_attestation_advertisement(public_peer_1, b"a" * 20, b"attribute", "id_metadata",
-                                                                {b"a": b"b"})
+        self.overlay(1).add_known_hash(self.FAKE_HASH, "attribute", self.key_bin(0), {"c": "d"})
+        self.overlay(0).request_attestation_advertisement(self.peer(1), self.FAKE_HASH, "attribute", "id_metadata",
+                                                          {"a": "b"})
 
         await self.deliver_messages()
 
-        self.assertIsNone(self.nodes[1].overlay.persistence.get(pk_1, 1))
+        for node_nr in [0, 1]:
+            pseudonym = self.overlay(node_nr).identity_manager.get_pseudonym(self.peer(0).public_key)
+
+            self.assertEqual(1, len(pseudonym.get_credentials()))
+            self.assertEqual(0, len(pseudonym.get_credentials()[0].attestations))
 
     async def test_advertise_reject_hash(self):
         """
         Check if unknown hashes are not signed.
         """
-        pk_1 = self.nodes[1].my_peer.public_key.key_to_bin()
-        public_peer_1 = Peer(pk_1, self.nodes[1].endpoint.wan_address)
-
         await self.introduce_nodes()
 
-        self.nodes[0].overlay.request_attestation_advertisement(public_peer_1, b"a" * 20, b"attribute")
+        self.overlay(0).request_attestation_advertisement(self.peer(1), self.FAKE_HASH, "attribute")
 
         await self.deliver_messages()
 
-        for node_nr in [0, 1]:
-            self.assertIsNone(self.nodes[node_nr].overlay.persistence.get(pk_1, 1))
+        pseudonym = self.overlay(0).identity_manager.get_pseudonym(self.peer(0).public_key)
+        self.assertEqual(1, len(pseudonym.get_credentials()))
+        self.assertEqual(0, len(pseudonym.get_credentials()[0].attestations))
+
+        pseudonym = self.overlay(1).identity_manager.get_pseudonym(self.peer(0).public_key)
+        self.assertEqual(0, len(pseudonym.get_credentials()))
 
     async def test_advertise_reject_public_key(self):
         """
         Check if we don't sign correct hashes for the wrong peer.
         """
-        pk_1 = self.nodes[1].my_peer.public_key.key_to_bin()
-        public_peer_1 = Peer(pk_1, self.nodes[1].endpoint.wan_address)
-
         await self.introduce_nodes()
 
-        self.nodes[1].overlay.add_known_hash(b"a" * 20, b"attribute", self.nodes[1].my_peer.public_key.key_to_bin())
-        self.nodes[0].overlay.request_attestation_advertisement(public_peer_1, b"a" * 20, b"attribute")
+        self.overlay(1).add_known_hash(self.FAKE_HASH, "attribute", self.key_bin(1))
+        self.overlay(0).request_attestation_advertisement(self.peer(1), self.FAKE_HASH, "attribute")
 
         await self.deliver_messages()
 
-        for node_nr in [0, 1]:
-            self.assertIsNone(self.nodes[node_nr].overlay.persistence.get(pk_1, 1))
+        pseudonym = self.overlay(0).identity_manager.get_pseudonym(self.peer(0).public_key)
+        self.assertEqual(1, len(pseudonym.get_credentials()))
+        self.assertEqual(0, len(pseudonym.get_credentials()[0].attestations))
+
+        pseudonym = self.overlay(1).identity_manager.get_pseudonym(self.peer(0).public_key)
+        self.assertEqual(0, len(pseudonym.get_credentials()))
 
     async def test_advertise_reject_old(self):
         """
         Check if we don't sign old attestations.
         """
-        pk_1 = self.nodes[1].my_peer.public_key.key_to_bin()
-        public_peer_1 = Peer(pk_1, self.nodes[1].endpoint.wan_address)
-
         await self.introduce_nodes()
 
-        self.nodes[1].overlay.known_attestation_hashes[b"a" * 20] = (b"attribute",
-                                                                     0, self.nodes[0].my_peer.public_key.key_to_bin())
-        self.nodes[0].overlay.request_attestation_advertisement(public_peer_1, b"a" * 20, b"attribute")
+        self.overlay(1).known_attestation_hashes[self.FAKE_HASH] = ("attribute", 0, self.key_bin(0))
+        self.overlay(0).request_attestation_advertisement(self.peer(1), self.FAKE_HASH, "attribute")
 
         await self.deliver_messages()
 
         for node_nr in [0, 1]:
-            self.assertIsNone(self.nodes[node_nr].overlay.persistence.get(pk_1, 1))
+            pseudonym = self.overlay(node_nr).identity_manager.get_pseudonym(self.peer(0).public_key)
+
+            self.assertEqual(1, len(pseudonym.get_credentials()))
+            self.assertEqual(0, len(pseudonym.get_credentials()[0].attestations))
 
     async def test_advertise_reject_wrong_name(self):
         """
         Check if we don't sign attestations with incorrect metadata.
         """
-        pk_1 = self.nodes[1].my_peer.public_key.key_to_bin()
-        public_peer_1 = Peer(pk_1, self.nodes[1].endpoint.wan_address)
-
         await self.introduce_nodes()
 
-        self.nodes[1].overlay.add_known_hash(b"a" * 20, b"attribute", self.nodes[1].my_peer.public_key.key_to_bin())
-        self.nodes[0].overlay.request_attestation_advertisement(public_peer_1, b"a" * 20, b"attribute")
+        self.overlay(1).add_known_hash(self.FAKE_HASH, "attribute", self.key_bin(0))
+        self.overlay(0).request_attestation_advertisement(self.peer(1), self.FAKE_HASH, "attr1bute")
 
         await self.deliver_messages()
 
         for node_nr in [0, 1]:
-            self.assertIsNone(self.nodes[node_nr].overlay.persistence.get(pk_1, 1))
+            pseudonym = self.overlay(node_nr).identity_manager.get_pseudonym(self.peer(0).public_key)
+
+            self.assertEqual(1, len(pseudonym.get_credentials()))
+            self.assertEqual(0, len(pseudonym.get_credentials()[0].attestations))

--- a/ipv8/test/attestation/tokentree/test_tree.py
+++ b/ipv8/test/attestation/tokentree/test_tree.py
@@ -76,7 +76,7 @@ class TestTree(TestCase):
         self.assertEqual(1, len(tree.unchained))
         self.assertListEqual([b"ab" * 16], list(tree.get_missing()))
         self.assertFalse(tree.verify(pub_token))
-        self.assertIsNone(token.content)
+        self.assertIsNone(token)
 
     def test_other_add_outsequence_overflow(self):
         """


### PR DESCRIPTION
This PR performs integration of the new ID Trustchain derivative with the identity overlay for #733.

In the process of testing I also automated the tutorial (which I will probably make a PR for in the future):
https://gist.github.com/qstokkink/a76a91ec00f8e5c496e0d21c91af6217

Concretely this PR;

 - Updates the attestation tutorial documentation.
 - Ports the old REST API to use the new backend.
 - Ports the old community to no longer subclass the currency Trustchain.
 - Ports the old identity tests to the new format.
 - Adds a convenience method to the ID 2.0 token datastructure for getting a single chain.
 - Internally uses unicode strings instead of flip-flopping to and from bytes for metadata.
 - Fixes race conditions in the REST tests.

*Roadmap*
This is the most intensive operation of #733, but ends the big backend work. After this the REST API bindings should be modernized and #733 is done.