### PR TITLE
Add message ID to tunnel payload classes

### DIFF
--- a/ipv8/messaging/anonymization/tunnel.py
+++ b/ipv8/messaging/anonymization/tunnel.py
@@ -153,7 +153,7 @@ class TunnelExitSocket(Tunnel, DatagramProtocol, TaskManager):
                 self.logger.debug("Resolved hostname %s to ip_address %s", destination[0], ip_address)
                 try:
                     self.transport.sendto(data, (ip_address, destination[1]))
-                    self.overlay.increase_bytes_sent(self, len(data))
+                    self.bytes_up += len(data)
                 except socket.error as e:
                     self.logger.error("Failed to write to transport. Destination: %r error: %r", destination, e)
 
@@ -175,7 +175,7 @@ class TunnelExitSocket(Tunnel, DatagramProtocol, TaskManager):
 
     def datagram_received(self, data, source):
         self.beat_heart()
-        self.overlay.increase_bytes_received(self, len(data))
+        self.bytes_down += len(data)
         if self.is_allowed(data):
             try:
                 self.tunnel_data(source, data)

--- a/ipv8/test/messaging/anonymization/test_community.py
+++ b/ipv8/test/messaging/anonymization/test_community.py
@@ -466,5 +466,5 @@ class TestTunnelCommunity(TestBase):
         send_cell = self.nodes[0].overlay.send_cell
         self.nodes[0].overlay.send_cell = Mock(wraps=send_cell)
         data, _ = await self.nodes[0].overlay.send_test_request(circuit, 3, 6)
-        self.assertEqual(len(self.nodes[0].overlay.send_cell.call_args[0][2].data), 3)
+        self.assertEqual(len(self.nodes[0].overlay.send_cell.call_args[0][1].data), 3)
         self.assertEqual(len(data), 6)

--- a/ipv8/test/messaging/anonymization/test_hiddenservices.py
+++ b/ipv8/test/messaging/anonymization/test_hiddenservices.py
@@ -312,13 +312,13 @@ class TestHiddenServices(TestBase):
         send_cell = self.nodes[0].overlay.send_cell
         self.nodes[0].overlay.send_cell = Mock(wraps=send_cell)
         on_test_request = self.nodes[2].overlay.on_test_request
-        self.nodes[2].overlay.decode_map_private[chr(30)] = Mock(wraps=on_test_request)
+        self.nodes[2].overlay.decode_map_private[30] = Mock(wraps=on_test_request)
 
         circuit, = self.nodes[0].overlay.find_circuits(ctype=CIRCUIT_TYPE_RP_DOWNLOADER)
         data, _ = await self.nodes[0].overlay.send_test_request(circuit, 3, 6)
-        self.assertEqual(len(self.nodes[0].overlay.send_cell.call_args[0][2].data), 3)
+        self.assertEqual(len(self.nodes[0].overlay.send_cell.call_args[0][1].data), 3)
         self.assertEqual(len(data), 6)
-        self.nodes[2].overlay.decode_map_private[chr(30)].assert_called_once()
+        self.nodes[2].overlay.decode_map_private[30].assert_called_once()
 
         self.nodes[0].overlay.leave_swarm(self.service)
         self.nodes[2].overlay.leave_swarm(self.service)


### PR DESCRIPTION
This PR:
- Adds `Payload.msg_id` to the tunnel payload classes, so we can use `add_message_handler`.
- Adds `add_cell_handler` for messages that are wrapped in a `Cell`.
- Fixes some cases in which control packets were not included in `bytes_up/bytes_down`.
- Adds `vp_compile` decorator wherever possible to speed up message serialization.
- Renames `tc_lazy_wrapper_unsigned` to `unpack_cell`.