### PR TITLE
Added speed test functionality to TunnelCommunity

### DIFF
--- a/ipv8/messaging/anonymization/caches.py
+++ b/ipv8/messaging/anonymization/caches.py
@@ -1,4 +1,5 @@
 import logging
+import time
 from asyncio import Future
 
 from .tunnel import CIRCUIT_STATE_CLOSING, CIRCUIT_STATE_READY
@@ -148,6 +149,19 @@ class LinkRequestCache(RandomNumberCache):
         self.circuit = circuit
         self.info_hash = info_hash
         self.hs_session_keys = hs_session_keys
+
+    def on_timeout(self):
+        pass
+
+
+class TestRequestCache(RandomNumberCache):
+
+    def __init__(self, community, circuit):
+        super(TestRequestCache, self).__init__(community.request_cache, "test-request")
+        self.circuit = circuit
+        self.ts = time.time()
+        self.future = Future()
+        self.register_future(self.future)
 
     def on_timeout(self):
         pass

--- a/ipv8/messaging/anonymization/endpoint.py
+++ b/ipv8/messaging/anonymization/endpoint.py
@@ -1,6 +1,6 @@
 from collections import deque
 
-from .tunnel import CIRCUIT_STATE_READY, CIRCUIT_TYPE_IPV8
+from .tunnel import CIRCUIT_STATE_READY, PEER_FLAG_EXIT_IPV8
 
 
 class TunnelEndpoint(object):
@@ -26,12 +26,12 @@ class TunnelEndpoint(object):
             return
 
         if self.tunnel_community:
-            circuits = self.tunnel_community.find_circuits(ctype=CIRCUIT_TYPE_IPV8, hops=self.hops, state=None)
+            circuits = self.tunnel_community.find_circuits(exit_flags=[PEER_FLAG_EXIT_IPV8], hops=self.hops, state=None)
             circuit = circuits[0] if circuits else None
             if not circuit or circuit.state != CIRCUIT_STATE_READY:
                 # Recreate tunnel when needed
                 if not circuit:
-                    self.tunnel_community.create_circuit(self.hops, ctype=CIRCUIT_TYPE_IPV8)
+                    self.tunnel_community.create_circuit(self.hops, exit_flags=[PEER_FLAG_EXIT_IPV8])
                 self.send_queue.append((address, packet))
                 return
 

--- a/ipv8/messaging/anonymization/payload.py
+++ b/ipv8/messaging/anonymization/payload.py
@@ -326,3 +326,34 @@ class LinkedE2EPayload(VariablePayload):
 
     format_list = ['I', 'H']
     names = ['circuit_id', 'identifier']
+
+
+class TestRequestPayload:
+
+    def __init__(self, circuit_id, identifier, response_size, data):
+        self.circuit_id = circuit_id
+        self.identifier = identifier
+        self.response_size = response_size
+        self.data = data
+
+    def to_bin(self):
+        return pack(f'!HH{len(self.data)}s', self.identifier, self.response_size, self.data)
+
+    @classmethod
+    def from_bin(cls, packet):
+        return cls(*unpack_from('!IHH', packet, 23), packet[31:])
+
+
+class TestResponsePayload:
+
+    def __init__(self, circuit_id, identifier, data):
+        self.circuit_id = circuit_id
+        self.identifier = identifier
+        self.data = data
+
+    def to_bin(self):
+        return pack(f'!H{len(self.data)}s', self.identifier, self.data)
+
+    @classmethod
+    def from_bin(cls, packet):
+        return cls(*unpack_from('!IH', packet, 23), packet[29:])

--- a/ipv8/messaging/anonymization/tunnel.py
+++ b/ipv8/messaging/anonymization/tunnel.py
@@ -26,6 +26,7 @@ PEER_SOURCE_PEX = 2
 PEER_FLAG_RELAY = 1
 PEER_FLAG_EXIT_BT = 2
 PEER_FLAG_EXIT_IPV8 = 4
+PEER_FLAG_SPEED_TEST = 8
 
 # Data circuits are general purpose circuits for exiting data
 CIRCUIT_TYPE_DATA = 'DATA'

--- a/ipv8/messaging/anonymization/tunnel.py
+++ b/ipv8/messaging/anonymization/tunnel.py
@@ -24,12 +24,11 @@ PEER_SOURCE_DHT = 1
 PEER_SOURCE_PEX = 2
 
 PEER_FLAG_RELAY = 1
-PEER_FLAG_EXIT_ANY = 2
+PEER_FLAG_EXIT_BT = 2
 PEER_FLAG_EXIT_IPV8 = 4
 
-# Data circuits are supposed to end in an exit peer that allows exiting data to the outside world
+# Data circuits are general purpose circuits for exiting data
 CIRCUIT_TYPE_DATA = 'DATA'
-CIRCUIT_TYPE_IPV8 = 'IPV8'
 
 # The other circuits are supposed to end in a connectable node, not allowed to exit
 # anything else than IPv8 messages, used for setting up end-to-end circuits
@@ -86,15 +85,14 @@ class DataChecker(object):
         return False
 
     @staticmethod
-    def could_be_ipv8(data):
-        return len(data) >= 23 and data[0:1] == b'\x00' and data[1:2] in [b'\x01', b'\x02']
-
-    @staticmethod
-    def is_allowed(data):
+    def could_be_bt(data):
         return (DataChecker.could_be_utp(data)
                 or DataChecker.could_be_udp_tracker(data)
-                or DataChecker.could_be_dht(data)
-                or DataChecker.could_be_ipv8(data))
+                or DataChecker.could_be_dht(data))
+
+    @staticmethod
+    def could_be_ipv8(data):
+        return len(data) >= 23 and data[0:1] == b'\x00' and data[1:2] in [b'\x01', b'\x02']
 
 
 class Tunnel(object):
@@ -143,7 +141,7 @@ class TunnelExitSocket(Tunnel, DatagramProtocol, TaskManager):
             return
 
         self.beat_heart()
-        if DataChecker.is_allowed(data):
+        if self.is_allowed(data):
             def on_ip_address(future):
                 try:
                     ip_address = future.result()
@@ -177,7 +175,7 @@ class TunnelExitSocket(Tunnel, DatagramProtocol, TaskManager):
     def datagram_received(self, data, source):
         self.beat_heart()
         self.overlay.increase_bytes_received(self, len(data))
-        if DataChecker.is_allowed(data):
+        if self.is_allowed(data):
             try:
                 self.tunnel_data(source, data)
             except Exception:
@@ -185,6 +183,17 @@ class TunnelExitSocket(Tunnel, DatagramProtocol, TaskManager):
                                   + ''.join(format_exception(*sys.exc_info())))
         else:
             self.logger.warning("Dropping forbidden packets to exit socket with circuit_id %d", self.circuit_id)
+
+    def is_allowed(self, data):
+        is_bt = DataChecker.could_be_bt(data)
+        is_ipv8 = DataChecker.could_be_ipv8(data)
+
+        if not (is_bt and PEER_FLAG_EXIT_BT in self.overlay.settings.peer_flags) \
+           and not (is_ipv8 and PEER_FLAG_EXIT_IPV8 in self.overlay.settings.peer_flags) \
+           and not (is_ipv8 and self.overlay._prefix == data[:22]):
+            self.logger.error("Dropping data packets, refusing to be an exit node (BT=%s, IPv8=%s)", is_bt, is_ipv8)
+            return False
+        return True
 
     def tunnel_data(self, source, data):
         self.logger.debug("Tunnel data to origin %s for circuit %s", ('0.0.0.0', 0), self.circuit_id)

--- a/ipv8/test/messaging/anonymization/test_community.py
+++ b/ipv8/test/messaging/anonymization/test_community.py
@@ -8,8 +8,7 @@ from ...mocking.exit_socket import MockTunnelExitSocket
 from ...mocking.ipv8 import MockIPv8
 from ....messaging.anonymization.community import TunnelCommunity, TunnelSettings
 from ....messaging.anonymization.endpoint import TunnelEndpoint
-from ....messaging.anonymization.tunnel import (CIRCUIT_STATE_EXTENDING, CIRCUIT_TYPE_IPV8,
-                                                PEER_FLAG_EXIT_ANY, PEER_FLAG_EXIT_IPV8)
+from ....messaging.anonymization.tunnel import CIRCUIT_STATE_EXTENDING, PEER_FLAG_EXIT_BT, PEER_FLAG_EXIT_IPV8
 from ....messaging.interfaces.udp.endpoint import UDPEndpoint
 from ....util import cast_to_bin, succeed
 
@@ -78,24 +77,24 @@ class TestTunnelCommunity(TestBase):
         """
         Check if introduction requests share the fact that nodes are exit nodes.
         """
-        self.nodes[0].overlay.settings.peer_flags.add(PEER_FLAG_EXIT_ANY)
+        self.nodes[0].overlay.settings.peer_flags.add(PEER_FLAG_EXIT_BT)
 
         await self.introduce_nodes()
 
-        self.assertIn(self.nodes[0].my_peer, self.nodes[1].overlay.get_candidates(PEER_FLAG_EXIT_ANY))
-        self.assertNotIn(self.nodes[1].my_peer, self.nodes[0].overlay.get_candidates(PEER_FLAG_EXIT_ANY))
+        self.assertIn(self.nodes[0].my_peer, self.nodes[1].overlay.get_candidates(PEER_FLAG_EXIT_BT))
+        self.assertNotIn(self.nodes[1].my_peer, self.nodes[0].overlay.get_candidates(PEER_FLAG_EXIT_BT))
 
     async def test_introduction_as_exit_twoway(self):
         """
         Check if two nodes can have each other as exit nodes.
         """
-        self.nodes[0].overlay.settings.peer_flags.add(PEER_FLAG_EXIT_ANY)
-        self.nodes[1].overlay.settings.peer_flags.add(PEER_FLAG_EXIT_ANY)
+        self.nodes[0].overlay.settings.peer_flags.add(PEER_FLAG_EXIT_BT)
+        self.nodes[1].overlay.settings.peer_flags.add(PEER_FLAG_EXIT_BT)
 
         await self.introduce_nodes()
 
-        self.assertIn(self.nodes[0].my_peer, self.nodes[1].overlay.get_candidates(PEER_FLAG_EXIT_ANY))
-        self.assertIn(self.nodes[1].my_peer, self.nodes[0].overlay.get_candidates(PEER_FLAG_EXIT_ANY))
+        self.assertIn(self.nodes[0].my_peer, self.nodes[1].overlay.get_candidates(PEER_FLAG_EXIT_BT))
+        self.assertIn(self.nodes[1].my_peer, self.nodes[0].overlay.get_candidates(PEER_FLAG_EXIT_BT))
 
     async def test_introduction_as_exit_noway(self):
         """
@@ -103,14 +102,14 @@ class TestTunnelCommunity(TestBase):
         """
         await self.introduce_nodes()
 
-        self.assertEqual(len(self.nodes[0].overlay.get_candidates(PEER_FLAG_EXIT_ANY)), 0)
-        self.assertEqual(len(self.nodes[1].overlay.get_candidates(PEER_FLAG_EXIT_ANY)), 0)
+        self.assertEqual(len(self.nodes[0].overlay.get_candidates(PEER_FLAG_EXIT_BT)), 0)
+        self.assertEqual(len(self.nodes[1].overlay.get_candidates(PEER_FLAG_EXIT_BT)), 0)
 
     async def test_create_circuit(self):
         """
         Check if 1 hop circuit creation works.
         """
-        self.nodes[1].overlay.settings.peer_flags.add(PEER_FLAG_EXIT_ANY)
+        self.nodes[1].overlay.settings.peer_flags.add(PEER_FLAG_EXIT_BT)
         await self.introduce_nodes()
 
         # Let node 0 build tunnels of 1 hop (settings.min_circuits = settings.max_circuits = 1)
@@ -144,7 +143,7 @@ class TestTunnelCommunity(TestBase):
         """
         Check if circuit creation is aborted when it's already building the requested circuit.
         """
-        self.nodes[1].overlay.settings.peer_flags.add(PEER_FLAG_EXIT_ANY)
+        self.nodes[1].overlay.settings.peer_flags.add(PEER_FLAG_EXIT_BT)
         await self.introduce_nodes()
 
         # Don't allow the exit node to answer, this keeps peer 0's circuit in EXTENDING state
@@ -163,7 +162,7 @@ class TestTunnelCommunity(TestBase):
         Check if a 2 hop circuit can be destroyed (by the exit node)
         """
         self.add_node_to_experiment(self.create_node())
-        self.nodes[2].overlay.settings.peer_flags.add(PEER_FLAG_EXIT_ANY)
+        self.nodes[2].overlay.settings.peer_flags.add(PEER_FLAG_EXIT_BT)
         await self.introduce_nodes()
         self.nodes[0].overlay.build_tunnels(2)
         await self.deliver_messages()
@@ -179,7 +178,7 @@ class TestTunnelCommunity(TestBase):
         Check if a 2 hop circuit can be destroyed (by the exit node)
         """
         self.add_node_to_experiment(self.create_node())
-        self.nodes[2].overlay.settings.peer_flags.add(PEER_FLAG_EXIT_ANY)
+        self.nodes[2].overlay.settings.peer_flags.add(PEER_FLAG_EXIT_BT)
         await self.introduce_nodes()
         self.nodes[0].overlay.build_tunnels(2)
         await self.deliver_messages()
@@ -194,7 +193,7 @@ class TestTunnelCommunity(TestBase):
         Check if a 2 hop circuit can be destroyed (by the relay node)
         """
         self.add_node_to_experiment(self.create_node())
-        self.nodes[2].overlay.settings.peer_flags.add(PEER_FLAG_EXIT_ANY)
+        self.nodes[2].overlay.settings.peer_flags.add(PEER_FLAG_EXIT_BT)
         await self.introduce_nodes()
         self.nodes[0].overlay.build_tunnels(2)
         await self.deliver_messages()
@@ -208,7 +207,7 @@ class TestTunnelCommunity(TestBase):
         """
         Check if the correct circuit gets destroyed.
         """
-        self.nodes[1].overlay.settings.peer_flags.add(PEER_FLAG_EXIT_ANY)
+        self.nodes[1].overlay.settings.peer_flags.add(PEER_FLAG_EXIT_BT)
         await self.introduce_nodes()
         self.nodes[0].overlay.build_tunnels(1)
         await self.deliver_messages()
@@ -233,7 +232,7 @@ class TestTunnelCommunity(TestBase):
         ep_listener = MockEndpointListener(self.public_endpoint)
 
         # Build a tunnel
-        self.nodes[1].overlay.settings.peer_flags.add(PEER_FLAG_EXIT_ANY)
+        self.nodes[1].overlay.settings.peer_flags.add(PEER_FLAG_EXIT_BT)
         await self.introduce_nodes()
         self.nodes[0].overlay.build_tunnels(1)
         await self.deliver_messages()
@@ -265,7 +264,7 @@ class TestTunnelCommunity(TestBase):
         self.add_node_to_experiment(self.create_node())
 
         # Build a tunnel
-        self.nodes[1].overlay.settings.peer_flags.add(PEER_FLAG_EXIT_ANY)
+        self.nodes[1].overlay.settings.peer_flags.add(PEER_FLAG_EXIT_BT)
         await self.introduce_nodes()
         self.nodes[0].overlay.build_tunnels(2)
         await self.deliver_messages()
@@ -282,7 +281,7 @@ class TestTunnelCommunity(TestBase):
         self.add_node_to_experiment(self.create_node())
 
         # Build a tunnel
-        self.nodes[1].overlay.settings.peer_flags.add(PEER_FLAG_EXIT_ANY)
+        self.nodes[1].overlay.settings.peer_flags.add(PEER_FLAG_EXIT_BT)
         await self.introduce_nodes()
         self.nodes[0].overlay.build_tunnels(3)
         await self.deliver_messages()
@@ -296,8 +295,8 @@ class TestTunnelCommunity(TestBase):
         self.add_node_to_experiment(self.create_node())
         self.nodes[0].overlay.settings.min_circuits = 2
         self.nodes[0].overlay.settings.max_circuits = 2
-        self.nodes[1].overlay.settings.peer_flags.add(PEER_FLAG_EXIT_ANY)
-        self.nodes[2].overlay.settings.peer_flags.add(PEER_FLAG_EXIT_ANY)
+        self.nodes[1].overlay.settings.peer_flags.add(PEER_FLAG_EXIT_BT)
+        self.nodes[2].overlay.settings.peer_flags.add(PEER_FLAG_EXIT_BT)
         await self.introduce_nodes()
 
         # Let node 0 build tunnels of 1 hop (settings.min_circuits = settings.max_circuits = 2)
@@ -319,7 +318,7 @@ class TestTunnelCommunity(TestBase):
         """
         self.add_node_to_experiment(self.create_node())
 
-        self.nodes[2].overlay.settings.peer_flags.add(PEER_FLAG_EXIT_ANY)
+        self.nodes[2].overlay.settings.peer_flags.add(PEER_FLAG_EXIT_BT)
         self.nodes[2].overlay.should_join_circuit = lambda *args: succeed(False)
         await self.introduce_nodes()
         self.nodes[0].overlay.build_tunnels(2)
@@ -332,7 +331,7 @@ class TestTunnelCommunity(TestBase):
 
         # Let's add a new exit node, and retry to extend the circuit
         self.add_node_to_experiment(self.create_node())
-        self.nodes[3].overlay.settings.peer_flags.add(PEER_FLAG_EXIT_ANY)
+        self.nodes[3].overlay.settings.peer_flags.add(PEER_FLAG_EXIT_BT)
         await self.introduce_nodes()
         # Let's pretend that node 1 selected node 3 as a possible node for circuit extension
         cache = self.nodes[1].overlay.request_cache.get(u"created", circuit.circuit_id)
@@ -355,7 +354,7 @@ class TestTunnelCommunity(TestBase):
         """
         self.add_node_to_experiment(self.create_node())
 
-        self.nodes[2].overlay.settings.peer_flags.add(PEER_FLAG_EXIT_ANY)
+        self.nodes[2].overlay.settings.peer_flags.add(PEER_FLAG_EXIT_BT)
         self.nodes[1].overlay.should_join_circuit = lambda *args: succeed(False)
         await self.introduce_nodes()
         self.nodes[0].overlay.build_tunnels(2)
@@ -387,7 +386,7 @@ class TestTunnelCommunity(TestBase):
         self.add_node_to_experiment(self.create_node())
         self.nodes[2].overlay.settings.peer_flags.add(PEER_FLAG_EXIT_IPV8)
         await self.introduce_nodes()
-        self.nodes[0].overlay.create_circuit(1, CIRCUIT_TYPE_IPV8)
+        self.nodes[0].overlay.create_circuit(1, exit_flags=[PEER_FLAG_EXIT_IPV8])
         await self.deliver_messages()
 
         exit_socket = list(self.nodes[2].overlay.exit_sockets.values())[0]
@@ -410,7 +409,7 @@ class TestTunnelCommunity(TestBase):
 
         # When a circuit closes, sending data should fail
         self.nodes[0].overlay.send_data = Mock(wraps=send_data)
-        circuit = self.nodes[0].overlay.find_circuits(ctype=CIRCUIT_TYPE_IPV8)[0]
+        circuit = self.nodes[0].overlay.find_circuits(exit_flags=[PEER_FLAG_EXIT_IPV8])[0]
         await self.nodes[0].overlay.remove_circuit(circuit.circuit_id)
         endpoint.send(self.nodes[1].overlay.my_estimated_wan, prefix + b'DATA')
         await self.deliver_messages()
@@ -438,7 +437,7 @@ class TestTunnelCommunity(TestBase):
         """
         Check if the encoding/decoding a unicode hostname works.
         """
-        self.nodes[1].overlay.settings.peer_flags.add(PEER_FLAG_EXIT_ANY)
+        self.nodes[1].overlay.settings.peer_flags.add(PEER_FLAG_EXIT_BT)
         await self.introduce_nodes()
         circuit = self.nodes[0].overlay.create_circuit(1)
         await circuit.ready

--- a/ipv8/test/messaging/anonymization/test_datachecker.py
+++ b/ipv8/test/messaging/anonymization/test_datachecker.py
@@ -3,23 +3,61 @@ from binascii import unhexlify
 from ...base import TestBase
 from ....messaging.anonymization.tunnel import DataChecker
 
+tracker_pkt = unhexlify('00000417271019800000000012345678')
+dht_pkt = b'd1:ad2:id20:abcdefghij01234567899:info_hash20:mnopqrstuvwxyz123456e1:q9:get_peers1:t2:aa1:y1:qe'
+utp_pkt = unhexlify('210086446ed69ec1ddbd9e6000100000f32e86be')
+ipv8_pkt = unhexlify('0002123456789abcdef123456789abcdef123456789a00000001')
+tunnel_pkt = unhexlify('000281ded07332bdc775aa5a46f96de9f8f390bbc9f300000001')
+
 
 class TestDataChecker(TestBase):
 
-    def test_could_be_dht_correct(self):
+    def test_could_be_dht(self):
         """
-        Check if a valid DHT packet is correctly identified.
+        Check if a DHT packet is correctly identified.
         """
-        pkt = b"64313a6164323a696432303a3b2cb14348257b7a481f7010ca7c519b8bef5086393a696e666f5f6861736832303af84b51" \
-              b"f0d2c3455ab5dabb6643b4340234cd036e65313a71393a6765745f7065657273313a74323ae037313a76343a4c54010131" \
-              b"3a79313a7165"
-        self.assertTrue(DataChecker.could_be_dht(unhexlify(pkt)))
+        self.assertFalse(DataChecker.could_be_dht(tracker_pkt))
+        self.assertTrue(DataChecker.could_be_dht(dht_pkt))
+        self.assertFalse(DataChecker.could_be_dht(utp_pkt))
+        self.assertFalse(DataChecker.could_be_dht(ipv8_pkt))
+        self.assertFalse(DataChecker.could_be_dht(tunnel_pkt))
 
-    def test_could_be_dht_incorrect(self):
+    def test_could_be_udp_tracker(self):
         """
-        Check if an invalid DHT packet is correctly identified.
+        Check if a UDP tracker packet is correctly identified.
         """
-        pkt = b"63313a6164323a696432303a3b2cb14348257b7a481f7010ca7c519b8bef5086393a696e666f5f6861736832303af84b51" \
-              b"f0d2c3455ab5dabb6643b4340234cd036e65313a71393a6765745f7065657273313a74323ae037313a76343a4c54010131" \
-              b"3a79313a7165"
-        self.assertFalse(DataChecker.could_be_dht(unhexlify(pkt)))
+        self.assertTrue(DataChecker.could_be_udp_tracker(tracker_pkt))
+        self.assertFalse(DataChecker.could_be_udp_tracker(dht_pkt))
+        self.assertFalse(DataChecker.could_be_udp_tracker(utp_pkt))
+        self.assertFalse(DataChecker.could_be_udp_tracker(ipv8_pkt))
+        self.assertFalse(DataChecker.could_be_udp_tracker(tunnel_pkt))
+
+    def test_could_be_utp(self):
+        """
+        Check if a UTP packet is correctly identified.
+        """
+        self.assertFalse(DataChecker.could_be_utp(tracker_pkt))
+        self.assertFalse(DataChecker.could_be_utp(dht_pkt))
+        self.assertTrue(DataChecker.could_be_utp(utp_pkt))
+        self.assertFalse(DataChecker.could_be_utp(ipv8_pkt))
+        self.assertFalse(DataChecker.could_be_utp(tunnel_pkt))
+
+    def test_could_be_ipv8(self):
+        """
+        Check if a IPv8 packet is correctly identified.
+        """
+        self.assertFalse(DataChecker.could_be_ipv8(tracker_pkt))
+        self.assertFalse(DataChecker.could_be_ipv8(dht_pkt))
+        self.assertFalse(DataChecker.could_be_ipv8(utp_pkt))
+        self.assertTrue(DataChecker.could_be_ipv8(ipv8_pkt))
+        self.assertTrue(DataChecker.could_be_ipv8(tunnel_pkt))
+
+    def test_could_be_bt(self):
+        """
+        Check if a BitTorrent packet is correctly identified.
+        """
+        self.assertTrue(DataChecker.could_be_bt(tracker_pkt))
+        self.assertTrue(DataChecker.could_be_bt(dht_pkt))
+        self.assertTrue(DataChecker.could_be_bt(utp_pkt))
+        self.assertFalse(DataChecker.could_be_bt(ipv8_pkt))
+        self.assertFalse(DataChecker.could_be_bt(tunnel_pkt))

--- a/ipv8/test/messaging/anonymization/test_datachecker.py
+++ b/ipv8/test/messaging/anonymization/test_datachecker.py
@@ -13,7 +13,7 @@ class TestDataChecker(TestBase):
         pkt = b"64313a6164323a696432303a3b2cb14348257b7a481f7010ca7c519b8bef5086393a696e666f5f6861736832303af84b51" \
               b"f0d2c3455ab5dabb6643b4340234cd036e65313a71393a6765745f7065657273313a74323ae037313a76343a4c54010131" \
               b"3a79313a7165"
-        self.assertTrue(DataChecker.is_allowed(unhexlify(pkt)))
+        self.assertTrue(DataChecker.could_be_dht(unhexlify(pkt)))
 
     def test_could_be_dht_incorrect(self):
         """
@@ -22,4 +22,4 @@ class TestDataChecker(TestBase):
         pkt = b"63313a6164323a696432303a3b2cb14348257b7a481f7010ca7c519b8bef5086393a696e666f5f6861736832303af84b51" \
               b"f0d2c3455ab5dabb6643b4340234cd036e65313a71393a6765745f7065657273313a74323ae037313a76343a4c54010131" \
               b"3a79313a7165"
-        self.assertFalse(DataChecker.is_allowed(unhexlify(pkt)))
+        self.assertFalse(DataChecker.could_be_dht(unhexlify(pkt)))

--- a/ipv8/test/messaging/anonymization/test_exit_socket.py
+++ b/ipv8/test/messaging/anonymization/test_exit_socket.py
@@ -1,0 +1,46 @@
+from binascii import unhexlify
+from unittest.mock import Mock
+
+from .test_datachecker import dht_pkt, ipv8_pkt, tracker_pkt, tunnel_pkt, utp_pkt
+from ...base import TestBase
+from ....messaging.anonymization.tunnel import PEER_FLAG_EXIT_BT, PEER_FLAG_EXIT_IPV8, TunnelExitSocket
+
+
+class TestExitSocket(TestBase):
+
+    async def test_is_allowed(self):
+        """
+        Check if the ExitSocket correctly detects forbidden packets.
+        """
+        overlay = Mock(_prefix=unhexlify('000281ded07332bdc775aa5a46f96de9f8f390bbc9f3'))
+        exit_socket = TunnelExitSocket(0, None, overlay)
+
+        overlay.settings.peer_flags = {}
+        self.assertFalse(exit_socket.is_allowed(tracker_pkt))
+        self.assertFalse(exit_socket.is_allowed(dht_pkt))
+        self.assertFalse(exit_socket.is_allowed(utp_pkt))
+        self.assertFalse(exit_socket.is_allowed(ipv8_pkt))
+        self.assertTrue(exit_socket.is_allowed(tunnel_pkt))
+
+        overlay.settings.peer_flags = {PEER_FLAG_EXIT_BT}
+        self.assertTrue(exit_socket.is_allowed(tracker_pkt))
+        self.assertTrue(exit_socket.is_allowed(dht_pkt))
+        self.assertTrue(exit_socket.is_allowed(utp_pkt))
+        self.assertFalse(exit_socket.is_allowed(ipv8_pkt))
+        self.assertTrue(exit_socket.is_allowed(tunnel_pkt))
+
+        overlay.settings.peer_flags = {PEER_FLAG_EXIT_IPV8}
+        self.assertFalse(exit_socket.is_allowed(tracker_pkt))
+        self.assertFalse(exit_socket.is_allowed(dht_pkt))
+        self.assertFalse(exit_socket.is_allowed(utp_pkt))
+        self.assertTrue(exit_socket.is_allowed(ipv8_pkt))
+        self.assertTrue(exit_socket.is_allowed(tunnel_pkt))
+
+        overlay.settings.peer_flags = {PEER_FLAG_EXIT_BT, PEER_FLAG_EXIT_IPV8}
+        self.assertTrue(exit_socket.is_allowed(tracker_pkt))
+        self.assertTrue(exit_socket.is_allowed(dht_pkt))
+        self.assertTrue(exit_socket.is_allowed(utp_pkt))
+        self.assertTrue(exit_socket.is_allowed(ipv8_pkt))
+        self.assertTrue(exit_socket.is_allowed(tunnel_pkt))
+
+        await exit_socket.close()

--- a/ipv8/test/messaging/anonymization/test_hiddenservices.py
+++ b/ipv8/test/messaging/anonymization/test_hiddenservices.py
@@ -7,8 +7,8 @@ from ...mocking.exit_socket import MockTunnelExitSocket
 from ...mocking.ipv8 import MockIPv8
 from ....messaging.anonymization.community import CIRCUIT_TYPE_RP_DOWNLOADER, TunnelSettings
 from ....messaging.anonymization.hidden_services import HiddenTunnelCommunity
-from ....messaging.anonymization.tunnel import CIRCUIT_TYPE_DATA, CIRCUIT_TYPE_IP_SEEDER, IntroductionPoint,\
-    PEER_FLAG_EXIT_ANY, PEER_SOURCE_DHT
+from ....messaging.anonymization.tunnel import CIRCUIT_TYPE_DATA, CIRCUIT_TYPE_IP_SEEDER, IntroductionPoint, \
+                                               PEER_FLAG_EXIT_BT, PEER_SOURCE_DHT
 from ....peer import Peer
 from ....util import fail, succeed
 
@@ -107,7 +107,7 @@ class TestHiddenServices(TestBase):
         """
         exit_node = self.create_node()
         self.private_nodes.append(exit_node)
-        exit_node.overlay.settings.peer_flags.add(PEER_FLAG_EXIT_ANY)
+        exit_node.overlay.settings.peer_flags.add(PEER_FLAG_EXIT_BT)
         public_peer = Peer(exit_node.my_peer.public_key, exit_node.my_peer.address)
         self.nodes[node_nr].network.add_verified_peer(public_peer)
         self.nodes[node_nr].network.discover_services(public_peer, exit_node.overlay.master_peer.mid)

--- a/ipv8/test/mocking/exit_socket.py
+++ b/ipv8/test/mocking/exit_socket.py
@@ -19,7 +19,7 @@ class MockTunnelExitSocket(TunnelExitSocket, EndpointListener):
         self.enabled = True
 
     def sendto(self, data, destination):
-        if DataChecker.is_allowed(data):
+        if DataChecker.could_be_bt(data) or DataChecker.could_be_ipv8(data):
             self.endpoint.send(destination, data)
         else:
             raise AssertionError("Attempted to exit data which is not allowed" % repr(data))


### PR DESCRIPTION
This PR:

- Removes `PEER_FLAG_EXIT_ANY`. From now on we will only use more specific flags: `PEER_FLAG_EXIT_BT/IPV8`.
- Removes `CIRCUIT_TYPE_IPV8`.
- Adds an `exit_flags` argument to `create_circuit` that allows the caller to specify which capabilities the circuit should have.
- Adds speed test functionality to the `TunnelCommunity`. It supports both upload and download tests. End-to-end circuits are also supported. By implementing special messages for the test (test-request/response), we are able to do a speed test without involving an outside source (e.g. a BitTorrent swarm). By adding a new peer flag (`PEER_FLAG_SPEED_TEST`) we extend the tunnel protocol without breaking compatibility.
