### PR TITLE
Added EndpointDispatcher

### DIFF
--- a/ipv8/messaging/interfaces/dispatcher/endpoint.py
+++ b/ipv8/messaging/interfaces/dispatcher/endpoint.py
@@ -1,0 +1,134 @@
+import ipaddress
+import logging
+import typing
+
+from ..endpoint import Endpoint
+from ..udp.endpoint import UDPEndpoint, UDPv4Address, UDPv6Address, UDPv6Endpoint
+
+INTERFACES = {
+    "UDPIPv4": UDPEndpoint,
+    "UDPIPv6": UDPv6Endpoint
+}
+"""
+The INTERFACES dictionary describes the mapping of interface names to interface classes.
+"""
+
+PREFERENCE_ORDER = [
+    "UDPIPv4",
+    "UDPIPv6"
+]
+"""
+The PREFERENCE_ORDER list describes the order of preference for the available interfaces.
+For example, ``["UDPIPv4", "UDPIPv6"]`` means: use IPv4 over IPv6, if it is available.
+"""
+
+
+FAST_ADDR_TO_INTERFACE = {
+    UDPv4Address: "UDPIPv4",
+    UDPv6Address: "UDPIPv6"
+}
+"""
+The FAST_ADDR_TO_INTERFACE is an internal DispatcherEndpoint mapping, to quickly route information.
+For addresses which do not use these classes the slower ``guess_interface`` will be used.
+"""
+
+
+def guess_interface(socket_address: typing.Any):
+    """
+    Attempt to guess the interface for the given address.
+
+    If the given address is a tuple of a valid IPv4 address string and a port this returns "UDPIPv4".
+    If the given address is a tuple of a valid IPv6 address string and a port this returns "UDPIPv6".
+    Otherwise, this returns None.
+    """
+    try:
+        if (isinstance(socket_address, tuple) and len(socket_address) == 2
+                and isinstance(socket_address[0], str) and isinstance(socket_address[1], int)):
+            if isinstance(ipaddress.ip_address(socket_address[0]), ipaddress.IPv4Address):
+                return "UDPIPv4"
+            else:
+                return "UDPIPv6"
+    except Exception:
+        logging.exception("Exception occurred while guessing interface for %s", repr(socket_address))
+    return None
+
+
+class DispatcherEndpoint(Endpoint):
+    """
+    An Endpoint implementation to dispatch to other Endpoint implementations.
+
+    The added complexity is as follows:
+
+     - Receiving of packets is hooked directly into the sub-Endpoints, no speed is lost.
+     - Sending packets will be directed to the appropriate interface. If an address object class is not defined in
+       FAST_ADDR_TO_INTERFACE, this will have to use ``guess_interface``.
+     - Adding and removing listeners will have to be forwarded to all sub-Endpoints.
+    """
+
+    def __init__(self, interfaces: typing.List[str], **kwargs) -> None:
+        """
+        Create a new DispatcherEndpoint by giving a list of interfaces to load (check INTERFACES for available
+        interfaces).
+
+        You can optionally supply keyword arguments to launch each selected Endpoint implementation, for example:
+
+         .. code-block :: Python
+
+            DispatcherEndpoint(["UDPIPv4"], UDPIPv4={'port': my_custom_port})
+
+        :param interfaces: list of interfaces to load.
+        :param kwargs: optional interface-specific launch arguments.
+        :returns: None
+        """
+        super(DispatcherEndpoint, self).__init__()
+        # Filter the available interfaces and preference order, based on the user's selection.
+        self.interfaces = {interface: INTERFACES[interface](**(kwargs.get(interface, {}))) for interface in interfaces}
+        self.interface_order = [interface for interface in PREFERENCE_ORDER if interface in interfaces]
+        # The order of preference will not change, we can precompute the preferred interface Endpoint.
+        self._preferred_interface = self.interfaces[self.interface_order[0]] if self.interface_order else None
+
+    def add_listener(self, listener) -> None:
+        for interface in self.interfaces.values():
+            interface.add_listener(listener)
+
+    def add_prefix_listener(self, listener, prefix) -> None:
+        for interface in self.interfaces.values():
+            interface.add_prefix_listener(listener, prefix)
+
+    def remove_listener(self, listener) -> None:
+        for interface in self.interfaces.values():
+            interface.remove_listener(listener)
+
+    def notify_listeners(self, packet) -> None:
+        for interface in self.interfaces.values():
+            interface.notify_listeners(packet)
+
+    def assert_open(self) -> None:
+        assert self.is_open()
+
+    def is_open(self) -> bool:
+        return any(interface.is_open() for interface in self.interfaces.values())
+
+    def get_address(self, interface=None) -> typing.Optional[typing.Any]:
+        if interface is not None:
+            return self.interfaces[interface].get_address()
+        elif self._preferred_interface:
+            return self._preferred_interface.get_address()
+
+    def send(self, socket_address, packet, interface=None) -> None:
+        if interface is not None:
+            self.interfaces[interface].send(socket_address, packet)
+        elif socket_address.__class__ in FAST_ADDR_TO_INTERFACE:
+            self.interfaces[FAST_ADDR_TO_INTERFACE[socket_address.__class__]].send(socket_address, packet)
+        else:
+            interface = guess_interface(socket_address)
+            if interface is not None:
+                self.interfaces[interface].send(socket_address, packet)
+
+    async def open(self) -> None:
+        for interface in self.interfaces.values():
+            await interface.open()
+
+    def close(self) -> None:
+        for interface in self.interfaces.values():
+            interface.close()

--- a/ipv8/messaging/interfaces/endpoint.py
+++ b/ipv8/messaging/interfaces/endpoint.py
@@ -125,7 +125,7 @@ class EndpointListener(metaclass=abc.ABCMeta):
         self.endpoint = endpoint
 
         self._netifaces_failed = netifaces is None
-        self.my_estimated_lan = (self._get_lan_address(True)[0], self.endpoint._port)
+        self.my_estimated_lan = (self._get_lan_address(True)[0], getattr(self.endpoint, "_port", 0))
         self.my_estimated_wan = self.my_estimated_lan
 
     @property

--- a/ipv8_service.py
+++ b/ipv8_service.py
@@ -21,6 +21,7 @@ else:
         from ipv8.messaging.anonymization.community import TunnelCommunity
         from ipv8.messaging.anonymization.endpoint import TunnelEndpoint
         from ipv8.messaging.anonymization.hidden_services import HiddenTunnelCommunity
+        from ipv8.messaging.interfaces.dispatcher.endpoint import DispatcherEndpoint
         from ipv8.messaging.interfaces.udp.endpoint import UDPEndpoint
         from ipv8.peer import Peer
         from ipv8.peerdiscovery.community import DiscoveryCommunity
@@ -38,6 +39,7 @@ else:
         from .ipv8.messaging.anonymization.community import TunnelCommunity
         from .ipv8.messaging.anonymization.endpoint import TunnelEndpoint
         from .ipv8.messaging.anonymization.hidden_services import HiddenTunnelCommunity
+        from .ipv8.messaging.interfaces.dispatcher.endpoint import DispatcherEndpoint
         from .ipv8.messaging.interfaces.udp.endpoint import UDPEndpoint
         from .ipv8.peer import Peer
         from .ipv8.peerdiscovery.community import DiscoveryCommunity
@@ -71,7 +73,9 @@ else:
             if endpoint_override:
                 self.endpoint = endpoint_override
             else:
-                self.endpoint = UDPEndpoint(port=configuration['port'], ip=configuration['address'])
+                self.endpoint = DispatcherEndpoint(["UDPIPv4"],
+                                                   UDPIPv4={'port': configuration['port'],
+                                                            'ip': configuration['address']})
                 if enable_statistics:
                     self.endpoint = StatisticsEndpoint(self, self.endpoint)
                 if any([overlay.get('initialize', {}).get('anonymize') for overlay in configuration['overlays']]):


### PR DESCRIPTION
Related to https://github.com/Tribler/py-ipv8/issues/615#issuecomment-667913436

This is the first step in moving from a single universal Endpoint to multiple concurrent Endpoints.

This implementation is fully backwards compatible with our current configuration and usage, also within Tribler.

This PR:

 - Adds the DispatcherEndpoint to dispatch to multiple Endpoint implementations (as opposed to choosing just one).
 - Adds the UDPv6Endpoint for sending and receiving IPv6 traffic.

Note that we cannot expose this IPv6 functionality yet, as receiving IPv6 traffic will absolutely decimate most Community logic.
Future work also includes having Peers maintain a dictionary of address per interface, instead of just one address.