### PR TITLE
Added settings for the sign timeouts

### DIFF
--- a/ipv8/attestation/trustchain/caches.py
+++ b/ipv8/attestation/trustchain/caches.py
@@ -93,14 +93,14 @@ class HalfBlockSignCache(NumberCache):
         Note that we use a very high timeout for a half block signature. Ideally, we would like to have a request
         cache without any timeouts and just keep track of outstanding signature requests but this isn't possible (yet).
         """
-        return 10.0
+        return self.community.settings.sign_attempt_delay
 
     def on_timeout(self):
         if self.sign_future.done():
             self._logger.debug("Race condition encountered with timeout/removal of HalfBlockSignCache, recovering.")
             return
         self._logger.info("Timeout for sign request for half block %s, note that it can still arrive!", self.half_block)
-        if self.timeouts < 360:
+        if self.timeouts < self.community.settings.sign_timeout:
             self.community.send_block(self.half_block, address=self.socket_address)
 
             async def add_later():

--- a/ipv8/attestation/trustchain/settings.py
+++ b/ipv8/attestation/trustchain/settings.py
@@ -24,3 +24,9 @@ class TrustChainSettings(object):
 
         # How many blocks at most we allow others to crawl in one batch
         self.max_crawl_batch = 10
+
+        # The delay in seconds after which we send a half block to the counterparty again
+        self.sign_attempt_delay = 10
+
+        # The timeout after which we stop trying to get the half block signed by the counterparty
+        self.sign_timeout = 360

--- a/ipv8/requestcache.py
+++ b/ipv8/requestcache.py
@@ -104,7 +104,7 @@ class RequestCache(TaskManager):
         assert isinstance(cache, NumberCache), type(cache)
         assert isinstance(cache.number, int), type(cache.number)
         assert isinstance(cache.prefix, str), type(cache.prefix)
-        assert isinstance(cache.timeout_delay, float), type(cache.timeout_delay)
+        assert isinstance(cache.timeout_delay, (int, float)), type(cache.timeout_delay)
         assert cache.timeout_delay > 0.0, cache.timeout_delay
 
         with self.lock:


### PR DESCRIPTION
I noticed that I frequently have to change these values during Gumby experiments, so I'm converting them to settings.

I also made the `RequestCache` accept integers.