### PR TITLE
Added v2 ID 2.0 REST API

### DIFF
--- a/ipv8/REST/attestation_endpoint.py
+++ b/ipv8/REST/attestation_endpoint.py
@@ -245,8 +245,9 @@ class AttestationEndpoint(BaseEndpoint):
             # Generate new key
             my_new_peer = Peer(default_eccrypto.generate_key(u"curve25519"))
             identity_manager = self.identity_overlay.identity_manager
-            self.session.unload_overlay(self.identity_overlay)
-            self.identity_overlay = create_community(my_new_peer.key, self.session, identity_manager)
+            await self.session.unload_overlay(self.identity_overlay)
+            self.identity_overlay = create_community(my_new_peer.key, self.session, identity_manager,
+                                                     endpoint=self.session.endpoint)
             for overlay in self.session.overlays:
                 overlay.my_peer = my_new_peer
             return Response({"success": True})
@@ -291,8 +292,7 @@ class AttestationEndpoint(BaseEndpoint):
                 metadata = {"id_format": id_format}
                 if 'metadata' in args:
                     metadata_unicode = json.loads(b64decode(args['metadata']))
-                    for k, v in metadata_unicode.items():
-                        metadata[cast_to_bin(k)] = cast_to_bin(v)
+                    metadata.update(metadata_unicode)
                 self.attestation_metadata[(self.identity_overlay.my_peer, attribute_name)] = metadata
                 self.attestation_overlay.request_attestation(peer, attribute_name, key, metadata)
                 return Response({"success": True})

--- a/ipv8/REST/identity_endpoint.py
+++ b/ipv8/REST/identity_endpoint.py
@@ -1,0 +1,588 @@
+import base64
+
+from aiohttp import web
+
+from aiohttp_apispec import docs, json_schema
+
+from marshmallow.fields import Dict, Float, String
+
+from .base_endpoint import BaseEndpoint, HTTP_BAD_REQUEST, Response
+from .schema import DefaultResponseSchema, schema
+from ..attestation.communication_manager import CommunicationManager
+
+
+PseudonymListResponseSchema = schema(PseudonymListResponse={"names": [String]})
+CredentialSchema = schema(Credential={"name": String, "hash": String, "metadata": Dict, "attesters": [String]})
+CredentialListResponseSchema = schema(CredentialListResponse={"names": [CredentialSchema]})
+
+
+def ez_b64_encode(s):
+    return base64.b64encode(s).decode()
+
+
+def ez_b64_decode(s):
+    return base64.b64decode(s.encode())
+
+
+class IdentityEndpoint(BaseEndpoint):
+
+    def __init__(self, middlewares=()):
+        super(IdentityEndpoint, self).__init__(middlewares)
+        self.communication_manager = None
+
+    def initialize(self, session):
+        super(IdentityEndpoint, self).initialize(session)
+        self.communication_manager = CommunicationManager(session)
+
+    def setup_routes(self):
+        self.app.add_routes([web.get('', self.list_pseudonyms),
+
+                             web.get('/{pseudonym_name}/schemas', self.list_schemas),
+
+                             web.get('/{pseudonym_name}/public_key', self.get_pseudonym_public_key),
+                             web.get('/{pseudonym_name}/unload', self.unload_pseudonym),
+                             web.get('/{pseudonym_name}/remove', self.remove_pseudonym),
+
+                             web.get('/{pseudonym_name}/credentials', self.list_pseudonym_credentials),
+                             web.get('/{pseudonym_name}/credentials/{subject_key}', self.list_subject_credentials),
+                             web.get('/{pseudonym_name}/peers', self.list_pseudonym_peers),
+
+                             web.put('/{pseudonym_name}/allow/{verifier_key}', self.allow_pseudonym_verification),
+                             web.put('/{pseudonym_name}/disallow/{verifier_key}', self.disallow_pseudonym_verification),
+                             web.put('/{pseudonym_name}/request/{authority_key}', self.create_pseudonym_credential),
+
+                             web.put('/{pseudonym_name}/attest/{subject_key}', self.attest_pseudonym_credential),
+                             web.put('/{pseudonym_name}/verify/{subject_key}', self.verify_pseudonym_credential),
+
+                             web.get('/{pseudonym_name}/outstanding/attestations', self.list_pseudonym_outstanding_attestations),
+                             web.get('/{pseudonym_name}/outstanding/verifications', self.list_pseudonym_outstanding_verifications),
+
+                             web.get('/{pseudonym_name}/verifications', self.list_pseudonym_verification_output)
+                             ])
+
+    @docs(
+        tags=["Identity"],
+        summary="List our pseudonyms.",
+        responses={
+            200: {
+                "schema": PseudonymListResponseSchema
+            }
+        }
+    )
+    async def list_pseudonyms(self, request):
+        return Response({"names": self.communication_manager.list_names()})
+
+    @docs(
+        tags=["Identity"],
+        summary="List our available identity schemas.",
+        parameters=[{
+            'in': 'path',
+            'name': 'pseudonym_name',
+            'description': 'The name of the pseudonym to use.',
+            'type': 'string',
+        }],
+        responses={
+            200: {
+                "schema": schema(SchemaListResponse={"schemas": [String]})
+            }
+        }
+    )
+    async def list_schemas(self, request):
+        channel = self.communication_manager.load(request.match_info['pseudonym_name'])
+        return Response({"schemas": channel.schemas})
+
+    @docs(
+        tags=["Identity"],
+        summary="Get the public key for a pseudonym.",
+        parameters=[{
+            'in': 'path',
+            'name': 'pseudonym_name',
+            'description': 'The name of the pseudonym to use.',
+            'type': 'string',
+        }],
+        responses={
+            200: {
+                "schema": PseudonymListResponseSchema
+            }
+        }
+    )
+    async def get_pseudonym_public_key(self, request):
+        channel = self.communication_manager.load(request.match_info['pseudonym_name'])
+        return Response({"public_key": ez_b64_encode(channel.public_key_bin)})
+
+    @docs(
+        tags=["Identity"],
+        summary="Unload a pseudonym.",
+        parameters=[{
+            'in': 'path',
+            'name': 'pseudonym_name',
+            'description': 'The name of the pseudonym to use.',
+            'type': 'string',
+        }],
+        responses={
+            200: {
+                "schema": DefaultResponseSchema,
+                "example": {"success": True}
+            }
+        }
+    )
+    async def unload_pseudonym(self, request):
+        await self.communication_manager.unload(request.match_info['pseudonym_name'])
+        return Response({"success": True})
+
+    @docs(
+        tags=["Identity"],
+        summary="Remove a pseudonym.",
+        parameters=[{
+            'in': 'path',
+            'name': 'pseudonym_name',
+            'description': 'The name of the pseudonym to use.',
+            'type': 'string',
+        }],
+        responses={
+            200: {
+                "schema": DefaultResponseSchema,
+                "example": {"success": True}
+            }
+        }
+    )
+    async def remove_pseudonym(self, request):
+        await self.communication_manager.remove(request.match_info['pseudonym_name'])
+        return Response({"success": True})
+
+    @docs(
+        tags=["Identity"],
+        summary="List a pseudonym's credentials.",
+        parameters=[{
+            'in': 'path',
+            'name': 'pseudonym_name',
+            'description': 'The name of the pseudonym to use.',
+            'type': 'string',
+        }],
+        responses={
+            200: {
+                "schema": CredentialListResponseSchema
+            }
+        }
+    )
+    async def list_pseudonym_credentials(self, request):
+        channel = self.communication_manager.load(request.match_info['pseudonym_name'])
+        return Response({"names": [{
+            "name": data[0],
+            "hash": ez_b64_encode(attribute_hash.lstrip(b'SHA-1\x00\x00\x00\x00\x00\x00\x00')),
+            "metadata": data[1],
+            "attesters": [ez_b64_encode(attester) for attester in data[2]]
+        }
+            for attribute_hash, data in channel.get_my_attributes().items()]
+        })
+
+    @docs(
+        tags=["Identity"],
+        summary="List a subject's credentials.",
+        parameters=[
+            {
+                'in': 'path',
+                'name': 'pseudonym_name',
+                'description': 'The name of the pseudonym to use.',
+                'type': 'string',
+            },
+            {
+                'in': 'path',
+                'name': 'subject_key',
+                'description': 'The public key of the subject to attest for.',
+                'type': 'string',
+            }
+        ],
+        responses={
+            200: {
+                "schema": CredentialListResponseSchema
+            },
+            400: {
+                "schema": DefaultResponseSchema,
+                "examples": {'Subject not found': {"success": False, "error": "failed to find subject"}}
+            }
+        }
+    )
+    async def list_subject_credentials(self, request):
+        channel = self.communication_manager.load(request.match_info['pseudonym_name'])
+
+        subject = None
+        for peer in channel.peers:
+            if peer.public_key.key_to_bin() == ez_b64_decode(request.match_info['subject_key']):
+                subject = peer
+                break
+        if subject is None:
+            return Response({"success": False, "error": "failed to find subject"})
+
+        return Response({"names": [{
+            "name": data[0],
+            "hash": ez_b64_encode(attribute_hash.lstrip(b'SHA-1\x00\x00\x00\x00\x00\x00\x00')),
+            "metadata": data[1],
+            "attesters": [ez_b64_encode(attester) for attester in data[2]]
+        }
+            for attribute_hash, data in channel.get_attributes(subject).items()]
+        })
+
+    @docs(
+        tags=["Identity"],
+        summary="List a pseudonym's peers.",
+        parameters=[{
+            'in': 'path',
+            'name': 'pseudonym_name',
+            'description': 'The name of the pseudonym to use.',
+            'type': 'string',
+        }],
+        responses={
+            200: {
+                "schema": schema(PeerListResponse={"peers": [String]})
+            }
+        }
+    )
+    async def list_pseudonym_peers(self, request):
+        channel = self.communication_manager.load(request.match_info['pseudonym_name'])
+        return Response({"peers": [ez_b64_encode(peer.public_key.key_to_bin()) for peer in channel.peers]})
+
+    @docs(
+        tags=["Identity"],
+        summary="Verify a credential.",
+        parameters=[
+            {
+                'in': 'path',
+                'name': 'pseudonym_name',
+                'description': 'The name of the pseudonym to use.',
+                'type': 'string',
+            },
+            {
+                'in': 'path',
+                'name': 'verifier_key',
+                'description': 'The public key of the verifier.',
+                'type': 'string',
+            }
+        ],
+        responses={
+            200: {
+                "schema": DefaultResponseSchema,
+                "example": {"success": True}
+            },
+            400: {
+                "schema": DefaultResponseSchema,
+                "examples": {'Authority not found': {"success": False, "error": "failed to find authority"}}
+            }
+        }
+    )
+    @json_schema(schema(AllowVerification={
+        'name*': (String, 'The name of the attribute to allow verification of.')
+    }))
+    async def allow_pseudonym_verification(self, request):
+        parameters = await request.json()
+        if 'name' not in parameters:
+            return Response({"error": "incorrect parameters"}, status=HTTP_BAD_REQUEST)
+
+        channel = self.communication_manager.load(request.match_info['pseudonym_name'])
+        verifier = None
+        for peer in channel.peers:
+            if peer.public_key.key_to_bin() == ez_b64_decode(request.match_info['verifier_key']):
+                verifier = peer
+                break
+        if verifier is None:
+            return Response({"success": False, "error": "failed to find verifier"})
+
+        channel.allow_verification(verifier, parameters['name'])
+
+        return Response({"success": True})
+
+    @docs(
+        tags=["Identity"],
+        summary="Disallow verification of a credential.",
+        parameters=[
+            {
+                'in': 'path',
+                'name': 'pseudonym_name',
+                'description': 'The name of the pseudonym to use.',
+                'type': 'string',
+            },
+            {
+                'in': 'path',
+                'name': 'verifier_key',
+                'description': 'The public key of the verifier.',
+                'type': 'string',
+            }
+        ],
+        responses={
+            200: {
+                "schema": DefaultResponseSchema,
+                "example": {"success": True}
+            },
+            400: {
+                "schema": DefaultResponseSchema,
+                "examples": {'Authority not found': {"success": False, "error": "failed to find authority"}}
+            }
+        }
+    )
+    @json_schema(schema(DisallowVerification={
+        'name*': (String, 'The name of the attribute to disallow verification of.')
+    }))
+    async def disallow_pseudonym_verification(self, request):
+        parameters = await request.json()
+        if 'name' not in parameters:
+            return Response({"error": "incorrect parameters"}, status=HTTP_BAD_REQUEST)
+
+        channel = self.communication_manager.load(request.match_info['pseudonym_name'])
+        verifier = None
+        for peer in channel.peers:
+            if peer.public_key.key_to_bin() == ez_b64_decode(request.match_info['verifier_key']):
+                verifier = peer
+                break
+        if verifier is None:
+            return Response({"success": False, "error": "failed to find verifier"})
+
+        channel.disallow_verification(verifier, parameters['name'])
+
+        return Response({"success": True})
+
+    @docs(
+        tags=["Identity"],
+        summary="Create a credential.",
+        parameters=[
+            {
+                'in': 'path',
+                'name': 'pseudonym_name',
+                'description': 'The name of the pseudonym to use.',
+                'type': 'string',
+            },
+            {
+                'in': 'path',
+                'name': 'authority_key',
+                'description': 'The public key of the authority to request attestation from.',
+                'type': 'string',
+            }
+        ],
+        responses={
+            200: {
+                "schema": DefaultResponseSchema,
+                "example": {"success": True}
+            },
+            400: {
+                "schema": DefaultResponseSchema,
+                "examples": {'Authority not found': {"success": False, "error": "failed to find authority"}}
+            }
+        }
+    )
+    @json_schema(schema(AttestationRequest={
+        'name*': (String, 'The name of the attribute to request attestation for.'),
+        'schema*': (String, 'The attribute schema to use.'),
+        'metadata': (Dict, 'The metadata to attach.')
+    }))
+    async def create_pseudonym_credential(self, request):
+        parameters = await request.json()
+        if 'name' not in parameters or 'schema' not in parameters:
+            return Response({"error": "incorrect parameters"}, status=HTTP_BAD_REQUEST)
+
+        channel = self.communication_manager.load(request.match_info['pseudonym_name'])
+        authority = None
+        for peer in channel.peers:
+            if peer.public_key.key_to_bin() == ez_b64_decode(request.match_info['authority_key']):
+                authority = peer
+                break
+        if authority is None:
+            return Response({"success": False, "error": "failed to find authority"})
+
+        metadata = parameters['metadata'] if 'metadata' in parameters else {}
+        channel.request_attestation(authority, parameters['name'], parameters['schema'], metadata)
+
+        return Response({"success": True})
+
+    @docs(
+        tags=["Identity"],
+        summary="Attest to a credential.",
+        parameters=[
+            {
+                'in': 'path',
+                'name': 'pseudonym_name',
+                'description': 'The name of the pseudonym to use.',
+                'type': 'string',
+            },
+            {
+                'in': 'path',
+                'name': 'subject_key',
+                'description': 'The public key of the subject to attest for.',
+                'type': 'string',
+            }
+        ],
+        responses={
+            200: {
+                "schema": DefaultResponseSchema,
+                "example": {"success": True}
+            },
+            400: {
+                "schema": DefaultResponseSchema,
+                "examples": {'Subject not found': {"success": False, "error": "failed to find subject"}}
+            }
+        }
+    )
+    @json_schema(schema(Attestation={
+        'name*': (String, 'The name of the subject\'s attribute.'),
+        'value*': (String, 'The value we believe the subject\'s attribute has.')
+    }))
+    async def attest_pseudonym_credential(self, request):
+        parameters = await request.json()
+        if 'name' not in parameters or 'value' not in parameters:
+            return Response({"error": "incorrect parameters"}, status=HTTP_BAD_REQUEST)
+
+        channel = self.communication_manager.load(request.match_info['pseudonym_name'])
+
+        subject = None
+        for peer in channel.peers:
+            if peer.public_key.key_to_bin() == ez_b64_decode(request.match_info['subject_key']):
+                subject = peer
+                break
+        if subject is None:
+            return Response({"success": False, "error": "failed to find subject"})
+
+        channel.attest(subject, parameters["name"], ez_b64_decode(parameters["value"]))
+
+        return Response({"success": True})
+
+    @docs(
+        tags=["Identity"],
+        summary="Request verification of a credential.",
+        parameters=[
+            {
+                'in': 'path',
+                'name': 'pseudonym_name',
+                'description': 'The name of the pseudonym to use.',
+                'type': 'string',
+            },
+            {
+                'in': 'path',
+                'name': 'subject_key',
+                'description': 'The public key of the subject to verify.',
+                'type': 'string',
+            }
+        ],
+        responses={
+            200: {
+                "schema": DefaultResponseSchema,
+                "example": {"success": True}
+            },
+            400: {
+                "schema": DefaultResponseSchema,
+                "examples": {'Subject not found': {"success": False, "error": "failed to find subject"}}
+            }
+        }
+    )
+    @json_schema(schema(VerificationRequest={
+        'hash*': (String, 'The hash of the subject\'s attribute.'),
+        'value*': (String, 'The value we require the subject\'s attribute to have.'),
+        'schema*': (String, 'The schema we require the subject\'s attribute to have.')
+    }))
+    async def verify_pseudonym_credential(self, request):
+        parameters = await request.json()
+        if 'hash' not in parameters or 'value' not in parameters or 'schema' not in parameters:
+            return Response({"error": "incorrect parameters"}, status=HTTP_BAD_REQUEST)
+
+        channel = self.communication_manager.load(request.match_info['pseudonym_name'])
+
+        subject = None
+        for peer in channel.peers:
+            if peer.public_key.key_to_bin() == ez_b64_decode(request.match_info['subject_key']):
+                subject = peer
+                break
+        if subject is None:
+            return Response({"success": False, "error": "failed to find subject"})
+
+        channel.verify(subject, ez_b64_decode(parameters["hash"]), [ez_b64_decode(parameters["value"])],
+                       parameters["schema"])
+
+        return Response({"success": True})
+
+    @docs(
+        tags=["Identity"],
+        summary="List the oustanding requests for attestations by others.",
+        parameters=[{
+            'in': 'path',
+            'name': 'pseudonym_name',
+            'description': 'The name of the pseudonym to use.',
+            'type': 'string',
+        }],
+        responses={
+            200: {
+                "schema": schema(AttestationRequestsResponse={"requests": [schema(OutstandingAttestationRequest={
+                    "peer": String,
+                    "attribute_name": String,
+                    "metadata": Dict
+                })]})
+            }
+        }
+    )
+    async def list_pseudonym_outstanding_attestations(self, request):
+        channel = self.communication_manager.load(request.match_info['pseudonym_name'])
+        formatted = []
+        for k, v in channel.attestation_requests.items():
+            formatted.append({
+                "peer": ez_b64_encode(k[0].public_key.key_to_bin()),
+                "attribute_name": k[1],
+                "metadata": v[1]
+            })
+        return Response({"requests": formatted})
+
+    @docs(
+        tags=["Identity"],
+        summary="List the oustanding requests for verification by others.",
+        parameters=[{
+            'in': 'path',
+            'name': 'pseudonym_name',
+            'description': 'The name of the pseudonym to use.',
+            'type': 'string',
+        }],
+        responses={
+            200: {
+                "schema": schema(VerificationRequestsResponse={"requests": [schema(OutstandingVerificationRequest={
+                    "peer": String,
+                    "attribute_name": String
+                })]})
+            }
+        }
+    )
+    async def list_pseudonym_outstanding_verifications(self, request):
+        channel = self.communication_manager.load(request.match_info['pseudonym_name'])
+        formatted = []
+        for k in channel.verify_requests.keys():
+            formatted.append({
+                "peer": ez_b64_encode(k[0].public_key.key_to_bin()),
+                "attribute_name": k[1]
+            })
+        return Response({"requests": formatted})
+
+    @docs(
+        tags=["Identity"],
+        summary="Return the output of our verification requests.",
+        parameters=[
+            {
+                'in': 'path',
+                'name': 'pseudonym_name',
+                'description': 'The name of the pseudonym to use.',
+                'type': 'string',
+            }
+        ],
+        responses={
+            200: {
+                "schema": schema(VerificationOutputResponse={"outputs": [schema(VerificationOutput={
+                    "hash": String,
+                    "reference": String,
+                    "match": Float
+                })]})
+            }
+        }
+    )
+    async def list_pseudonym_verification_output(self, request):
+        channel = self.communication_manager.load(request.match_info['pseudonym_name'])
+
+        formatted = []
+        for k, v in channel.verification_output.items():
+            if not v or v[0][1] is None:
+                # Not done yet
+                continue
+            formatted.append({"hash": ez_b64_encode(k), "reference": ez_b64_encode(v[0][0]), "match": v[0][1]})
+
+        return Response({"outputs": formatted})

--- a/ipv8/REST/rest_manager.py
+++ b/ipv8/REST/rest_manager.py
@@ -45,6 +45,8 @@ async def error_middleware(request, handler):
     try:
         response = await handler(request)
     except Exception as e:
+        import traceback
+        traceback.print_exc()
         return Response({
             "success": False,
             "error": {
@@ -64,17 +66,18 @@ class RESTManager:
         self._logger = logging.getLogger(self.__class__.__name__)
         self.session = session
         self.site = None
+        self.root_endpoint = None
 
     async def start(self, port=8085, host='127.0.0.1', api_key=None, ssl_context=None):
         """
         Starts the HTTP API with the listen port as specified in the session configuration.
         """
-        root_endpoint = RootEndpoint(middlewares=[ApiKeyMiddleware(api_key),
-                                                  cors_middleware,
-                                                  error_middleware])
-        root_endpoint.initialize(self.session)
+        self.root_endpoint = RootEndpoint(middlewares=[ApiKeyMiddleware(api_key),
+                                                       cors_middleware,
+                                                       error_middleware])
+        self.root_endpoint.initialize(self.session)
         setup_aiohttp_apispec(
-            app=root_endpoint.app,
+            app=self.root_endpoint.app,
             title="IPv8 REST API documentation",
             version="v1.9",
             url="/docs/swagger.json",
@@ -85,7 +88,7 @@ class RESTManager:
         if 'head' in VALID_METHODS_OPENAPI_V2:
             VALID_METHODS_OPENAPI_V2.remove('head')
 
-        runner = web.AppRunner(root_endpoint.app, access_log=None)
+        runner = web.AppRunner(self.root_endpoint.app, access_log=None)
         await runner.setup()
         # If localhost is used as hostname, it will randomly either use 127.0.0.1 or ::1
         self.site = web.TCPSite(runner, host, port, ssl_context=ssl_context)

--- a/ipv8/REST/root_endpoint.py
+++ b/ipv8/REST/root_endpoint.py
@@ -2,6 +2,7 @@ from .asyncio_endpoint import AsyncioEndpoint
 from .attestation_endpoint import AttestationEndpoint
 from .base_endpoint import BaseEndpoint
 from .dht_endpoint import DHTEndpoint
+from .identity_endpoint import IdentityEndpoint
 from .isolation_endpoint import IsolationEndpoint
 from .network_endpoint import NetworkEndpoint
 from .noblock_dht_endpoint import NoBlockDHTEndpoint
@@ -20,6 +21,7 @@ class RootEndpoint(BaseEndpoint):
         endpoints = {'/asyncio': AsyncioEndpoint,
                      '/attestation': AttestationEndpoint,
                      '/dht': DHTEndpoint,
+                     '/identity': IdentityEndpoint,
                      '/isolation': IsolationEndpoint,
                      '/network': NetworkEndpoint,
                      '/noblockdht': NoBlockDHTEndpoint,

--- a/ipv8/attestation/communication_manager.py
+++ b/ipv8/attestation/communication_manager.py
@@ -1,0 +1,262 @@
+import asyncio
+import json
+import os
+import typing
+
+from .identity.community import IdentityCommunity, create_community
+from .identity.manager import IdentityManager
+from .wallet.community import AttestationCommunity
+from ..keyvault.crypto import ECCrypto
+from ..util import succeed
+
+
+class CommunicationChannel(object):
+
+    def __init__(self, attestation_community, identity_community):
+        super(CommunicationChannel, self).__init__()
+        self.attestation_overlay = attestation_community
+        self.identity_overlay = identity_community
+
+        self.attestation_requests = {}
+        self.verify_requests = {}
+        self.verification_output = {}
+        self.attestation_metadata = {}
+
+        self.attestation_overlay.set_attestation_request_callback(self.on_request_attestation)
+        self.attestation_overlay.set_attestation_request_complete_callback(self.on_attestation_complete)
+        self.attestation_overlay.set_verify_request_callback(self.on_verify_request)
+
+    @property
+    def public_key_bin(self):
+        return self.identity_overlay.my_peer.public_key.key_to_bin()
+
+    @property
+    def peers(self):
+        return self.identity_overlay.get_peers()
+
+    @property
+    def schemas(self):
+        return list(self.attestation_overlay.schema_manager.formats.keys())
+
+    def on_request_attestation(self, peer, attribute_name, metadata):
+        """
+        Return the measurement of an attribute for a certain peer.
+        """
+        future = asyncio.Future()
+        self.attestation_requests[(peer, attribute_name)] = (future, json.dumps(metadata))
+        self.attestation_metadata[(peer, attribute_name)] = metadata
+        return future
+
+    def on_attestation_complete(self, for_peer, attribute_name, attribute_hash, id_format, from_peer=None):
+        """
+        Callback for when an attestation has been completed for another peer.
+        We can now sign for it.
+        """
+        metadata = self.attestation_metadata.get((for_peer, attribute_name), None)
+        if for_peer == self.identity_overlay.my_peer:
+            if from_peer == self.identity_overlay.my_peer:
+                self.identity_overlay.self_advertise(attribute_hash, attribute_name, id_format, metadata)
+            else:
+                self.identity_overlay.request_attestation_advertisement(from_peer, attribute_hash, attribute_name,
+                                                                        id_format, metadata)
+        else:
+            self.identity_overlay.add_known_hash(attribute_hash, attribute_name, for_peer.public_key.key_to_bin(),
+                                                 metadata)
+
+    def on_verify_request(self, peer, attribute_hash):
+        """
+        Return the measurement of an attribute for a certain peer.
+        """
+        metadata = self.identity_overlay.get_attestation_by_hash(attribute_hash)
+        if not metadata:
+            return succeed(None)
+        attribute_name = json.loads(metadata.serialized_json_dict)["name"]
+        future = asyncio.Future()
+        self.verify_requests[(peer, attribute_name)] = future
+        return future
+
+    def on_verification_results(self, attribute_hash, values):
+        """
+        Callback for when verification has concluded.
+        """
+        references = self.verification_output[attribute_hash]
+        out = []
+        for i in range(len(references)):
+            out.append((references[i][0] if isinstance(references[i], tuple) else references[i], values[i]))
+        self.verification_output[attribute_hash] = out
+
+    def _drop_identity_table_data(self):
+        """
+        Remove all metadata from the identity community.
+
+        :return: the list of attestation hashes which have been removed
+        :rtype: [database_blob]
+        """
+        database = self.identity_overlay.identity_manager.database
+        attestation_hashes = [t.content_hash for t in database.get_tokens_for(self.identity_overlay.my_peer.public_key)]
+
+        database.executescript("BEGIN TRANSACTION; "
+                               "DELETE FROM Tokens WHERE public_key = ?; "
+                               "DELETE FROM Metadata WHERE public_key = ?; "
+                               "DELETE FROM Attestations WHERE public_key = ?; "
+                               "COMMIT;",
+                               (self.public_key_bin, self.public_key_bin, self.public_key_bin))
+        database.commit()
+
+        return attestation_hashes
+
+    def _drop_attestation_table_data(self, attestation_hashes):
+        """
+        Remove all attestation data (claim based keys and ZKP blobs) by list of attestation hashes.
+
+        :param attestation_hashes: hashes to remove
+        :type attestation_hashes: [database_blob]
+        :returns: None
+        """
+        if not attestation_hashes:
+            return
+
+        self.attestation_overlay.database.execute(("DELETE FROM %s" % self.attestation_overlay.database.db_name)
+                                                  + " WHERE hash IN ("
+                                                  + ", ".join(c for c in "?" * len(attestation_hashes))
+                                                  + ")",
+                                                  attestation_hashes)
+        self.attestation_overlay.database.commit()
+
+    def remove(self):
+        """
+        Remove this pseudonym from existence.
+        """
+        self._drop_attestation_table_data(self._drop_identity_table_data())
+        self.attestation_requests.clear()
+
+    def get_my_attributes(self):
+        return self.get_attributes(self.identity_overlay.my_peer)
+
+    def get_attributes(self, peer):
+        pseudonym = self.identity_overlay.identity_manager.get_pseudonym(peer.public_key)
+        out = {}
+        for credential in pseudonym.get_credentials():
+            attestations = list(credential.attestations)
+            attesters = []
+            for attestation in attestations:
+                attesters.append(self.identity_overlay.identity_manager.database.get_authority(attestation))
+            attribute_hash = pseudonym.tree.elements[credential.metadata.token_pointer].content_hash
+            json_metadata = json.loads(credential.metadata.serialized_json_dict)
+            out[attribute_hash] = (json_metadata["name"], json_metadata, attesters)
+        return out
+
+    def request_attestation(self, peer, attribute_name, id_format, metadata):
+        key = self.attestation_overlay.get_id_algorithm(id_format).generate_secret_key()
+        metadata.update({"id_format": id_format})
+        self.attestation_metadata[(self.identity_overlay.my_peer, attribute_name)] = metadata
+        self.attestation_overlay.request_attestation(peer, attribute_name, key, metadata)
+
+    def attest(self, peer, attribute_name, value):
+        outstanding = self.attestation_requests.pop((peer, attribute_name))
+        outstanding[0].set_result(value)
+
+    def import_blob(self, attribute_name, id_format, metadata, value):
+        metadata.update({"id_format": id_format})
+        self.attestation_overlay.dump_blob(attribute_name, id_format, value, metadata)
+
+    def allow_verification(self, peer, attribute_name):
+        outstanding = self.verify_requests.pop((peer, attribute_name))
+        outstanding.set_result(True)
+
+    def disallow_verification(self, peer, attribute_name):
+        outstanding = self.verify_requests.pop((peer, attribute_name))
+        outstanding.set_result(False)
+
+    def verify(self, peer, attribute_hash, reference_values, id_format):
+        self.verification_output[attribute_hash] = \
+            [(v, None) for v in reference_values]
+        self.attestation_overlay.verify_attestation_values(peer.address, attribute_hash, reference_values,
+                                                           self.on_verification_results, id_format)
+
+
+class CommunicationManager(object):
+
+    def __init__(self, ipv8_instance, pseudonym_folder: str = "pseudonyms", working_directory="."):
+        super(CommunicationManager, self).__init__()
+
+        self.ipv8_instance = ipv8_instance
+        self.channels = {}
+
+        self.working_directory = working_directory
+        self.pseudonym_folder = pseudonym_folder
+        self.name_to_channel = {}
+
+        self.crypto = ECCrypto()
+
+        loaded_community = ipv8_instance.get_overlay(IdentityCommunity)
+        if loaded_community is not None:
+            self.identity_manager = loaded_community.identity_manager
+        else:
+            self.identity_manager = IdentityManager(working_directory if working_directory == ":memory:"
+                                                    else os.path.join(working_directory, "identity.db"))
+
+    def load(self, name: str) -> CommunicationChannel:
+        """
+        Load a pseudonym.
+        """
+        if name in self.name_to_channel:
+            return self.name_to_channel[name]
+
+        os.makedirs(self.pseudonym_folder, exist_ok=True)
+        pseudonym_file = os.path.join(self.pseudonym_folder, name)
+        if os.path.exists(pseudonym_file):
+            with open(pseudonym_file, 'rb') as file_handle:
+                private_key = self.crypto.key_from_private_bin(file_handle.read())
+        else:
+            private_key = self.crypto.generate_key("curve25519")
+            with open(pseudonym_file, 'wb') as file_handle:
+                file_handle.write(private_key.key_to_bin())
+
+        public_key = private_key.pub().key_to_bin()
+        if public_key not in self.channels:
+            identity_overlay = create_community(private_key, self.ipv8_instance, self.identity_manager,
+                                                working_directory=self.working_directory)
+            attestation_overlay = AttestationCommunity(identity_overlay.my_peer, identity_overlay.endpoint,
+                                                       identity_overlay.network,
+                                                       working_directory=self.working_directory)
+            self.channels[public_key] = CommunicationChannel(attestation_overlay, identity_overlay)
+            self.name_to_channel[name] = self.channels[public_key]
+
+        return self.name_to_channel[name]
+
+    async def unload(self, name: str) -> None:
+        """
+        Unload a pseudonym.
+        """
+        if name in self.name_to_channel:
+            communication_channel = self.name_to_channel.pop(name)
+            self.channels.pop(communication_channel.public_key_bin)
+            await self.ipv8_instance.unload_overlay(communication_channel.identity_overlay)
+            await communication_channel.attestation_overlay.unload()
+            communication_channel.identity_overlay.endpoint.close()
+
+    async def remove(self, name: str) -> None:
+        """
+        Remove a pseudonym from existence by name.
+        """
+        if name in self.name_to_channel:
+            self.name_to_channel.pop(name).remove()
+            await self.unload(name)
+            pseudonym_file = os.path.join(self.pseudonym_folder, name)
+            if os.path.exists(pseudonym_file):
+                os.remove(pseudonym_file)
+
+    def list_names(self) -> typing.List[str]:
+        """
+        List all known pseudonyms.
+        """
+        if not os.path.exists(self.pseudonym_folder):
+            return []
+        return os.listdir(self.pseudonym_folder)
+
+    def list_loaded(self) -> typing.List[str]:
+        """
+        List all loaded pseudonyms by name.
+        """
+        return [name for name in self.list_names() if name in self.name_to_channel]

--- a/ipv8/attestation/wallet/community.py
+++ b/ipv8/attestation/wallet/community.py
@@ -18,7 +18,7 @@ from ...lazy_community import lazy_wrapper
 from ...messaging.payload_headers import BinMemberAuthenticationPayload, GlobalTimeDistributionPayload
 from ...peer import Peer
 from ...requestcache import RequestCache
-from ...util import cast_to_bin, cast_to_chr, cast_to_unicode, maybe_coroutine
+from ...util import cast_to_bin, cast_to_chr, maybe_coroutine
 
 
 def synchronized(f):
@@ -157,7 +157,7 @@ class AttestationCommunity(Community):
             "id_format": id_format
         }
         meta_dict.update(metadata)
-        metadata = cast_to_bin(json.dumps({cast_to_unicode(k): cast_to_unicode(v) for k, v in meta_dict.items()}))
+        metadata = json.dumps(meta_dict).encode()
 
         global_time = self.claim_global_time()
         auth = BinMemberAuthenticationPayload(self.my_peer.public_key.key_to_bin()).to_pack_list()

--- a/ipv8/test/REST/attestationendpoint/test_attestation_endpoint.py
+++ b/ipv8/test/REST/attestationendpoint/test_attestation_endpoint.py
@@ -214,8 +214,11 @@ class TestAttestationEndpoint(RESTTestBase):
                         "At least one of the verification responses was non-empty.")
 
         # Unlock the verification
-        outstanding_verifications = await self.make_outstanding_verify(self.nodes[1])
-        self.assertIsNotNone(outstanding_verifications, "Could not retrieve any outstanding verifications")
+        outstanding_verifications = []
+        while not outstanding_verifications:
+            outstanding_verifications = await self.make_outstanding_verify(self.nodes[1])
+            self.assertIsNotNone(outstanding_verifications, "Could not retrieve any outstanding verifications")
+            await self.deliver_messages()
 
         mid = outstanding_verifications[0][0]
         await self.make_allow_verify(self.nodes[1], 'QR', mid)
@@ -252,6 +255,7 @@ class TestAttestationEndpoint(RESTTestBase):
         while not outstanding_verifications:
             outstanding_verifications = await self.make_outstanding_verify(self.nodes[1])
             self.assertIsNotNone(outstanding_verifications, "Could not retrieve any outstanding verifications")
+            await self.deliver_messages()
 
         # Retrieve only the mids
         result = [x[0] for x in outstanding_verifications]
@@ -393,6 +397,7 @@ class TestAttestationEndpoint(RESTTestBase):
         while not outstanding_verifications:
             outstanding_verifications = await self.make_outstanding_verify(self.nodes[1])
             self.assertIsNotNone(outstanding_verifications, "Could not retrieve any outstanding verifications")
+            await self.deliver_messages()
 
         mid = outstanding_verifications[0][0]
         response = await self.make_allow_verify(self.nodes[1], 'QR', mid)

--- a/ipv8/test/REST/identity/test_identity_endpoint.py
+++ b/ipv8/test/REST/identity/test_identity_endpoint.py
@@ -1,0 +1,364 @@
+import base64
+import json
+import os
+import urllib.parse
+
+from ...REST.rest_base import RESTTestBase, partial_cls
+from ....attestation.communication_manager import CommunicationChannel
+from ....attestation.default_identity_formats import FORMATS
+from ....attestation.identity.community import IdentityCommunity
+from ....attestation.identity.manager import IdentityManager
+from ....attestation.wallet.community import AttestationCommunity
+from ....community import _DEFAULT_ADDRESSES
+from ....keyvault.crypto import ECCrypto
+
+
+class TestIdentityEndpoint(RESTTestBase):
+    """
+    Class for testing the REST API of the IdentityEndpoint
+    """
+
+    async def setUp(self):
+        super(TestIdentityEndpoint, self).setUp()
+
+        while _DEFAULT_ADDRESSES:
+            _DEFAULT_ADDRESSES.pop()
+
+        self.pseudonym_directories = []
+        identity_manager = IdentityManager(u":memory:")
+
+        await self.initialize([partial_cls(IdentityCommunity, identity_manager=identity_manager,
+                                           working_directory=':memory:')], 2)
+
+    async def create_node(self, *args, **kwargs):
+        """
+        We load each node i with a pseudonym `my_peer{i}`, which is the default IPv8 `my_peer` key.
+        """
+        ipv8 = await super(TestIdentityEndpoint, self).create_node(*args, **kwargs)
+        temp_dir = self.temporary_directory()
+        key_file_name = 'my_peer' + str(len(self.pseudonym_directories))
+        with open(os.path.join(temp_dir, key_file_name), 'wb') as f:
+            f.write(ipv8.my_peer.key.key_to_bin())
+        communication_manager = ipv8.rest_manager.root_endpoint.endpoints['/identity'].communication_manager
+        communication_manager.working_directory = ':memory:'
+        communication_manager.pseudonym_folder = temp_dir
+
+        identity_overlay = ipv8.get_overlay(IdentityCommunity)
+        attestation_overlay = AttestationCommunity(identity_overlay.my_peer, identity_overlay.endpoint,
+                                                   identity_overlay.network, working_directory=':memory:')
+        channel = CommunicationChannel(attestation_overlay, identity_overlay)
+
+        communication_manager.channels[ipv8.my_peer.public_key.key_to_bin()] = channel
+        communication_manager.name_to_channel[key_file_name] = channel
+        self.pseudonym_directories.append(temp_dir)
+        return ipv8
+
+    async def introduce_pseudonyms(self):
+        all_interfaces = []
+        for node in self.nodes:
+            all_interfaces.append([overlay.endpoint.wan_address for overlay in node.overlays
+                                   if isinstance(overlay, IdentityCommunity)])
+        for i in range(len(self.nodes)):
+            other_addresses = list(range(len(self.nodes)))
+            other_addresses.remove(i)
+            for j in other_addresses:
+                for overlay in self.nodes[i].overlays:
+                    if isinstance(overlay, IdentityCommunity):
+                        for address in all_interfaces[j]:
+                            overlay.walk_to(address)
+            await self.deliver_messages()
+
+    def node(self, i):
+        return self.nodes[i]
+
+    async def test_list_pseudonyms_empty(self):
+        """
+        Check that we do not start with any pseudonyms.
+        """
+        await self.make_request(self.node(0), 'identity/my_peer0/remove', 'get')
+        result = await self.make_request(self.node(0), 'identity', 'get')
+
+        self.assertDictEqual({'names': []}, result)
+
+    async def test_list_schemas(self):
+        """
+        Check that the endpoint reports the available schemas correctly.
+        """
+        schemas = await self.make_request(self.node(0), 'identity/test_pseudonym/schemas', 'get')
+
+        self.assertSetEqual(set(FORMATS.keys()), set(schemas['schemas']))
+
+    async def test_list_pseudonyms_one(self):
+        """
+        Check that a loaded pseudonym is reported as such.
+        """
+        result = await self.make_request(self.node(0), 'identity', 'get')
+
+        self.assertDictEqual({'names': ['my_peer0']}, result)
+
+    async def test_list_pseudonyms_many(self):
+        """
+        Check that all loaded pseudonyms are reported as such.
+        """
+        pseudonyms = ['test_pseudonym1', 'test_pseudonym2', 'test_pseudonym3', 'test_pseudonym4']
+        for pseudonym in pseudonyms:
+            await self.make_request(self.node(0), f'identity/{pseudonym}/schemas', 'get')
+
+        result = await self.make_request(self.node(0), 'identity', 'get')
+
+        self.assertSetEqual(set(pseudonyms) | {'my_peer0'}, set(result['names']))
+
+    async def test_list_public_key_one(self):
+        """
+        Check that we retrieve the pseudonym public key correctly.
+        """
+        result = await self.make_request(self.node(0), 'identity/test_pseudonym/public_key', 'get')
+        decoded_public_key = base64.b64decode(result['public_key'])
+
+        # This should have made the `test_pseudonym` private key file (corresponding to the reported public key).
+        key_file = os.path.join(self.pseudonym_directories[0], 'test_pseudonym')
+        with open(key_file, 'rb') as key_file_handle:
+            private_key = ECCrypto().key_from_private_bin(key_file_handle.read())
+
+        self.assertEqual(private_key.pub().key_to_bin(), decoded_public_key)
+
+    async def test_list_public_key_many(self):
+        """
+        Check that we retrieve the pseudonym public key correctly.
+        """
+        pseudonyms = ['test_pseudonym1', 'test_pseudonym2', 'test_pseudonym3', 'test_pseudonym4']
+        # Make sure all pseudonyms exist before querying their keys.
+        # This is not necessary, but has the highest chance of exposing failures.
+        for pseudonym in pseudonyms:
+            await self.make_request(self.node(0), f'identity/{pseudonym}/schemas', 'get')
+        for pseudonym in pseudonyms:
+            result = await self.make_request(self.node(0), f'identity/{pseudonym}/public_key', 'get')
+            decoded_public_key = base64.b64decode(result['public_key'])
+
+            key_file = os.path.join(self.pseudonym_directories[0], pseudonym)
+            with open(key_file, 'rb') as key_file_handle:
+                private_key = ECCrypto().key_from_private_bin(key_file_handle.read())
+
+            self.assertEqual(private_key.pub().key_to_bin(), decoded_public_key)
+
+    async def test_list_peers(self):
+        """
+        Check if peers are correctly listed.
+        """
+        result1 = await self.make_request(self.node(0), 'identity/my_peer0/peers', 'get')
+        result2 = await self.make_request(self.node(1), 'identity/my_peer1/peers', 'get')
+
+        self.assertListEqual([], result1['peers'])
+        self.assertListEqual([], result2['peers'])
+
+        await self.introduce_pseudonyms()
+
+        result1 = await self.make_request(self.node(0), 'identity/my_peer0/peers', 'get')
+        result2 = await self.make_request(self.node(1), 'identity/my_peer1/peers', 'get')
+
+        self.assertEqual(1, len(result1['peers']))
+        self.assertEqual(1, len(result2['peers']))
+
+    async def test_list_unload(self):
+        """
+        Check if a pseudonym stops communicating on unload.
+        """
+        await self.make_request(self.node(0), 'identity/my_peer0/unload', 'get')
+        await self.make_request(self.node(1), 'identity/my_peer1/unload', 'get')
+
+        self.assertListEqual([], self.node(0).overlays)
+        self.assertListEqual([], self.node(1).overlays)
+
+    async def test_list_credentials_empty(self):
+        """
+        Check that we retrieve credentials correctly, if none exist.
+        """
+        result = await self.make_request(self.node(0), 'identity/my_peer0/credentials', 'get')
+
+        self.assertListEqual([], result['names'])
+
+    async def test_request_attestation(self):
+        """
+        Check that requesting an attestation works.
+        """
+        b64_subject_key = (await self.make_request(self.node(0), 'identity/my_peer0/public_key', 'get'))['public_key']
+        result = await self.make_request(self.node(1), 'identity/my_peer1/public_key', 'get')
+        qb64_authority_key = urllib.parse.quote(result['public_key'], safe='')
+
+        await self.introduce_pseudonyms()
+
+        request = await self.make_request(self.node(0), f'identity/my_peer0/request/{qb64_authority_key}', 'put',
+                                          json={
+                                              "name": "My attribute",
+                                              "schema": "id_metadata",
+                                              "metadata": {}})
+        self.assertTrue(request['success'])
+
+        outstanding = await self.make_request(self.node(1), 'identity/my_peer1/outstanding/attestations', 'get')
+
+        self.assertEqual(1, len(outstanding['requests']))
+        self.assertEqual(b64_subject_key, outstanding['requests'][0]['peer'])
+        self.assertEqual("My attribute", outstanding['requests'][0]['attribute_name'])
+        self.assertDictEqual({}, json.loads(outstanding['requests'][0]['metadata']))
+
+    async def test_request_attestation_metadata(self):
+        """
+        Check that requesting an attestation with metadata works.
+        """
+        b64_subject_key = (await self.make_request(self.node(0), 'identity/my_peer0/public_key', 'get'))['public_key']
+        result = await self.make_request(self.node(1), 'identity/my_peer1/public_key', 'get')
+        qb64_authority_key = urllib.parse.quote(result['public_key'], safe='')
+
+        await self.introduce_pseudonyms()
+
+        request = await self.make_request(self.node(0), f'identity/my_peer0/request/{qb64_authority_key}', 'put',
+                                          json={
+                                              "name": "My attribute",
+                                              "schema": "id_metadata",
+                                              "metadata": {"Some key": "Some value"}})
+        self.assertTrue(request['success'])
+
+        outstanding = await self.make_request(self.node(1), 'identity/my_peer1/outstanding/attestations', 'get')
+
+        self.assertEqual(1, len(outstanding['requests']))
+        self.assertEqual(b64_subject_key, outstanding['requests'][0]['peer'])
+        self.assertEqual("My attribute", outstanding['requests'][0]['attribute_name'])
+        self.assertDictEqual({"Some key": "Some value"}, json.loads(outstanding['requests'][0]['metadata']))
+
+    async def test_attest(self):
+        """
+        Check that attesting to an attestation request with metadata works.
+        """
+        b64_subject_key = (await self.make_request(self.node(0), 'identity/my_peer0/public_key', 'get'))['public_key']
+        qb64_subject_key = urllib.parse.quote(b64_subject_key, safe='')
+        b64_authority_key = (await self.make_request(self.node(1), 'identity/my_peer1/public_key', 'get'))['public_key']
+        qb64_authority_key = urllib.parse.quote(b64_authority_key, safe='')
+        metadata = {"Some key": "Some value"}
+        request = {"name": "My attribute", "schema": "id_metadata", "metadata": metadata}
+
+        await self.introduce_pseudonyms()
+        await self.make_request(self.node(0), f'identity/my_peer0/request/{qb64_authority_key}', 'put', json=request)
+        await self.make_request(self.node(1), 'identity/my_peer1/outstanding/attestations', 'get')
+
+        result = await self.make_request(self.node(1), f'identity/my_peer1/attest/{qb64_subject_key}', 'put',
+                                         json={
+                                             "name": "My attribute",
+                                             "value": base64.b64encode(b'Some value').decode()})
+        self.assertTrue(result['success'])
+
+        # How node 0 sees itself after receiving the attestation
+        result = await self.make_request(self.node(0), 'identity/my_peer0/credentials', 'get')
+        self.assertEqual(1, len(result['names']))
+        self.assertEqual("My attribute", result['names'][0]['name'])
+        self.assertListEqual([b64_authority_key], result['names'][0]['attesters'])
+        for k, v in metadata.items():
+            self.assertIn(k, result['names'][0]['metadata'])
+            self.assertEqual(v, result['names'][0]['metadata'][k])
+
+        # How node 1 sees node 0 after making the attestation
+        result = await self.make_request(self.node(1), f'identity/my_peer1/credentials/{qb64_subject_key}', 'get')
+        self.assertEqual(1, len(result['names']))
+        self.assertEqual("My attribute", result['names'][0]['name'])
+        self.assertListEqual([b64_authority_key], result['names'][0]['attesters'])
+        for k, v in metadata.items():
+            self.assertIn(k, result['names'][0]['metadata'])
+            self.assertEqual(v, result['names'][0]['metadata'][k])
+
+    async def test_verify(self):
+        """
+        Check that verifying a credential works.
+        """
+        self.nodes.append(await self.create_node())  # We need a third node for this one
+
+        b64_subject_key = (await self.make_request(self.node(0), 'identity/my_peer0/public_key', 'get'))['public_key']
+        qb64_subject_key = urllib.parse.quote(b64_subject_key, safe='')
+        b64_authority_key = (await self.make_request(self.node(1), 'identity/my_peer1/public_key', 'get'))['public_key']
+        qb64_authority_key = urllib.parse.quote(b64_authority_key, safe='')
+        b64_verifier_key = (await self.make_request(self.node(2), 'identity/my_peer2/public_key', 'get'))['public_key']
+        qb64_verifier_key = urllib.parse.quote(b64_verifier_key, safe='')
+
+        metadata = {"Some key": "Some value"}
+        request = {"name": "My attribute", "schema": "id_metadata", "metadata": metadata}
+        attest = {"name": "My attribute", "value": base64.b64encode(b'Some value').decode()}
+
+        await self.introduce_pseudonyms()
+        await self.make_request(self.node(0), f'identity/my_peer0/request/{qb64_authority_key}', 'put', json=request)
+        await self.make_request(self.node(1), 'identity/my_peer1/outstanding/attestations', 'get')
+        await self.make_request(self.node(1), f'identity/my_peer1/attest/{qb64_subject_key}', 'put', json=attest)
+
+        credentials = await self.make_request(self.node(0), 'identity/my_peer0/credentials', 'get')
+        attribute_hash = credentials["names"][0]["hash"]
+
+        result = await self.make_request(self.node(2), f'identity/my_peer2/verify/{qb64_subject_key}', 'put',
+                                         json={
+                                             "hash": attribute_hash,
+                                             "value": attest["value"],
+                                             "schema": request["schema"]})
+        self.assertTrue(result['success'])
+
+        await self.deliver_messages()
+        verification_requests = (await self.make_request(self.node(0),
+                                                         f'identity/my_peer0/outstanding/verifications',
+                                                         'get'))['requests']
+        self.assertEqual(b64_verifier_key, verification_requests[0]['peer'])
+        self.assertEqual("My attribute", verification_requests[0]['attribute_name'])
+
+        result = await self.make_request(self.node(0), f'identity/my_peer0/allow/{qb64_verifier_key}', 'put',
+                                         json={"name": "My attribute"})
+        self.assertTrue(result['success'])
+
+        await self.deliver_messages()
+        output = await self.make_request(self.node(2), 'identity/my_peer2/verifications', 'get')
+
+        self.assertEqual(1, len(output['outputs']))
+        self.assertEqual(attribute_hash, output['outputs'][0]['hash'])
+        self.assertEqual(base64.b64encode(b'Some value').decode(), output['outputs'][0]['reference'])
+        self.assertGreaterEqual(output['outputs'][0]['match'], 0.98)
+
+    async def test_disallow_verify(self):
+        """
+        Check that no verification is performed, if not allowed.
+        """
+        self.nodes.append(await self.create_node())  # We need a third node for this one
+
+        b64_subject_key = (await self.make_request(self.node(0), 'identity/my_peer0/public_key', 'get'))['public_key']
+        qb64_subject_key = urllib.parse.quote(b64_subject_key, safe='')
+        b64_authority_key = (await self.make_request(self.node(1), 'identity/my_peer1/public_key', 'get'))['public_key']
+        qb64_authority_key = urllib.parse.quote(b64_authority_key, safe='')
+        b64_verifier_key = (await self.make_request(self.node(2), 'identity/my_peer2/public_key', 'get'))['public_key']
+        qb64_verifier_key = urllib.parse.quote(b64_verifier_key, safe='')
+
+        metadata = {"Some key": "Some value"}
+        request = {"name": "My attribute", "schema": "id_metadata", "metadata": metadata}
+        attest = {"name": "My attribute", "value": base64.b64encode(b'Some value').decode()}
+
+        await self.introduce_pseudonyms()
+        await self.make_request(self.node(0), f'identity/my_peer0/request/{qb64_authority_key}', 'put', json=request)
+        await self.make_request(self.node(1), 'identity/my_peer1/outstanding/attestations', 'get')
+        await self.make_request(self.node(1), f'identity/my_peer1/attest/{qb64_subject_key}', 'put', json=attest)
+
+        credentials = await self.make_request(self.node(0), 'identity/my_peer0/credentials', 'get')
+        attribute_hash = credentials["names"][0]["hash"]
+
+        result = await self.make_request(self.node(2), f'identity/my_peer2/verify/{qb64_subject_key}', 'put',
+                                         json={
+                                             "hash": attribute_hash,
+                                             "value": attest["value"],
+                                             "schema": request["schema"]})
+        self.assertTrue(result['success'])
+
+        await self.deliver_messages()
+        verification_requests = (await self.make_request(self.node(0),
+                                                         f'identity/my_peer0/outstanding/verifications',
+                                                         'get'))['requests']
+        self.assertEqual(b64_verifier_key, verification_requests[0]['peer'])
+        self.assertEqual("My attribute", verification_requests[0]['attribute_name'])
+
+        result = await self.make_request(self.node(0), f'identity/my_peer0/disallow/{qb64_verifier_key}', 'put',
+                                         json={"name": "My attribute"})
+        self.assertTrue(result['success'])
+
+        await self.deliver_messages()
+        output = await self.make_request(self.node(2), 'identity/my_peer2/verifications', 'get')
+
+        self.assertEqual(0, len(output['outputs']))

--- a/ipv8/test/REST/rest_base.py
+++ b/ipv8/test/REST/rest_base.py
@@ -41,6 +41,11 @@ class MockRestIPv8(object):
                            if strategy.overlay != instance]
         return maybe_coroutine(instance.unload)
 
+    def produce_anonymized_endpoint(self):
+        endpoint = AutoMockEndpoint()
+        endpoint.open()
+        return endpoint
+
     async def start_api(self):
         self.rest_manager = RESTManager(self)
         await self.rest_manager.start(0)
@@ -84,7 +89,7 @@ class RESTTestBase(TestBase):
                         overlay.walk_to(other.endpoint.wan_address)
         await self.deliver_messages()
 
-    async def make_request(self, node, endpoint, request_type, arguments, json_response=True):
+    async def make_request(self, node, endpoint, request_type, arguments=None, json_response=True, json=None):
         """
         Forward an HTTP request of the specified type to a url, with the specified set of arguments.
 
@@ -100,5 +105,5 @@ class RESTTestBase(TestBase):
         headers = {'User-Agent': 'aiohttp'}
 
         async with ClientSession() as session:
-            async with session.request(request_type, url, params=arguments, headers=headers) as response:
+            async with session.request(request_type, url, json=json, params=arguments, headers=headers) as response:
                 return await response.json(content_type=None) if json_response else await response.read()

--- a/ipv8/test/attestation/wallet/test_attestation_community.py
+++ b/ipv8/test/attestation/wallet/test_attestation_community.py
@@ -86,7 +86,7 @@ class TestCommunity(TestBase):
         def f(peer, attribute_name, metadata):
             self.assertEqual(peer.address, self.nodes[1].endpoint.wan_address)
             self.assertEqual(attribute_name, "MyAttribute")
-            self.assertDictEqual(metadata, {u'test': u'123'})
+            self.assertDictEqual(metadata, {u'test': 123})
 
             f.called = True
 

--- a/ipv8/test/base.py
+++ b/ipv8/test/base.py
@@ -146,7 +146,7 @@ class TestBase(asynctest.TestCase):
         await self.deliver_messages()
 
     def temporary_directory(self):
-        rndstr = 'temp_'.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(10))
+        rndstr = '_temp_' + ''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(10))
         d = os.path.abspath(self.__class__.__name__ + rndstr)
         self._tempdirs.append(d)
         os.makedirs(d)

--- a/ipv8_service.py
+++ b/ipv8_service.py
@@ -65,6 +65,9 @@ else:
     class IPv8(object):
 
         def __init__(self, configuration, endpoint_override=None, enable_statistics=False, extra_communities=None):
+            super(IPv8, self).__init__()
+            self.configuration = configuration
+
             if endpoint_override:
                 self.endpoint = endpoint_override
             else:
@@ -176,6 +179,11 @@ else:
 
         def get_overlays(self, overlay_cls):
             return (o for o in self.overlays if isinstance(o, overlay_cls))
+
+        def produce_anonymized_endpoint(self):
+            base_endpoint = UDPEndpoint(port=self.configuration['port'], ip=self.configuration['address'])
+            base_endpoint.open()
+            return TunnelEndpoint(base_endpoint)
 
         async def stop(self, stop_loop=True):
             if self.state_machine_task:


### PR DESCRIPTION
This PR:

 - Adds middleware (CommunicationManager/CommunicationChannel) for dealing with ID 2.0 pseudonyms.
 - Adds a new `identity` REST endpoint to replace `attestation` (and a lot of tests 😃).
 - Adds the factory method `produce_anonymized_endpoint` to `IPv8` to facilitate clean testing.
 - Fixes the name of the `temporary_directory` of `TestBase`.
 - Fixes the infinite loop on the main thread in the (old) attestation REST API.
 - Adds the ability to specify a JSON body to the REST test base in `make_request`.
 - Saves the launch configuration of IPv8 into `IPv8.configuration`.
 - Fixes #742
 - Fixes #774

Remaining for the roadmap of #733 after this PR are: updating the documentation and adding an access token for the API.