### PR TITLE
Added convenience add strategy method

### DIFF
--- a/ipv8/attestation/identity/community.py
+++ b/ipv8/attestation/identity/community.py
@@ -294,8 +294,5 @@ async def create_community(private_key: PrivateKey, ipv8, identity_manager: Iden
         working_directory = ipv8.configuration.get("working_directory")
     community = IdentityCommunity(my_peer, endpoint, identity_manager=identity_manager,
                                   working_directory=working_directory, anonymize=anonymize)
-    strategy = RandomWalk(community)
-    with ipv8.overlay_lock:
-        ipv8.strategies.append((strategy, -1))
-        ipv8.overlays.append(community)
+    ipv8.add_strategy(community, RandomWalk(community), -1)
     return community

--- a/ipv8/messaging/anonymization/hidden_services.py
+++ b/ipv8/messaging/anonymization/hidden_services.py
@@ -482,10 +482,9 @@ class HiddenTunnelCommunity(TunnelCommunity):
             self.logger.error('No IPv8 service object available, cannot start PEXCommunity')
         elif payload.info_hash not in self.pex:
             community = PexCommunity(self.my_peer, self.endpoint, Network(), info_hash=payload.info_hash)
-            self.ipv8.overlays.append(community)
             # Since IPv8 takes a step every .5s until we have 10 peers, the PexCommunity will generate
             # a lot of traffic in case there are <10 peers in existence. Therefore, we slow the walk down to a 5s/step.
-            self.ipv8.strategies.append((RandomWalk(community, target_interval=5), 10))
+            self.ipv8.add_strategy(community, RandomWalk(community, target_interval=5), 10)
             self.pex[payload.info_hash] = community
 
         # PEX announce

--- a/ipv8/test/REST/rest_base.py
+++ b/ipv8/test/REST/rest_base.py
@@ -40,6 +40,11 @@ class MockRestIPv8(object):
     def get_overlay(self, overlay_cls):
         return next((o for o in self.overlays if isinstance(o, overlay_cls)), None)
 
+    def add_strategy(self, overlay, strategy, target_peers):
+        with self.overlay_lock:
+            self.overlays.append(overlay)
+            self.strategies.append((strategy, target_peers))
+
     def unload_overlay(self, instance):
         self.overlays = [overlay for overlay in self.overlays if overlay != instance]
         self.strategies = [(strategy, target_peers) for (strategy, target_peers) in self.strategies

--- a/ipv8/test/messaging/anonymization/test_hiddenservices.py
+++ b/ipv8/test/messaging/anonymization/test_hiddenservices.py
@@ -77,9 +77,6 @@ class TestHiddenServices(TestBase):
         settings.min_circuits = 0
         settings.max_circuits = 0
         ipv8 = MockIPv8(u"curve25519", HiddenTunnelCommunity, settings=settings)
-
-        ipv8.overlays = []
-        ipv8.strategies = []
         ipv8.overlay.ipv8 = ipv8
 
         # Then kill all automated circuit creation

--- a/ipv8/test/mocking/ipv8.py
+++ b/ipv8/test/mocking/ipv8.py
@@ -42,8 +42,15 @@ class MockIPv8(object):
         self.overlay.my_estimated_wan = self.endpoint.wan_address
         self.overlay.my_estimated_lan = self.endpoint.lan_address
 
+        self.overlays = []
+        self.strategies = []
+
         if enable_statistics:
             self.endpoint.enable_community_statistics(self.overlay.get_prefix(), True)
+
+    def add_strategy(self, overlay, strategy, target_peers):
+        self.overlays.append(overlay)
+        self.strategies.append((strategy, target_peers))
 
     def get_overlay(self, overlay_cls):
         return next(self.get_overlays(overlay_cls), None)

--- a/ipv8_service.py
+++ b/ipv8_service.py
@@ -167,6 +167,12 @@ else:
                     else:
                         await sleep(self.walk_interval)
 
+        def add_strategy(self, overlay, strategy, target_peers):
+            with self.overlay_lock:
+                if overlay not in self.overlays:
+                    self.overlays.append(overlay)
+                self.strategies.append((strategy, target_peers))
+
         def unload_overlay(self, instance):
             with self.overlay_lock:
                 self.overlays = [overlay for overlay in self.overlays if overlay != instance]


### PR DESCRIPTION
This PR adds a convenience method to add strategies/overlays to IPv8. This makes sure programmers don't have to worry about acquiring a lock.