### PR TITLE
Removed identity communities from default configuration

### DIFF
--- a/ipv8/configuration.py
+++ b/ipv8/configuration.py
@@ -94,32 +94,6 @@ default = {
             'on_start': []
         },
         {
-            'class': 'AttestationCommunity',
-            'key': "anonymous id",
-            'walkers': [{
-                'strategy': "RandomWalk",
-                'peers': 20,
-                'init': {
-                    'timeout': 3.0
-                }
-            }],
-            'initialize': {'anonymize': True},
-            'on_start': []
-        },
-        {
-            'class': 'IdentityCommunity',
-            'key': "anonymous id",
-            'walkers': [{
-                'strategy': "RandomWalk",
-                'peers': 20,
-                'init': {
-                    'timeout': 3.0
-                }
-            }],
-            'initialize': {'anonymize': True},
-            'on_start': []
-        },
-        {
             'class': 'DHTDiscoveryCommunity',
             'key': "anonymous id",
             'walkers': [{

--- a/ipv8/test/test_configuration.py
+++ b/ipv8/test/test_configuration.py
@@ -297,16 +297,6 @@ class TestConfiguration(TestBase):
                                                                                             'edge_timeout': 3.0})],
                                                   {},
                                                   []) \
-                                     .add_overlay("AttestationCommunity",
-                                                  "anonymous id",
-                                                  [WalkerDefinition(Strategy.RandomWalk, 20, {'timeout': 3.0})],
-                                                  {'anonymize': True},
-                                                  []) \
-                                     .add_overlay("IdentityCommunity",
-                                                  "anonymous id",
-                                                  [WalkerDefinition(Strategy.RandomWalk, 20, {'timeout': 3.0})],
-                                                  {'anonymize': True},
-                                                  []) \
                                      .add_overlay("DHTDiscoveryCommunity",
                                                   "anonymous id",
                                                   [WalkerDefinition(Strategy.RandomWalk, 20, {'timeout': 3.0})],


### PR DESCRIPTION
Fixes #824

This PR:

 - Removes the `IdentityCommunity` and `AttestationCommunity` from the **default** configuration (they are still configurable for backwards compatibility).
 
