### PR TITLE
Make pseudonym directory in working directory

### DIFF
--- a/ipv8/attestation/communication_manager.py
+++ b/ipv8/attestation/communication_manager.py
@@ -185,20 +185,18 @@ class CommunicationManager(object):
         self.ipv8_instance = ipv8_instance
         self.channels = {}
 
-        self.pseudonym_folder = pseudonym_folder
         self.name_to_channel = {}
 
         self.crypto = ECCrypto()
 
         loaded_community = ipv8_instance.get_overlay(IdentityCommunity)
-        if loaded_community is not None:
-            self.identity_manager = loaded_community.identity_manager
-        else:
-            if working_directory is None:
-                working_directory = ipv8_instance.configuration.get("working_directory", ".")
-            self.identity_manager = None
+        self.identity_manager = None if loaded_community is None else loaded_community.identity_manager
+
+        if working_directory is None:
+            working_directory = ipv8_instance.configuration.get("working_directory", ".")
 
         self.working_directory = working_directory
+        self.pseudonym_folder = os.path.join(self.working_directory, pseudonym_folder)
 
     def lazy_identity_manager(self) -> IdentityManager:
         """


### PR DESCRIPTION
After #808 I conducted a full scale sanity check. I also found the `pseudonyms` folder being created in the current working directory instead of the `working_directory` specified by IPv8's configuration.

This PR:

  - Makes sure the `pseudonyms` folder is created in the specified `working_directory`.
  - Fixes a bug where using the default working dir with an already loaded `IdentityCommunity` would produce a `NoneType` error.