### PR TITLE
Various fixes

### DIFF
--- a/ipv8/REST/attestation_endpoint.py
+++ b/ipv8/REST/attestation_endpoint.py
@@ -12,7 +12,7 @@ from ..attestation.identity.community import IdentityCommunity, create_community
 from ..attestation.wallet.community import AttestationCommunity
 from ..keyvault.crypto import default_eccrypto
 from ..peer import Peer
-from ..util import cast_to_bin, succeed
+from ..util import cast_to_bin, strip_sha1_padding, succeed
 
 
 class AttestationEndpoint(BaseEndpoint):
@@ -224,7 +224,7 @@ class AttestationEndpoint(BaseEndpoint):
                 # List of (name, attribute_hash, metadata, attester)
                 return Response([(
                     data[0],
-                    b64encode(attribute_hash.lstrip(b'SHA-1\x00\x00\x00\x00\x00\x00\x00')).decode(),
+                    b64encode(strip_sha1_padding(attribute_hash)).decode(),
                     data[1],
                     data[2]) for attribute_hash, data in trimmed.items()])
             else:

--- a/ipv8/REST/identity_endpoint.py
+++ b/ipv8/REST/identity_endpoint.py
@@ -9,6 +9,7 @@ from marshmallow.fields import Dict, Float, String
 from .base_endpoint import BaseEndpoint, HTTP_BAD_REQUEST, Response
 from .schema import DefaultResponseSchema, schema
 from ..attestation.communication_manager import CommunicationManager
+from ..util import strip_sha1_padding
 
 
 PseudonymListResponseSchema = schema(PseudonymListResponse={"names": [String]})
@@ -169,7 +170,7 @@ class IdentityEndpoint(BaseEndpoint):
         channel = await self.communication_manager.load(request.match_info['pseudonym_name'])
         return Response({"names": [{
             "name": data[0],
-            "hash": ez_b64_encode(attribute_hash.lstrip(b'SHA-1\x00\x00\x00\x00\x00\x00\x00')),
+            "hash": ez_b64_encode(strip_sha1_padding(attribute_hash)),
             "metadata": data[1],
             "attesters": [ez_b64_encode(attester) for attester in data[2]]
         }
@@ -216,7 +217,7 @@ class IdentityEndpoint(BaseEndpoint):
 
         return Response({"names": [{
             "name": data[0],
-            "hash": ez_b64_encode(attribute_hash.lstrip(b'SHA-1\x00\x00\x00\x00\x00\x00\x00')),
+            "hash": ez_b64_encode(strip_sha1_padding(attribute_hash)),
             "metadata": data[1],
             "attesters": [ez_b64_encode(attester) for attester in data[2]]
         }

--- a/ipv8/attestation/wallet/community.py
+++ b/ipv8/attestation/wallet/community.py
@@ -244,8 +244,13 @@ class AttestationCommunity(Community):
         """
         We received a request to verify one of our attestations. Send the requested attestation back.
         """
-        attestation_blob, = self.database.get_attestation_by_hash(payload.hash)
+        attestation_blob = self.database.get_attestation_by_hash(payload.hash)
         if not attestation_blob:
+            self.logger.warning("Dropping verification request of unknown hash!")
+            return
+        attestation_blob, = attestation_blob
+        if not attestation_blob:
+            self.logger.warning("Attestation blob for verification is empty!")
             return
 
         value = await maybe_coroutine(self.verify_request_callback, peer, payload.hash)

--- a/ipv8/taskmanager.py
+++ b/ipv8/taskmanager.py
@@ -1,5 +1,6 @@
 import logging
 import time
+import traceback
 from asyncio import CancelledError, Future, Task, ensure_future, gather, iscoroutinefunction, sleep
 from contextlib import suppress
 from functools import wraps
@@ -131,7 +132,7 @@ class TaskManager(object):
                 except CancelledError:
                     pass
                 except ignore as e:
-                    self._logger.error('Task resulted in error: %s', e)
+                    self._logger.error('Task resulted in error: %s\n%s', e, ''.join(traceback.format_exc()))
 
             self._pending_tasks[name] = task
             task.add_done_callback(done_cb)

--- a/ipv8/util.py
+++ b/ipv8/util.py
@@ -54,3 +54,7 @@ def coroutine(func):
     async def call_async(*args, **kwargs):
         return func(*args, **kwargs)
     return call_async
+
+
+def strip_sha1_padding(s: bytes):
+    return s[12:] if s.startswith(b'SHA-1\x00\x00\x00\x00\x00\x00\x00') else s


### PR DESCRIPTION
This PR:

 - Uses the best practice of using a multiprocessing `context` for test execution.
 - Adds the `-a` option to the script to not spam the logging output for loggers that do not support caret modifications (like our PR testers 😃).
 - Adds tracebacks to logging output of failed `TaskManager` tests.
 - Doesn't fail when receiving an unknown hash verification request.
 - Adds and uses a `wait_for` construction to avoid race conditions in the identity REST tests.
 - Fixes the `lstrip` bug.