### PR TITLE
DO NOT MERGE: Automated Version Update

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -20,13 +20,13 @@
 # -- Project information -----------------------------------------------------
 
 project = u'IPv8'
-copyright = u'2019, Tribler'
+copyright = '2017-2020, Tribler'  # Do not change manually! Handled by github_increment_version.py
 author = u'Tribler'
 
 # The short X.Y version
-version = u'2.1'
+version = '2.2'  # Do not change manually! Handled by github_increment_version.py
 # The full version, including alpha/beta/rc tags
-release = u'2.1.0'
+release = '2.2.0'  # Do not change manually! Handled by github_increment_version.py
 
 
 # -- General configuration ---------------------------------------------------

--- a/ipv8/REST/rest_manager.py
+++ b/ipv8/REST/rest_manager.py
@@ -79,7 +79,7 @@ class RESTManager:
         setup_aiohttp_apispec(
             app=self.root_endpoint.app,
             title="IPv8 REST API documentation",
-            version="v1.9",
+            version="v2.2",  # Do not change manually! Handled by github_increment_version.py
             url="/docs/swagger.json",
             swagger_path="/docs",
         )

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     description='The Python implementation of the IPV8 library',
     long_description=long_description,
     long_description_content_type='text/markdown',
-    version='2.1.0',
+    version='2.2.0',  # Do not change manually! Handled by github_increment_version.py
     url='https://github.com/Tribler/py-ipv8',
     package_data={'': ['*.*']},
     packages=find_packages(),


### PR DESCRIPTION
## This is a sample of the automated version update with the changes of #785

Suggested release message
---
Tag version: 2.2
Release title: IPv8 v2.2.1387 release
Body:
Includes the first 1387 commits (+90 since v2.1) for IPv8, containing:

 - Fixed automated GitHub PR script
 - Make the host binding for the REST api configurable
 - Refactored id formats into SchemaManager
 - Added token chaining datastructure
 - Various testing infrastructure improvements
 - Aesthetic changes and testing (documentation) updates
 - Update tunnel endpoint
 - Avoid loosing peer_flags on disconnect
 - Fix missing imports
 - Fix coverage report not registering module-import coverage
 - Added REST endpoint for measuring core drift
 - Added identity datatypes
 - Fixed PingChurn and updated DHT endpoints
 - Fixed bucket refreshing
 - Added identity manager structures
 - Fixed test runner ignoring failures.
 - Fixed DHT ping assert location
 - Fixed Trustchain update script
 - Updated DHT to use less bandwidth
 - Integrated ID 2.0 pseudonym management
 - Added Asyncio debug endpoints
 - Fix deadlock while shutting down RequestCache
 - Added apikey/TLS support to REST API server
 - Small fixes
 - Added v2 ID 2.0 REST API
 - Fixes and documentation for ID 2.0
 - Added ConfigBuilder
 - Test file consolidation and sanity fixes