### PR TITLE
Removed check_num_packets from TunnelExitSocket

### DIFF
--- a/ipv8/configuration.py
+++ b/ipv8/configuration.py
@@ -71,7 +71,6 @@ default = {
                     'max_time': 10 * 60,
                     'max_time_inactive': 20,
                     'max_traffic': 250 * 1024 * 1024,
-                    'max_packets_without_reply': 50,
                     'dht_lookup_interval': 30
                 }
             },

--- a/ipv8/messaging/anonymization/community.py
+++ b/ipv8/messaging/anonymization/community.py
@@ -5,6 +5,7 @@ Author(s): Egbert Bouman
 """
 from asyncio import iscoroutine, sleep
 from binascii import unhexlify
+from collections import defaultdict
 
 from .caches import *
 from .endpoint import TunnelEndpoint
@@ -90,8 +91,6 @@ class TunnelSettings(object):
         # Maximum number of seconds before a circuit is considered inactive (and is removed)
         self.max_time_inactive = 20
         self.max_traffic = 250 * 1024 * 1024
-
-        self.max_packets_without_reply = 50
 
         # Maximum number of seconds circuit creation is allowed to take. Within this time period, the unverified hop
         # of the circuit can still change in case it is unresponsive.

--- a/ipv8/test/test_configuration.py
+++ b/ipv8/test/test_configuration.py
@@ -287,7 +287,6 @@ class TestConfiguration(TestBase):
                                                       'max_time': 10 * 60,
                                                       'max_time_inactive': 20,
                                                       'max_traffic': 250 * 1024 * 1024,
-                                                      'max_packets_without_reply': 50,
                                                       'dht_lookup_interval': 30
                                                   }},
                                                   [('build_tunnels', 1)]) \


### PR DESCRIPTION
After doing some tunnel performance monitoring, it turns out the circuits are often destroyed well before their time. Unfortunately, this is having a significant negative impact on performance.

Luckily we recently fixed an issue with the `DestroyPayload` not setting the `reason` field, so we can now see why this is happening. As it turns out the circuits are frequently destroyed because of [`check_num_packets`](https://github.com/Tribler/py-ipv8/blob/10836c5f70f0d381a6c808b0d4c24f5e07451d77/ipv8/messaging/anonymization/tunnel.py#L208). Given the fact that this restriction is rather arbitrary to begin with, I'd like to get rid of it.
