### PR TITLE
Fixed IPv8 exit node script

### DIFF
--- a/scripts/exitnode_ipv8_only_plugin.py
+++ b/scripts/exitnode_ipv8_only_plugin.py
@@ -55,7 +55,7 @@ class ExitnodeIPv8Service(object):
                 overlay['initialize']['settings']['min_circuits'] = 0
                 overlay['initialize']['settings']['max_circuits'] = 0
                 overlay['initialize']['settings']['max_relays_or_exits'] = 1000
-                overlay['initialize']['settings']['peer_flags'] = PEER_FLAG_EXIT_IPV8
+                overlay['initialize']['settings']['peer_flags'] = {PEER_FLAG_EXIT_IPV8}
 
         self.ipv8 = IPv8(configuration, enable_statistics=statistics)
         await self.ipv8.start()

--- a/systemd/ipv8-exit-node@.service
+++ b/systemd/ipv8-exit-node@.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=IPv8 exit node listening at port %i
+
+[Service]
+ProtectSystem=yes
+
+Environment="PYTHONPATH=/opt/ipv8"
+
+WorkingDirectory=/opt/ipv8
+
+ExecStartPre=/bin/mkdir -p ${HOME}/%i
+ExecStart=/usr/bin/python3 scripts/exitnode_ipv8_only_plugin.py --listen_port=%i --statedir=${HOME}/%i
+
+User=ipv8_exitnode
+Group=ipv8_exitnode
+
+Restart=always
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
- Added a `.service` file for integration in `systemctl`.
- Fixed the `peer_status` variable when initializing the configuration.
- Added a `statedir` option to the IPv8 exit node script.