### PR TITLE
Updates to documentation

### DIFF
--- a/doc/basics/overlay_tutorial.rst
+++ b/doc/basics/overlay_tutorial.rst
@@ -226,52 +226,48 @@ Update your ``main.py`` once again to contain the following code:
 
     @vp_compile
     class MyMessage(VariablePayload):
-       format_list = ['I'] # When reading data, we unpack an unsigned integer from it.
-       names = ["clock"] # We will name this unsigned integer "clock"
+        msg_id = 1  # The byte identifying this message, must be unique per community.
+        format_list = ['I']  # When reading data, we unpack an unsigned integer from it.
+        names = ["clock"]  # We will name this unsigned integer "clock"
 
 
     class MyCommunity(Community):
-       master_peer = Peer(ECCrypto().generate_key(u"medium"))
+        master_peer = Peer(ECCrypto().generate_key(u"medium"))
 
-       def __init__(self, my_peer, endpoint, network):
-           super(MyCommunity, self).__init__(my_peer, endpoint, network)
-           # Register the message handler for messages with the identifier "1".
-           self.add_message_handler(1, self.on_message)
-           # The Lamport clock this peer maintains.
-           # This is for the example of global clock synchronization.
-           self.lamport_clock = 0
+        def __init__(self, my_peer, endpoint, network):
+            super(MyCommunity, self).__init__(my_peer, endpoint, network)
+            # Register the message handler for messages with the identifier "1".
+            self.add_message_handler(1, self.on_message)
+            # The Lamport clock this peer maintains.
+            # This is for the example of global clock synchronization.
+            self.lamport_clock = 0
 
-       def started(self):
-           async def start_communication():
-               if not self.lamport_clock:
-                   # If we have not started counting, try boostrapping
-                   # communication with our other known peers.
-                   for p in self.get_peers():
-                       self.send_message(p.address)
-               else:
-                   self.cancel_pending_task("start_communication")
-           self.register_task("start_communication", start_communication, interval=5.0, delay=0)
+        def started(self):
+            async def start_communication():
+                if not self.lamport_clock:
+                    # If we have not started counting, try boostrapping
+                    # communication with our other known peers.
+                    for p in self.get_peers():
+                        self.ez_send(p, MyMessage(self.lamport_clock))
+                else:
+                    self.cancel_pending_task("start_communication")
+            self.register_task("start_communication", start_communication, interval=5.0, delay=0)
 
-       def send_message(self, address):
-           # Send a message with our digital signature on it.
-           # We use the latest version of our Lamport clock.
-           self.endpoint.send(address, self.ezr_pack(1, MyMessage(self.lamport_clock)))
-
-       @lazy_wrapper(MyMessage)
-       def on_message(self, peer, payload):
-           # Update our Lamport clock.
-           self.lamport_clock = max(self.lamport_clock, payload.clock) + 1
-           print(self.my_peer, "current clock:", self.lamport_clock)
-           # Then synchronize with the rest of the network again.
-           self.send_message(peer.address)
+        @lazy_wrapper(MyMessage)
+        def on_message(self, peer, payload):
+            # Update our Lamport clock.
+            self.lamport_clock = max(self.lamport_clock, payload.clock) + 1
+            print(self.my_peer, "current clock:", self.lamport_clock)
+            # Then synchronize with the rest of the network again.
+            self.ez_send(peer, MyMessage(self.lamport_clock))
 
 
     async def start_communities():
-       for i in [1, 2, 3]:
-           builder = ConfigBuilder().clear_keys().clear_overlays()
-           builder.add_key("my peer", "medium", f"ec{i}.pem")
-           builder.add_overlay("MyCommunity", "my peer", [WalkerDefinition(Strategy.RandomWalk, 10, {'timeout': 3.0})], {}, [('started', )])
-           await IPv8(builder.finalize(), extra_communities={'MyCommunity': MyCommunity}).start()
+        for i in [1, 2, 3]:
+            builder = ConfigBuilder().clear_keys().clear_overlays()
+            builder.add_key("my peer", "medium", f"ec{i}.pem")
+            builder.add_overlay("MyCommunity", "my peer", [WalkerDefinition(Strategy.RandomWalk, 10, {'timeout': 3.0})], {}, [('started', )])
+            await IPv8(builder.finalize(), extra_communities={'MyCommunity': MyCommunity}).start()
 
     ensure_future(start_communities())
     get_event_loop().run_forever()

--- a/doc/further-reading/advanced_identity.rst
+++ b/doc/further-reading/advanced_identity.rst
@@ -76,6 +76,44 @@ All requests to the core will then have to use either:
 
 Any HTTP request without either of these entries or using the wrong key will be dropped.
 
+Using a REST API X509 certificate
+---------------------------------
+
+**Purpose:** *provide transport layer security (TLS) for the REST API.*
+
+In the basic identity tutorial we started the REST API as follows:
+
+.. code-block:: python
+
+    for peer_id in [1, 2]:
+        ipv8 = IPv8(configuration)
+        await ipv8.start()
+        rest_manager = RESTManager(ipv8)
+        await rest_manager.start(14410 + peer_id)
+
+To use a certificate file, we will have to pass it to the ``RESTManager`` constructor, as follows (replacing ``cert_fileX`` with the file path of your certificate file for the particular IPv8 instance):
+
+.. code-block:: python
+
+    for peer_id in [1, 2]:
+        ipv8 = IPv8(configuration)
+        await ipv8.start()
+        ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+        ssl_context.load_cert_chain(cert_fileX)
+        rest_manager = RESTManager(ipv8, ssl_context=ssl_context)
+        await rest_manager.start(14410 + peer_id)
+
+This can (and should) be combined with an API key.
+Also note that if you start two IPv8 instances, you would normally want them to have different certificates.
+
+If you don't have a certificate file, you can generate one with ``openssl`` as follows:
+
+.. code-block:: bash
+
+    openssl req -newkey rsa:2048 -nodes -keyout private.key -x509 -days 365 -out certfile.pem
+    cat private.key >> certfile.pem
+    rm private.key
+
 Setting a rendezvous token
 --------------------------
 


### PR DESCRIPTION
Fixes #816
Fixes #818

This PR:

 - Adds a description of using X509 certificates for REST API TLS.
 - Updates the overlay tutorial to use `ez_send`.


