### PR TITLE
Fixed EndpointListener LAN estimation

### DIFF
--- a/ipv8/messaging/interfaces/endpoint.py
+++ b/ipv8/messaging/interfaces/endpoint.py
@@ -125,8 +125,27 @@ class EndpointListener(metaclass=abc.ABCMeta):
         self.endpoint = endpoint
 
         self._netifaces_failed = netifaces is None
-        self.my_estimated_lan = (self._get_lan_address(True)[0], getattr(self.endpoint, "_port", 0))
+        self._my_estimated_lan = None
         self.my_estimated_wan = self.my_estimated_lan
+
+    @property
+    def my_estimated_lan(self):
+        """
+        Estimate our LAN IPv4 address and port.
+
+        If the endpoint is closed this returns ("0.0.0.0", 0).
+        If the endpoint is open and we have no idea what our address is, attempt to estimate it.
+        Otherwise, return the current value of the estimated LAN address and port.
+        """
+        if not self.endpoint.is_open():
+            return "0.0.0.0", 0
+        if self._my_estimated_lan is None:
+            self._my_estimated_lan = (self._get_lan_address(True)[0], self.endpoint.get_address()[1])
+        return self._my_estimated_lan
+
+    @my_estimated_lan.setter
+    def my_estimated_lan(self, value):
+        self._my_estimated_lan = value
 
     @property
     def use_main_thread(self):

--- a/ipv8/test/mocking/endpoint.py
+++ b/ipv8/test/mocking/endpoint.py
@@ -50,10 +50,14 @@ class AddressTester(EndpointListener):
     def on_packet(self, packet):
         pass
 
+    def is_lan(self, address):
+        return self._address_is_lan_without_netifaces(address)
+
 
 class AutoMockEndpoint(MockEndpoint):
 
     def __init__(self):
+        self._open = False
         super(AutoMockEndpoint, self).__init__(self._generate_unique_address(), self._generate_unique_address())
         self._port = 0
 
@@ -72,7 +76,7 @@ class AutoMockEndpoint(MockEndpoint):
         """
         self._port = address[1]
         address_tester = AddressTester(self)
-        return address_tester.address_is_lan(address[0])
+        return address_tester.is_lan(address[0])
 
     def _generate_unique_address(self):
         address = self._generate_address()


### PR DESCRIPTION
Fixes #844

This PR:

 - Fixes LAN estimation for EndpointListener subclasses.

Previously `my_estimated_lan` would falsely report its address before the port was actually claimed. Now it is extra broken through the `DispatcherEndpoint` PR. With this PR the address is now reported as `("0.0.0.0", 0)` if the endpoint is still unclaimed/closed, compatible with the introduction requests and responses.

As we are now checking `is_open` in the partially intialized `AutoMockEndpoint`, we require some small fixes there too.
