### PR TITLE
Fix deadlock while shutting down RequestCache

### DIFF
--- a/ipv8/REST/asyncio_endpoint.py
+++ b/ipv8/REST/asyncio_endpoint.py
@@ -145,10 +145,6 @@ class AsyncioEndpoint(BaseEndpoint):
                         "interval": Integer
                     })
                 ]})
-            },
-            400: {
-                "schema": DefaultResponseSchema,
-                "example": {"success": False, "error": "at least Python 3.7 is required"}
             }
         }
     )

--- a/ipv8/dht/community.py
+++ b/ipv8/dht/community.py
@@ -189,8 +189,11 @@ class DHTCommunity(Community):
         return {'PingChurn': PingChurn}
 
     async def unload(self):
-        await self.request_cache.shutdown()
+        # Note that order matters here. First we unload the community, then we shutdown
+        # the RequestCache. This prevents calls to RequestCache.add after
+        # RequestCache.shutdown is called (which will return None after shutdown).
         await super(DHTCommunity, self).unload()
+        await self.request_cache.shutdown()
 
     @property
     def my_node_id(self):

--- a/ipv8/dht/community.py
+++ b/ipv8/dht/community.py
@@ -1,7 +1,7 @@
 import hashlib
 import os
 import time
-from asyncio import FIRST_COMPLETED, Future, ensure_future, gather, wait
+from asyncio import FIRST_COMPLETED, Future, gather, wait
 from binascii import hexlify, unhexlify
 from collections import defaultdict, deque
 from itertools import zip_longest
@@ -402,7 +402,7 @@ class DHTCommunity(Community):
             # Keep running tasks until work is done.
             while not crawl.done and len(tasks) < MAX_CRAWL_TASKS:
                 node, puncture_node = crawl.nodes_todo.pop(0)
-                tasks.add(ensure_future(self._contact_node(crawl, node, puncture_node)))
+                tasks.add(self.register_anonymous_task('contact_node', self._contact_node, crawl, node, puncture_node))
                 # Add to nodes_tried immediately to prevent sending multiple find-requests to the same node.
                 crawl.nodes_tried.add(node)
             if not tasks:

--- a/ipv8/messaging/anonymization/community.py
+++ b/ipv8/messaging/anonymization/community.py
@@ -428,6 +428,7 @@ class TunnelCommunity(Community):
                 await exit_socket.close()
                 # Remove old session key
                 self.relay_session_keys.pop(circuit_id, None)
+            await exit_socket.shutdown_task_manager()
         return exit_socket
 
     def destroy_circuit(self, circuit, reason=0):

--- a/ipv8/messaging/lazy_payload.py
+++ b/ipv8/messaging/lazy_payload.py
@@ -40,7 +40,7 @@ class VariablePayload(Payload):
         # If our super class is an old-style Payload function, forward the required arguments.
         if not issubclass(super(VariablePayload, self).__class__, VariablePayload) and \
                 inspect.ismethod(super(VariablePayload, self).__init__):
-            super_argspec = inspect.getargspec(super(VariablePayload, self).__init__).args[1:]
+            super_argspec = inspect.getfullargspec(super(VariablePayload, self).__init__).args[1:]
             for arg in super_argspec:
                 if arg in kwargs:
                     fwd_args[arg] = kwargs.pop(arg)

--- a/ipv8/taskmanager.py
+++ b/ipv8/taskmanager.py
@@ -186,10 +186,9 @@ class TaskManager(object):
         """
         Waits until all registered tasks are done.
         """
-        with self._task_lock:
-            tasks = self.get_tasks()
-            if tasks:
-                await gather(*tasks, return_exceptions=True)
+        tasks = self.get_tasks()
+        if tasks:
+            await gather(*tasks, return_exceptions=True)
 
     async def shutdown_task_manager(self):
         """
@@ -198,9 +197,10 @@ class TaskManager(object):
         with self._task_lock:
             self._shutdown = True
             tasks = self.cancel_all_pending_tasks()
-            if tasks:
-                with suppress(CancelledError):
-                    await gather(*tasks)
+
+        if tasks:
+            with suppress(CancelledError):
+                await gather(*tasks)
 
 
 __all__ = ["TaskManager", "task"]

--- a/ipv8/taskmanager.py
+++ b/ipv8/taskmanager.py
@@ -95,7 +95,8 @@ class TaskManager(object):
                 if isinstance(task, (Task, Future)):
                     if not task.done():
                         task.cancel()
-                return task
+                # We need to return an awaitable in case the caller awaits the output of register_task.
+                return succeed(None)
 
             if self.is_pending_task_active(name):
                 raise RuntimeError("Task already exists: '%s'" % name)

--- a/ipv8/taskmanager.py
+++ b/ipv8/taskmanager.py
@@ -1,12 +1,12 @@
 import logging
 import time
-from asyncio import CancelledError, Future, Task, coroutine, ensure_future, gather, iscoroutinefunction, sleep
+from asyncio import CancelledError, Future, Task, ensure_future, gather, iscoroutinefunction, sleep
 from contextlib import suppress
 from functools import wraps
 from threading import RLock
 from weakref import WeakValueDictionary
 
-from .util import succeed
+from .util import coroutine, succeed
 
 MAX_TASK_AGE = 600
 

--- a/ipv8/test/attestation/tokentree/test_tree.py
+++ b/ipv8/test/attestation/tokentree/test_tree.py
@@ -129,7 +129,7 @@ class TestTree(TestCase):
         self.assertEqual(0, len(tree.get_missing()))
         self.assertTrue(tree.verify(pub_token))
         self.assertTrue(tree.verify(token))
-        self.assertEquals(b"some data", token.content)
+        self.assertEqual(b"some data", token.content)
 
     def test_serialize_public(self):
         """

--- a/ipv8/test/dht/test_community.py
+++ b/ipv8/test/dht/test_community.py
@@ -1,5 +1,5 @@
 import time
-from asyncio import TimeoutError, wait_for
+from asyncio import TimeoutError, ensure_future, wait_for
 
 from ..base import TestBase
 from ..mocking.ipv8 import MockIPv8
@@ -200,6 +200,14 @@ class TestDHTCommunity(TestBase):
         # Additional pings should get dropped (i.e. timeout)
         with self.assertRaises(TimeoutError):
             await wait_for(self.nodes[0].overlay.ping(node1), 0.1)
+
+    async def test_unload_while_contacting_node(self):
+        await self.introduce_nodes()
+        overlay = self.nodes[0].overlay
+        ensure_future(overlay.find_nodes(self.key))
+        await overlay.unload()
+        self.assertTrue(overlay.request_cache._shutdown)
+        self.assertTrue(overlay._shutdown)
 
 
 class TestDHTCommunityXL(TestBase):

--- a/ipv8/test/test_taskmanager.py
+++ b/ipv8/test/test_taskmanager.py
@@ -1,8 +1,9 @@
-from asyncio import Future, coroutine, ensure_future, get_event_loop, sleep
+from asyncio import Future, ensure_future, get_event_loop, sleep
 from contextlib import suppress
 
 from .base import TestBase
 from ..taskmanager import TaskManager, task
+from ..util import coroutine
 
 
 class TestTaskManager(TestBase):

--- a/ipv8/util.py
+++ b/ipv8/util.py
@@ -48,3 +48,9 @@ def maybe_coroutine(func, *args, **kwargs):
     async def coro():
         return value
     return coro()
+
+
+def coroutine(func):
+    async def call_async(*args, **kwargs):
+        return func(*args, **kwargs)
+    return call_async


### PR DESCRIPTION
This PR fixes a deadlock that occurs if:
* The request cache is in the middle of shutting down, but still holds the lock.
* At the same time a task wants to add something to the `RequestCache`, so it tries to get the lock.

I've noticed this in Tribler while unloading communities, so this should fix that issue as well.
Personally, I can't think of any situation in which the locks would be required, so we may have to think about removing them altogether.

This PR also:
* Fixes https://github.com/Tribler/py-ipv8/issues/770
* Fixes a memory leak caused by the exit socket `TaskManager` not being shutdown.
* Includes a bunch of smaller fixes.
