### PR TITLE
Added ConfigBuilder

### DIFF
--- a/ipv8/configuration.py
+++ b/ipv8/configuration.py
@@ -1,4 +1,7 @@
 import copy
+import enum
+import socket
+import typing
 
 default = {
     'address': '0.0.0.0',
@@ -138,4 +141,207 @@ def get_default_configuration():
     return copy.deepcopy(default)
 
 
-__all__ = ['get_default_configuration']
+class Strategy(enum.Enum):
+    RandomWalk = "RandomWalk"
+    RandomChurn = "RandomChurn"
+    PeriodicSimilarity = "PeriodicSimilarity"
+    EdgeWalk = "EdgeWalk"
+
+    @classmethod
+    def values(cls):
+        return [name for name, _ in cls.__members__.items()]
+
+
+class WalkerDefinition(typing.NamedTuple):
+    strategy: Strategy
+    peers: int
+    init: dict
+
+
+ConfigBuilderType = typing.TypeVar('ConfigBuilderType', bound='ConfigBuilder')
+
+
+class ConfigBuilder(object):
+
+    def __init__(self, clean: bool = False):
+        self.config = {} if clean else get_default_configuration()
+
+    def finalize(self) -> dict:
+        """
+        Process the builder input and check for errors, this produces a configuration dictionary suitable for IPv8.
+
+        Essentially this only checks the `config` variable for errors, use that instead if you're confident you never
+        make any errors.
+        """
+        assert self.config.get('address') is not None, "Missing address in config!"
+        assert self.config.get('port') is not None, "Missing port in config!"
+        assert self.config.get('keys') is not None, "Missing keys in config!"
+        assert self.config.get('logger') is not None, "Missing logger in config!"
+        assert self.config.get('walker_interval') is not None, "Missing walker_interval in config!"
+        assert self.config.get('overlays') is not None, "Missing overlays in config!"
+        assert self.config.get('working_directory') is not None, "Missing working_directory in config!"
+
+        socket.inet_aton(self.config.get('address'))  # Errors out if the address is illegal
+        assert 0 <= self.config['port'] <= 65535
+        assert self.config['walker_interval'] >= 0
+
+        for overlay in self.config['overlays']:
+            assert overlay.get('class') is not None, "Missing class in overlay config!"
+            assert overlay.get('key') is not None, f"Missing key in overlay config of {overlay['class']}!"
+            assert overlay.get('walkers') is not None, f"Missing walkers in overlay config of {overlay['class']}!"
+            assert overlay.get('initialize') is not None, f"Missing initialize in overlay config of {overlay['class']}!"
+            assert overlay.get('on_start') is not None, f"Missing on_start in overlay config of {overlay['class']}!"
+            assert any(key['alias'] == overlay['key'] for key in self.config['keys']),\
+                f"Unknown key alias {overlay['key']} in overlay config of {overlay['class']}!"
+            assert all(isinstance(key, str) for key in overlay['initialize'].keys()),\
+                f"Keyword argument mapping keys must be strings in overlay config of {overlay['class']}!"
+            assert all(isinstance(entry[0], str) for entry in overlay['on_start']),\
+                f"Start methods must be strings in overlay config of {overlay['class']}!"
+            for walker in overlay['walkers']:
+                assert walker.get('strategy') is not None,\
+                    f"Missing strategy class in strategy config of {overlay['class']}!"
+                assert walker.get('peers') is not None,\
+                    f"Missing peers in {walker['strategy']} config of {overlay['class']}!"
+                assert walker.get('init') is not None,\
+                    f"Missing init in {walker['strategy']} config of {overlay['class']}!"
+                assert walker['strategy'] in Strategy.values()
+                if (walker['strategy'] == Strategy.RandomChurn.value
+                        or walker['strategy'] == Strategy.PeriodicSimilarity.value):
+                    assert overlay['class'] == 'DiscoveryCommunity'
+
+        return self.config
+
+    def clear_keys(self) -> ConfigBuilderType:
+        """
+        Remove all keys in the current configuration.
+        """
+        self.config['keys'] = []
+        return self
+
+    def clear_overlays(self) -> ConfigBuilderType:
+        """
+        Remove all overlays in the current configuration.
+        """
+        self.config['overlays'] = []
+        return self
+
+    def set_address(self, address: str) -> ConfigBuilderType:
+        """
+        Set the address IPv8 is to try and bind to.
+
+        For localhost only use: 127.0.0.1
+        For Internet communication use: 0.0.0.0
+        """
+        assert address.count('.') == 3
+        self.config['address'] = address
+        return self
+
+    def set_port(self, port: int) -> ConfigBuilderType:
+        """
+        Set the port that IPv8 should TRY to bind to.
+        If your port is not available, IPv8 will try and find another one.
+        """
+        self.config['port'] = port
+        return self
+
+    def set_log_level(self, log_level: str) -> ConfigBuilderType:
+        """
+        Set the log level for all of IPv8's loggers.
+        Choose from 'CRITICAL', 'ERROR', 'WARNING', 'INFO', 'DEBUG' or 'NOTSET'.
+        """
+        assert log_level in ['CRITICAL', 'ERROR', 'WARNING', 'INFO', 'DEBUG', 'NOTSET']
+        self.config['logger'] = {'level': log_level}
+        return self
+
+    def set_working_directory(self, folder_path: str) -> ConfigBuilderType:
+        """
+        Set the common working directory for overlays.
+
+        Individual settings may override this working directory, but it serves as the base working directory.
+        """
+        self.config['working_directory'] = folder_path
+        return self
+
+    def set_walker_interval(self, interval: float) -> ConfigBuilderType:
+        """
+        Set the interval, in seconds, at which IPv8 schedules its strategies.
+
+        An interval of 3.14 would mean that each walker attempts to walk every 3.14 seconds.
+        Setting this interval too low will choke the event thread and decrease the QoS of IPv8 overlays.
+        Setting this interval too high will decrease the QoS of IPv8 overlays due to lack of content.
+        """
+        self.config['walker_interval'] = interval
+        return self
+
+    def add_key(self, alias: str, generation: str, file_path: str) -> ConfigBuilderType:
+        """
+        Add a key by alias and mode of generation, to be stored at a certain file path.
+
+        If a key already exists at the given file path, that will be loaded instead of generating a new key.
+        """
+        assert generation in ['curve25519', 'very-low', 'low', 'medium', 'high']
+        if 'keys' in self.config:
+            self.config['keys'] = [key for key in self.config['keys'] if key["alias"] != alias]
+        else:
+            self.config['keys'] = []
+        self.config['keys'].append({
+            'alias': alias,
+            'generation': generation,
+            'file': file_path
+        })
+        return self
+
+    def add_overlay(self,
+                    overlay_class: str,
+                    key_alias: str,
+                    walkers: typing.List[WalkerDefinition],
+                    initialize: typing.Dict[str, typing.Any],
+                    on_start: typing.List[tuple],
+                    allow_duplicate: bool = False) -> ConfigBuilderType:
+        """
+        Add an overlay by its class name. You can choose from the default communities or register your own (see IPv8's
+        ``extra_communities`` for the latter). Whatever key alias you choose for this overlay should be registered
+        through add_key.
+
+        The default communities include:
+
+         - 'AttestationCommunity'
+         - 'DiscoveryCommunity'
+         - 'HiddenTunnelCommunity'
+         - 'IdentityCommunity'
+         - 'TrustChainCommunity'
+         - 'TunnelCommunity'
+         - 'DHTDiscoveryCommunity'
+         - 'TrustChainTestnetCommunity'
+
+        The initialize argument is a key-value mapping passed to the constructor (__init__) of the overlay.
+
+        The on_start contains a list of tuples that specify the method to call on the overlay when IPv8 has initialized,
+        coupled to the positional arguments to pass to the method, for example to call ``some_method(1, 2)``:
+
+         [("some_method", 1, 2)]
+
+        Lastly, IPv8 is capable of loading two distinct instances of the same overlay class. Set ``allow_duplicate``
+        to explicitly allow this (usually this is programmer error).
+        """
+        if 'overlays' in self.config:
+            if not allow_duplicate:
+                self.config['overlays'] = [overlay for overlay in self.config['overlays']
+                                           if overlay["class"] != overlay_class]
+        else:
+            self.config['overlays'] = []
+        self.config['overlays'].append({
+            'class': overlay_class,
+            'key': key_alias,
+            'walkers': [{
+                'strategy': walker.strategy.value,
+                'peers': walker.peers,
+                'init': walker.init
+            } for walker in walkers],
+            'initialize': initialize,
+            'on_start': on_start
+        })
+        return self
+
+
+__all__ = ['ConfigBuilder', 'Strategy', 'WalkerDefinition', 'get_default_configuration']

--- a/ipv8/test/REST/identity/test_identity_endpoint.py
+++ b/ipv8/test/REST/identity/test_identity_endpoint.py
@@ -218,7 +218,10 @@ class TestIdentityEndpoint(RESTTestBase):
                                               "metadata": {"Some key": "Some value"}})
         self.assertTrue(request['success'])
 
-        outstanding = await self.make_request(self.node(1), 'identity/my_peer1/outstanding/attestations', 'get')
+        outstanding = []
+        while not outstanding:
+            await self.deliver_messages()
+            outstanding = await self.make_request(self.node(1), 'identity/my_peer1/outstanding/attestations', 'get')
 
         self.assertEqual(1, len(outstanding['requests']))
         self.assertEqual(b64_subject_key, outstanding['requests'][0]['peer'])
@@ -238,7 +241,12 @@ class TestIdentityEndpoint(RESTTestBase):
 
         await self.introduce_pseudonyms()
         await self.make_request(self.node(0), f'identity/my_peer0/request/{qb64_authority_key}', 'put', json=request)
-        await self.make_request(self.node(1), 'identity/my_peer1/outstanding/attestations', 'get')
+
+        attestation_requests = []
+        while not attestation_requests:
+            await self.deliver_messages()
+            attestation_requests = await self.make_request(self.node(1), 'identity/my_peer1/outstanding/attestations',
+                                                           'get')
 
         result = await self.make_request(self.node(1), f'identity/my_peer1/attest/{qb64_subject_key}', 'put',
                                          json={
@@ -296,10 +304,12 @@ class TestIdentityEndpoint(RESTTestBase):
                                              "schema": request["schema"]})
         self.assertTrue(result['success'])
 
-        await self.deliver_messages()
-        verification_requests = (await self.make_request(self.node(0),
-                                                         f'identity/my_peer0/outstanding/verifications',
-                                                         'get'))['requests']
+        verification_requests = []
+        while not verification_requests:
+            await self.deliver_messages()
+            verification_requests = (await self.make_request(self.node(0),
+                                                             f'identity/my_peer0/outstanding/verifications',
+                                                             'get'))['requests']
         self.assertEqual(b64_verifier_key, verification_requests[0]['peer'])
         self.assertEqual("My attribute", verification_requests[0]['attribute_name'])
 
@@ -347,10 +357,12 @@ class TestIdentityEndpoint(RESTTestBase):
                                              "schema": request["schema"]})
         self.assertTrue(result['success'])
 
-        await self.deliver_messages()
-        verification_requests = (await self.make_request(self.node(0),
-                                                         f'identity/my_peer0/outstanding/verifications',
-                                                         'get'))['requests']
+        verification_requests = []
+        while not verification_requests:
+            await self.deliver_messages()
+            verification_requests = (await self.make_request(self.node(0),
+                                                             f'identity/my_peer0/outstanding/verifications',
+                                                             'get'))['requests']
         self.assertEqual(b64_verifier_key, verification_requests[0]['peer'])
         self.assertEqual("My attribute", verification_requests[0]['attribute_name'])
 

--- a/ipv8/test/test_configuration.py
+++ b/ipv8/test/test_configuration.py
@@ -1,0 +1,318 @@
+import asynctest
+
+from ..configuration import ConfigBuilder, Strategy, WalkerDefinition, get_default_configuration
+
+
+class TestConfiguration(asynctest.TestCase):
+
+    def assertDictInDict(self, expected: dict, container: dict):
+        self.assertTrue(any(all(entry.get(key) == expected[key] for key in expected.keys())
+                            and len(entry) == len(expected)
+                            for entry in container))
+
+    def test_clear_keys(self):
+        """
+        Check if all keys are cleared when requested.
+        """
+        builder = ConfigBuilder().clear_keys()
+
+        self.assertEqual(0, len(builder.config['keys']))
+
+    def test_clear_overlays(self):
+        """
+        Check if all overlays are cleared when requested.
+        """
+        builder = ConfigBuilder().clear_overlays()
+
+        self.assertEqual(0, len(builder.finalize()['overlays']))
+
+    def test_add_illegal_port_negative(self):
+        """
+        Check if negative ports raise an error on finalization.
+        """
+        builder = ConfigBuilder().set_port(-1)
+
+        self.assertRaises(AssertionError, builder.finalize)
+
+    def test_add_illegal_port_big(self):
+        """
+        Check if ports over 65535 raise an error on finalization.
+        """
+        builder = ConfigBuilder().set_port(100000)
+
+        self.assertRaises(AssertionError, builder.finalize)
+
+    def test_change_port(self):
+        """
+        Check if changes to the port are finalized.
+        """
+        builder = ConfigBuilder().set_port(1000)
+
+        self.assertEqual(1000, builder.finalize()['port'])
+
+    def test_add_illegal_address(self):
+        """
+        Check if wrong IP addresses raise an error immediately.
+        """
+        builder = ConfigBuilder()
+
+        self.assertRaises(AssertionError, builder.set_address, "1.1.1")
+
+    def test_change_address(self):
+        """
+        Check if changes to the address are finalized.
+        """
+        builder = ConfigBuilder().set_address("1.1.1.1")
+
+        self.assertEqual("1.1.1.1", builder.finalize()['address'])
+
+    def test_set_illegal_log_level(self):
+        """
+        Check if wrong log levels raise an error immediately.
+        """
+        builder = ConfigBuilder()
+
+        self.assertRaises(AssertionError, builder.set_log_level, "I don't exist")
+
+    def test_change_log_level(self):
+        """
+        Check if changes to the log level are finalized.
+        """
+        builder = ConfigBuilder().set_log_level("CRITICAL")
+
+        self.assertEqual("CRITICAL", builder.finalize()['logger']['level'])
+
+    def test_set_illegal_walk_interval(self):
+        """
+        Check if negative walk intervals raise an error on finalization.
+        """
+        builder = ConfigBuilder().set_walker_interval(-1.0)
+
+        self.assertRaises(AssertionError, builder.finalize)
+
+    def test_change_walk_interval(self):
+        """
+        Check if changes to the walk interval are finalized.
+        """
+        builder = ConfigBuilder().set_walker_interval(3.14)
+
+        self.assertEqual(3.14, builder.finalize()['walker_interval'])
+
+    def test_add_key_illegal_curve(self):
+        """
+        Check if wrong key curves raise an error immediately.
+        """
+        builder = ConfigBuilder()
+
+        self.assertRaises(AssertionError, builder.add_key, "my key", "I don't exist", "some file")
+
+    def test_add_key(self):
+        """
+        Check if changes to the keys are finalized.
+        """
+        builder = ConfigBuilder().add_key("my new key", "very-low", "some file")
+
+        expected = {
+            'alias': "my new key",
+            'generation': "very-low",
+            'file': "some file"
+        }
+        keys = builder.finalize()['keys']
+
+        self.assertEqual(1 + len(get_default_configuration()['keys']), len(keys))
+        self.assertTrue(any(set(entry.items()) == set(expected.items()) for entry in keys))
+
+    def test_add_overlay_overwrite(self):
+        """
+        Check if the allow duplicate flag does not introduce duplicates.
+        """
+        builder = ConfigBuilder().add_overlay("DiscoveryCommunity", "anonymous id", [], {}, [], allow_duplicate=False)
+
+        expected = {
+            'class': "DiscoveryCommunity",
+            'key': "anonymous id",
+            'walkers': [],
+            'initialize': {},
+            'on_start': []
+        }
+
+        self.assertEqual(len(get_default_configuration()['overlays']), len(builder.finalize()['overlays']))
+        self.assertDictInDict(expected, builder.finalize()['overlays'])
+
+    def test_add_overlay_append(self):
+        """
+        Check if the duplicate overlays are simply appended.
+        """
+        builder = ConfigBuilder().add_overlay("DiscoveryCommunity", "anonymous id", [], {}, [], allow_duplicate=True)
+
+        expected = {
+            'class': "DiscoveryCommunity",
+            'key': "anonymous id",
+            'walkers': [],
+            'initialize': {},
+            'on_start': []
+        }
+
+        self.assertEqual(1 + len(get_default_configuration()['overlays']), len(builder.finalize()['overlays']))
+        self.assertDictInDict(expected, builder.finalize()['overlays'])
+
+    def test_add_overlay_complex(self):
+        """
+        Check if a complex overlay is correctly added.
+        """
+        builder = ConfigBuilder().add_overlay("MyCommunity",
+                                              "anonymous id",
+                                              [WalkerDefinition(Strategy.RandomWalk, 42, {'timeout': 3.0})],
+                                              {'settings': {"my_key": "my_value"}},
+                                              [('do_a_thing', 42), ('do_another_thing', )])
+
+        expected = {
+            'class': "MyCommunity",
+            'key': "anonymous id",
+            'walkers': [{
+                'strategy': "RandomWalk",
+                'peers': 42,
+                'init': {
+                    'timeout': 3.0
+                }
+            }],
+            'initialize': {'settings': {"my_key": "my_value"}},
+            'on_start': [('do_a_thing', 42), ('do_another_thing', )]
+        }
+
+        self.assertDictInDict(expected, builder.finalize()['overlays'])
+
+    def test_illegal_random_churn_strategy(self):
+        """
+        Only the DiscoveryCommunity may use the RandomChurn strategy.
+        """
+        builder = ConfigBuilder().add_overlay("MyCommunity",
+                                              "anonymous id",
+                                              [WalkerDefinition(Strategy.RandomChurn, 20, {})],
+                                              {},
+                                              [])
+
+        self.assertRaises(AssertionError, builder.finalize)
+
+    def test_illegal_periodic_similarity_strategy(self):
+        """
+        Only the DiscoveryCommunity may use the PeriodicSimilarity strategy.
+        """
+        builder = ConfigBuilder().add_overlay("MyCommunity",
+                                              "anonymous id",
+                                              [WalkerDefinition(Strategy.PeriodicSimilarity, 20, {})],
+                                              {},
+                                              [])
+
+        self.assertRaises(AssertionError, builder.finalize)
+
+    def test_correct_random_churn_strategy(self):
+        """
+        The DiscoveryCommunity may use the RandomChurn strategy.
+        """
+        builder = ConfigBuilder().add_overlay("DiscoveryCommunity",
+                                              "anonymous id",
+                                              [WalkerDefinition(Strategy.RandomChurn, 20, {})],
+                                              {},
+                                              [])
+
+        expected = {
+            'class': "DiscoveryCommunity",
+            'key': "anonymous id",
+            'walkers': [{
+                'strategy': "RandomChurn",
+                'peers': 20,
+                'init': {}
+            }],
+            'initialize': {},
+            'on_start': []
+        }
+
+        self.assertEqual(len(get_default_configuration()['overlays']), len(builder.finalize()['overlays']))
+        self.assertDictInDict(expected, builder.finalize()['overlays'])
+
+    def test_correct_periodic_similarity_strategy(self):
+        """
+        The DiscoveryCommunity may use the PeriodicSimilarity strategy.
+        """
+        builder = ConfigBuilder().add_overlay("DiscoveryCommunity",
+                                              "anonymous id",
+                                              [WalkerDefinition(Strategy.PeriodicSimilarity, 20, {})],
+                                              {},
+                                              [])
+
+        expected = {
+            'class': "DiscoveryCommunity",
+            'key': "anonymous id",
+            'walkers': [{
+                'strategy': "PeriodicSimilarity",
+                'peers': 20,
+                'init': {}
+            }],
+            'initialize': {},
+            'on_start': []
+        }
+
+        self.assertEqual(len(get_default_configuration()['overlays']), len(builder.finalize()['overlays']))
+        self.assertDictInDict(expected, builder.finalize()['overlays'])
+
+    def test_default_configuration(self):
+        """
+        Check if we can reconstruct the default configuration.
+        """
+        builder = ConfigBuilder(True).set_address("0.0.0.0") \
+                                     .set_port(8090) \
+                                     .add_key("anonymous id", "curve25519", "ec_multichain.pem") \
+                                     .set_log_level("INFO") \
+                                     .set_working_directory(".") \
+                                     .set_walker_interval(0.5) \
+                                     .add_overlay("DiscoveryCommunity",
+                                                  "anonymous id",
+                                                  [WalkerDefinition(Strategy.RandomWalk, 20, {'timeout': 3.0}),
+                                                   WalkerDefinition(Strategy.RandomChurn, -1, {
+                                                       'sample_size': 8,
+                                                       'ping_interval': 10.0,
+                                                       'inactive_time': 27.5,
+                                                       'drop_time': 57.5
+                                                   }),
+                                                   WalkerDefinition(Strategy.PeriodicSimilarity, -1, {})],
+                                                  {},
+                                                  [('resolve_dns_bootstrap_addresses', )]) \
+                                     .add_overlay("HiddenTunnelCommunity",
+                                                  "anonymous id",
+                                                  [WalkerDefinition(Strategy.RandomWalk, 20, {'timeout': 3.0})],
+                                                  {'settings': {
+                                                      'min_circuits': 1,
+                                                      'max_circuits': 1,
+                                                      'max_relays_or_exits': 100,
+                                                      'max_time': 10 * 60,
+                                                      'max_time_inactive': 20,
+                                                      'max_traffic': 250 * 1024 * 1024,
+                                                      'max_packets_without_reply': 50,
+                                                      'dht_lookup_interval': 30
+                                                  }},
+                                                  [('build_tunnels', 1)]) \
+                                     .add_overlay("TrustChainCommunity",
+                                                  "anonymous id",
+                                                  [WalkerDefinition(Strategy.EdgeWalk, 20, {'edge_length': 4,
+                                                                                            'neighborhood_size': 6,
+                                                                                            'edge_timeout': 3.0})],
+                                                  {},
+                                                  []) \
+                                     .add_overlay("AttestationCommunity",
+                                                  "anonymous id",
+                                                  [WalkerDefinition(Strategy.RandomWalk, 20, {'timeout': 3.0})],
+                                                  {'anonymize': True},
+                                                  []) \
+                                     .add_overlay("IdentityCommunity",
+                                                  "anonymous id",
+                                                  [WalkerDefinition(Strategy.RandomWalk, 20, {'timeout': 3.0})],
+                                                  {'anonymize': True},
+                                                  []) \
+                                     .add_overlay("DHTDiscoveryCommunity",
+                                                  "anonymous id",
+                                                  [WalkerDefinition(Strategy.RandomWalk, 20, {'timeout': 3.0})],
+                                                  {},
+                                                  [])
+
+        self.assertDictEqual(get_default_configuration(), builder.finalize())


### PR DESCRIPTION
Fixes #777.

This PR adds a builder object to construct IPv8 configurations. A typical example (this loads the DiscoveryCommunity with the default settings):

```python
builder = ConfigBuilder(True).set_address("0.0.0.0") \
                             .set_port(8090) \
                             .add_key("anonymous id", "curve25519", "ec_multichain.pem") \
                             .set_log_level("INFO") \
                             .set_working_directory(".") \
                             .set_walker_interval(0.5) \
                             .add_overlay("DiscoveryCommunity",
                                          "anonymous id",
                                          [WalkerDefinition(Strategy.RandomWalk, 20, {'timeout': 3.0}),
                                           WalkerDefinition(Strategy.RandomChurn, -1, {
                                               'sample_size': 8,
                                               'ping_interval': 10.0,
                                               'inactive_time': 27.5,
                                               'drop_time': 57.5
                                           }),
                                           WalkerDefinition(Strategy.PeriodicSimilarity, -1, {})],
                                          {},
                                          [('resolve_dns_bootstrap_addresses', )])
ipv8 = IPv8(builder.finalize())
```

The overlay tutorial has been updated and verified to work.

This PR also fixes [the frontpage builder failure on Mac](https://jenkins-ci.tribler.org/job/ipv8/job/test_ipv8_mac/386/console).