### PR TITLE
Added a code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,46 @@
+# Code of Conduct
+
+Any contributor of the IPv8 project (by posting an issue or by contributing code) is expected to follow the following 3 rules.
+In case of minor transgressions you will be warned.
+Major transgressions will result in banishment from this project.
+Administrators reserve the right to judge the severity of your transgression: it is not up for debate.
+
+### 1. Abide by the Golden Rule.
+
+https://en.wikipedia.org/wiki/Golden_Rule
+
+Examples of violations include:
+
+ - Posting non-constructive issues (e.g. posting an issue titled "I don't like you" without content).
+ - Excessive trolling (e.g. to the point of violating rule 2 and 3).
+ - Aggression (e.g. swearing at others or sexual intimidation).
+ - Not respecting someone's time (e.g. posting exceptionally long issues or linking to unrelated resources).
+
+Violations of this nature will **usually result in a warning and an edit or removal of your original content and may be accompanied by a ban**.
+
+### 2. Respect the Universal Declaration of Human Rights.
+
+https://www.un.org/en/universal-declaration-human-rights/
+
+Examples of violations include judging contributions based on:
+
+ - Racism.
+ - Sexism.
+ - Political or theological views.
+ 
+Violations of this nature are usually criminalized by law and will **always result in a ban without warning**.
+The offending content will be removed.
+
+### 3. Be professional and scientific.
+
+IPv8 should be a safe space for development, free from societal pressures and political games.
+
+Examples of violations include:
+
+ - Changing code without fixing a bug or implementing a feature (e.g. including a new dependency because "everyone else is using it"). This leads to edit wars, see also https://en.wikipedia.org/wiki/Wikipedia:Lamest_edit_wars.
+ - Gaming GitHub metrics (e.g. insisting on being the one to merge  a Pull Request to get a larger amount of line changes).
+ - Being pedantic or belittling when giving feedback (e.g. insulting someones education when pointing out a flaw).
+ - Ungracefully receiving feedback (e.g. closing an unrelated Pull Request if your changes did not get accepted).
+ - Administrator rights abuse (e.g. not adhering to the contributing guidelines "because you're an administrator").
+
+Violations of this nature will **usually result in a warning and an edit of your original content**. But, in extreme cases, **may also result in a ban**.


### PR DESCRIPTION
GitHub recommends adding a code of conduct to the repository. Inspired by https://www.contributor-covenant.org/version/2/0/code_of_conduct/code_of_conduct.txt I set out to create an as-small and as-concrete as possible set of contributor conduct guidelines. This should, to some extent, also provide uniformity (and therefore fairness) in the punishment of offenses. Thankfully none of the presented transgressions have ever happened before.

I will leave this PR open for (at least) a week to foster discussion. Please leave your feedback (preferably collected in a single post) on this PR if you would like to see any changes.