### PR TITLE
Updated auto version incrementer

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -20,13 +20,13 @@
 # -- Project information -----------------------------------------------------
 
 project = u'IPv8'
-copyright = u'2019, Tribler'
+copyright = '2019, Tribler'  # Do not change manually! Handled by github_increment_version.py
 author = u'Tribler'
 
 # The short X.Y version
-version = u'2.1'
+version = '2.1'  # Do not change manually! Handled by github_increment_version.py
 # The full version, including alpha/beta/rc tags
-release = u'2.1.0'
+release = '2.1.0'  # Do not change manually! Handled by github_increment_version.py
 
 
 # -- General configuration ---------------------------------------------------

--- a/github_increment_version.py
+++ b/github_increment_version.py
@@ -5,55 +5,171 @@ The suggested release message is used as the PR body.
 This script requires the additional dependency PyGithub.
 """
 import ast
+import datetime
 import getpass
 import sys
 from distutils.version import LooseVersion
 
-from github import Github
+from github import Github, InputGitTreeElement
 
-# MAKE SETUP.PY CHANGES
-print("[1/8] Parsing setup.py file")
 
-with open('setup.py', 'r') as f:
-    filecontents = f.read()
+def parse_setup():
+    print("[1/8] | Parsing setup.py file")
 
-treeobj = ast.parse(filecontents, 'setup.py')
+    with open('setup.py', 'r') as f:
+        file_contents = f.read()
 
-setup_expression = None
-for element in treeobj.body:
-    if isinstance(element, ast.Expr) and element.value.func.id == "setup":
-        setup_expression = element
+    treeobj = ast.parse(file_contents, 'setup.py')
 
-if not setup_expression:
-    print("No setup() found in setup.py")
-    sys.exit(1)
+    setup_expression = None
+    for element in treeobj.body:
+        if isinstance(element, ast.Expr) and element.value.func.id == "setup":
+            setup_expression = element
 
-print("[2/8] Modifying setup.py file")
-new_filecontents = ""
-old_version = ""
-old_version_tag = ""
-new_version = ""
-new_version_tag = ""
-for keyword in setup_expression.value.keywords:
-    if keyword.arg == "version":
-        lineno = keyword.value.lineno
-        coloffset = keyword.value.col_offset
-        old_version = keyword.value.s
-        version = LooseVersion(old_version)
+    if not setup_expression:
+        print("No setup() found in setup.py")
+        sys.exit(1)
 
-        new_vstring = version.version
-        old_version_tag = '.'.join(str(s) for s in new_vstring[:2])
-        new_vstring[1] += 1
-        new_version = '.'.join(str(s) for s in new_vstring)
-        new_version_tag = '.'.join(str(s) for s in new_vstring[:2])
+    return file_contents, setup_expression
 
-        new_split_filecontents = filecontents.splitlines(True)
+
+def parse_doc_conf():
+    print("[1/8] | Parsing doc/conf.py file")
+
+    with open('doc/conf.py', 'r') as f:
+        file_contents = f.read()
+
+    treeobj = ast.parse(file_contents, 'doc/conf.py')
+
+    copyright_element = None
+    version_element = None
+    release_element = None
+    for element in treeobj.body:
+        if isinstance(element, ast.Assign) and isinstance(element.value, ast.Constant):
+            if element.targets[0].id == "copyright":
+                copyright_element = element.value
+            elif element.targets[0].id == "version":
+                version_element = element.value
+            elif element.targets[0].id == "release":
+                release_element = element.value
+
+    if not copyright_element:
+        print("No 'copyright' assignment found in doc/conf.py")
+        sys.exit(1)
+    if not version_element:
+        print("No 'version' assignment found in doc/conf.py")
+        sys.exit(1)
+    if not release_element:
+        print("No 'release' assignment found in doc/conf.py")
+        sys.exit(1)
+
+    return file_contents, (copyright_element, version_element, release_element)
+
+
+def parse_rest_manager():
+    print("[1/8] | Parsing ipv8/REST/rest_manager.py file")
+
+    with open('ipv8/REST/rest_manager.py', 'r') as f:
+        file_contents = f.read()
+
+    treeobj = ast.parse(file_contents, 'ipv8/REST/rest_manager.py')
+
+    version_element = None
+    for element in treeobj.body:
+        if isinstance(element, ast.ClassDef) and element.name == "RESTManager":
+            for inner_definition in element.body:
+                if isinstance(inner_definition, ast.AsyncFunctionDef) and inner_definition.name == "start":
+                    for f_statement in inner_definition.body:
+                        if (isinstance(f_statement, ast.Expr)
+                                and isinstance(f_statement.value, ast.Call)
+                                and isinstance(f_statement.value.func, ast.Name)
+                                and f_statement.value.func.id == "setup_aiohttp_apispec"):
+                            for setup_arg in f_statement.value.keywords:
+                                if setup_arg.arg == "version":
+                                    version_element = setup_arg.value
+
+    if not version_element:
+        print("No 'version' assignment found in ipv8/REST/rest_manager.py")
+        sys.exit(1)
+
+    return file_contents, version_element
+
+
+def modify_setup(file_contents, setup_expression):
+    print("[2/8] | Modifying setup.py file")
+    new_filecontents = ""
+    old_version = ""
+    old_version_tag = ""
+    new_version = ""
+    new_version_tag = ""
+    for keyword in setup_expression.value.keywords:
+        if keyword.arg == "version":
+            lineno = keyword.value.lineno
+            coloffset = keyword.value.col_offset
+            old_version = keyword.value.s
+            version = LooseVersion(old_version)
+
+            new_vstring = version.version
+            old_version_tag = '.'.join(str(s) for s in new_vstring[:2])
+            new_vstring[1] += 1
+            new_version = '.'.join(str(s) for s in new_vstring)
+            new_version_tag = '.'.join(str(s) for s in new_vstring[:2])
+
+            new_split_filecontents = file_contents.splitlines(True)
+            source_line = new_split_filecontents[lineno - 1]
+            new_split_filecontents[lineno - 1] = (source_line[:coloffset + 1]
+                                                  + new_version
+                                                  + source_line[len(old_version) + coloffset + 1:])
+            new_filecontents = "".join(new_split_filecontents)
+            break
+    return old_version, old_version_tag, new_version, new_version_tag, new_filecontents
+
+
+def modify_docs(file_contents, ast_elements, new_version, new_version_tag):
+    print("[2/8] | Modifying doc/conf.py file")
+
+    to_insert = [f"2017-{datetime.datetime.now().year}, Tribler", new_version_tag, new_version]
+
+    new_split_filecontents = file_contents.splitlines(True)
+    for i, element in enumerate(ast_elements):
+        lineno = element.lineno
+        coloffset = element.col_offset
+        old_version = element.s
+
         source_line = new_split_filecontents[lineno - 1]
         new_split_filecontents[lineno - 1] = (source_line[:coloffset + 1]
-                                              + new_version
+                                              + to_insert[i]
                                               + source_line[len(old_version) + coloffset + 1:])
-        new_filecontents = "".join(new_split_filecontents)
-        break
+
+    return "".join(new_split_filecontents)
+
+
+def modify_rest_manager(file_contents, element, new_version_tag):
+    print("[2/8] | Modifying ipv8/REST/rest_manager.py file")
+
+    new_split_filecontents = file_contents.splitlines(True)
+
+    lineno = element.lineno
+    coloffset = element.col_offset
+    old_version = element.s
+
+    source_line = new_split_filecontents[lineno - 1]
+    new_split_filecontents[lineno - 1] = (source_line[:coloffset + 1]
+                                          + f"v{new_version_tag}"
+                                          + source_line[len(old_version) + coloffset + 1:])
+
+    return "".join(new_split_filecontents)
+
+
+print("[1/8] Parsing source files.")
+old_setup_file, setup_ast = parse_setup()
+old_docs_file, docs_ast_elements = parse_doc_conf()
+old_rest_manager_file, rest_manager_ast = parse_rest_manager()
+
+print("[2/8] Modifying source files")
+old_version, old_version_tag, new_version, new_version_tag, new_setup_file = modify_setup(old_setup_file, setup_ast)
+new_docs_file = modify_docs(old_docs_file, docs_ast_elements, new_version, new_version_tag)
+new_rest_manager_file = modify_rest_manager(old_rest_manager_file, rest_manager_ast, new_version_tag)
 
 # LOGIN
 print("[3/8] Requesting GitHub username and password")
@@ -105,11 +221,17 @@ for branch in ipv8_fork_repo.get_branches():
 print("[7/8] Pushing changes to branch on fork")
 
 sb = ipv8_repo.get_branch("master")
-ipv8_fork_repo.create_git_ref(ref='refs/heads/automated_version_update', sha=sb.commit.sha)
+git_commit_base = [ipv8_fork_repo.get_git_commit(sb.commit.sha)]
 
-contents = ipv8_fork_repo.get_contents("setup.py", ref='refs/heads/automated_version_update')
-ipv8_fork_repo.update_file(contents.path, "Automated version increment", new_filecontents, contents.sha,
-                           branch="automated_version_update")
+setup_file_tree_element = InputGitTreeElement("setup.py", "100644", "blob", new_setup_file)
+docs_file_tree_element = InputGitTreeElement("doc/conf.py", "100644", "blob", new_docs_file)
+rest_manager_tree_element = InputGitTreeElement("ipv8/REST/rest_manager.py", "100644", "blob", new_rest_manager_file)
+
+new_tree = ipv8_fork_repo.create_git_tree([setup_file_tree_element, docs_file_tree_element, rest_manager_tree_element],
+                                          ipv8_fork_repo.get_git_tree(sb.commit.sha))
+
+new_commit = ipv8_fork_repo.create_git_commit("Automated version increment", new_tree, git_commit_base)
+ipv8_fork_repo.create_git_ref(ref='refs/heads/automated_version_update', sha=new_commit.sha)
 
 # CREATE PULL REQUEST
 print("[8/8] Creating Pull Request to main repository")
@@ -119,14 +241,14 @@ pr = ipv8_repo.create_pull("Automated Version Update",
                            + "---\n"
                            + ("Tag version: %s\n" % new_version_tag)
                            + ("Release title: IPv8 v%s.%d release\n" % (new_version_tag, total_commits))
-                           + ("Body:\n")
+                           + "Body:\n"
                            + ("Includes the first %d commits (+%d since v%s) for IPv8, containing:\n" %
                               (total_commits, commits_since_last, old_version_tag))
-                           + ("\n - ")
+                           + "\n - "
                            + ("\n - ".join([c.commit.message.split('\n')[2]
                                             for c in comparison.commits if c.commit.message.startswith('Merge')])),
                            'master',
                            '{}:{}'.format(username, 'automated_version_update'), True)
 
-pr_labels = [l for l in ipv8_repo.get_labels() if l.name == "automatedpr"][0]
+pr_labels = [label for label in ipv8_repo.get_labels() if label.name == "automatedpr"][0]
 pr.add_to_labels(pr_labels)

--- a/ipv8/REST/rest_manager.py
+++ b/ipv8/REST/rest_manager.py
@@ -79,7 +79,7 @@ class RESTManager:
         setup_aiohttp_apispec(
             app=self.root_endpoint.app,
             title="IPv8 REST API documentation",
-            version="v1.9",
+            version="v1.9",  # Do not change manually! Handled by github_increment_version.py
             url="/docs/swagger.json",
             swagger_path="/docs",
         )

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     description='The Python implementation of the IPV8 library',
     long_description=long_description,
     long_description_content_type='text/markdown',
-    version='2.1.0',
+    version='2.1.0',  # Do not change manually! Handled by github_increment_version.py
     url='https://github.com/Tribler/py-ipv8',
     package_data={'': ['*.*']},
     packages=find_packages(),


### PR DESCRIPTION
Fixes #783

This PR modifies the `github_increment_version.py` script such that it updates all mentions of the IPv8 version in the source code.

Two notes:

 - The version specified in `setup.py` leads all others.
 - Because we modify multiple files at once, we can no longer use the simple GitHub update file API. Now we actually need a _tree_ to pack all the file edits into a single commit.

I'll perform a run of this script, so you can see the output: see #786.