### PR TITLE
Fixed M2CryptoSK.verify

### DIFF
--- a/ipv8/keyvault/public/m2crypto.py
+++ b/ipv8/keyvault/public/m2crypto.py
@@ -64,18 +64,12 @@ class M2CryptoPK(PublicKey):
         :param msg: the given message
         """
         length = len(signature) // 2
-        r = signature[:length]
-        # remove all "\x00" prefixes
-        while r and r[0:1] == b"\x00":
-            r = r[1:]
+        r = signature[:length].lstrip(b"\x00")  # remove all "\x00" prefixes
         # prepend "\x00" when the most significant bit is set
         if r[0] & 128:
             r = b"\x00" + r
 
-        s = signature[length:]
-        # remove all "\x00" prefixes
-        while s and s[0:1] == b"\x00":
-            s = s[1:]
+        s = signature[length:].lstrip(b"\x00")  # remove all "\x00" prefixes
         # prepend "\x00" when the most significant bit is set
         if s[0] & 128:
             s = b"\x00" + s
@@ -85,9 +79,9 @@ class M2CryptoPK(PublicKey):
         # verify
         try:
             if NEW_CRYPTOGRAPHY_SIGN_VERSION:
-                self.ec.verify(encode_dss_signature(r, s), msg, ec.ECDSA(hashes.SHA1()))
+                self.pub().ec.verify(encode_dss_signature(r, s), msg, ec.ECDSA(hashes.SHA1()))
             else:
-                self.ec.verifier(encode_dss_signature(r, s), ec.ECDSA(hashes.SHA1()))
+                self.pub().ec.verifier(encode_dss_signature(r, s), ec.ECDSA(hashes.SHA1()))
             return True
         except InvalidSignature:
             return False

--- a/ipv8/test/keyvault/test_crypto.py
+++ b/ipv8/test/keyvault/test_crypto.py
@@ -137,7 +137,7 @@ class TestECCrypto(TestBase):
         Check if ECCrypto is able to sign a verify using a m2crypto key.
         """
         sig = self.ecc.create_signature(TestECCrypto.m2crypto_key, b'test')
-        self.assertTrue(self.ecc.is_valid_signature(TestECCrypto.m2crypto_key.pub(), b'test', sig))
+        self.assertTrue(self.ecc.is_valid_signature(TestECCrypto.m2crypto_key, b'test', sig))
 
     def test_sign_and_verify_libnacl(self):
         """


### PR DESCRIPTION
Fixes https://github.com/Tribler/py-ipv8/pull/843#issuecomment-672791520 as reported by @egbertbouman .

This PR:

 - Fixes `M2CryptoSK.verify` always returning `False`.
 - Updates `M2CryptoPK.verify` to not strip all prepended `b'\x00'` characters manually from `r` and `s` and instead use `lstrip()`.
 - Updates `test_sign_and_verify_m2crypto` to behave the same as `test_sign_and_verify_libnacl`.

