### PR TITLE
Don't use decode_map directly for message handlers

### DIFF
--- a/ipv8/attestation/trustchain/community.py
+++ b/ipv8/attestation/trustchain/community.py
@@ -70,15 +70,13 @@ class TrustChainCommunity(Community):
         self.listeners_map = {}  # Map of block_type -> [callbacks]
         self.register_task("db_cleanup", self.do_db_cleanup, interval=600)
 
-        self.decode_map.update({
-            chr(1): self.received_half_block,
-            chr(2): self.received_crawl_request,
-            chr(3): self.received_crawl_response,
-            chr(4): self.received_half_block_pair,
-            chr(5): self.received_half_block_broadcast,
-            chr(6): self.received_half_block_pair_broadcast,
-            chr(7): self.received_empty_crawl_response,
-        })
+        self.add_message_handler(HalfBlockPayload, self.received_half_block)
+        self.add_message_handler(CrawlRequestPayload, self.received_crawl_request)
+        self.add_message_handler(CrawlResponsePayload, self.received_crawl_response)
+        self.add_message_handler(HalfBlockPairPayload, self.received_half_block_pair)
+        self.add_message_handler(HalfBlockBroadcastPayload, self.received_half_block_broadcast)
+        self.add_message_handler(HalfBlockPairBroadcastPayload, self.received_half_block_pair_broadcast)
+        self.add_message_handler(EmptyCrawlResponsePayload, self.received_empty_crawl_response)
 
     def do_db_cleanup(self):
         """

--- a/ipv8/attestation/trustchain/payload.py
+++ b/ipv8/attestation/trustchain/payload.py
@@ -6,6 +6,7 @@ class CrawlRequestPayload(Payload):
     Request a crawl of blocks starting with a specific sequence number or the first if 0.
     """
 
+    msg_id = 2
     format_list = ['74s', 'l', 'l', 'I']
 
     def __init__(self, public_key, start_seq_num, end_seq_num, crawl_id):
@@ -33,6 +34,7 @@ class EmptyCrawlResponsePayload(Payload):
     Payload for the message that indicates that there are no blocks to respond.
     """
 
+    msg_id = 7
     format_list = ['I']
 
     def __init__(self, crawl_id):
@@ -53,6 +55,7 @@ class HalfBlockPayload(Payload):
     Payload for message that ships a half block
     """
 
+    msg_id = 1
     format_list = ['74s', 'I', '74s', 'I', '32s', '64s', 'varlenI', 'varlenI', 'Q']
 
     def __init__(self, public_key, sequence_number, link_public_key, link_sequence_number, previous_hash,
@@ -105,6 +108,7 @@ class HalfBlockBroadcastPayload(HalfBlockPayload):
     Payload for a message that contains a half block and a TTL field for broadcasts.
     """
 
+    msg_id = 5
     format_list = ['74s', 'I', '74s', 'I', '32s', '64s', 'varlenI', 'varlenI', 'Q', 'I']
 
     def __init__(self, public_key, sequence_number, link_public_key, link_sequence_number, previous_hash,
@@ -144,6 +148,7 @@ class CrawlResponsePayload(Payload):
     Payload for the response to a crawl request.
     """
 
+    msg_id = 3
     format_list = ['74s', 'I', '74s', 'I', '32s', '64s', 'varlenI', 'varlenI', 'Q', 'I', 'I', 'I']
 
     def __init__(self, public_key, sequence_number, link_public_key, link_sequence_number, previous_hash, signature,
@@ -205,6 +210,7 @@ class HalfBlockPairPayload(Payload):
     Payload for message that ships two half blocks
     """
 
+    msg_id = 4
     format_list = ['74s', 'I', '74s', 'I', '32s', '64s', 'varlenI', 'varlenI', 'Q'] * 2
 
     def __init__(self, public_key1, sequence_number1, link_public_key1, link_sequence_number1, previous_hash1,
@@ -286,6 +292,7 @@ class HalfBlockPairBroadcastPayload(HalfBlockPairPayload):
     Payload for a broadcast message that ships two half blocks
     """
 
+    msg_id = 6
     format_list = ['74s', 'I', '74s', 'I', '32s', '64s', 'varlenI', 'varlenI', 'Q'] * 2 + ['I']
 
     def __init__(self, public_key1, sequence_number1, link_public_key1, link_sequence_number1, previous_hash1,

--- a/ipv8/attestation/wallet/community.py
+++ b/ipv8/attestation/wallet/community.py
@@ -73,13 +73,11 @@ class AttestationCommunity(Community):
 
         self.request_cache = RequestCache()
 
-        self.decode_map.update({
-            chr(1): self.on_verify_attestation_request,
-            chr(2): self.on_attestation_chunk,
-            chr(3): self.on_challenge,
-            chr(4): self.on_challenge_response,
-            chr(5): self.on_request_attestation
-        })
+        self.add_message_handler(VerifyAttestationRequestPayload, self.on_verify_attestation_request)
+        self.add_message_handler(AttestationChunkPayload, self.on_attestation_chunk)
+        self.add_message_handler(ChallengePayload, self.on_challenge)
+        self.add_message_handler(ChallengeResponsePayload, self.on_challenge_response)
+        self.add_message_handler(RequestAttestationPayload, self.on_request_attestation)
 
     async def unload(self):
         await self.request_cache.shutdown()

--- a/ipv8/attestation/wallet/payload.py
+++ b/ipv8/attestation/wallet/payload.py
@@ -5,6 +5,7 @@ class RequestAttestationPayload(Payload):
     """
     Request an attestation based on some meta data.
     """
+    msg_id = 5
     format_list = ['raw']
 
     def __init__(self, metadata):
@@ -24,6 +25,7 @@ class VerifyAttestationRequestPayload(Payload):
     """
     Request an attestation by hash (published with metadata somewhere).
     """
+    msg_id = 1
     format_list = ['20s']
 
     def __init__(self, hash):
@@ -43,6 +45,7 @@ class AttestationChunkPayload(Payload):
     """
     A chunk of Attestation.
     """
+    msg_id = 2
     format_list = ['20s', 'H', 'raw']
 
     def __init__(self, hash, sequence_number, data):
@@ -67,6 +70,7 @@ class ChallengePayload(Payload):
     """
     A challenge for an Attestee by a Verifier
     """
+    msg_id = 3
     format_list = ['20s', 'raw']
 
     def __init__(self, attestation_hash, challenge):
@@ -87,6 +91,7 @@ class ChallengeResponsePayload(Payload):
     """
     A challenge response from an Attestee to a Verifier
     """
+    msg_id = 4
     format_list = ['20s', 'raw']
 
     def __init__(self, challenge_hash, response):

--- a/ipv8/community.py
+++ b/ipv8/community.py
@@ -89,31 +89,30 @@ class Community(EZPackOverlay):
         self.network.blacklist.extend(_DEFAULT_ADDRESSES)
 
         self.last_bootstrap = 0
+        self.decode_map = {}
 
-        self.decode_map = {
-            chr(250): self.on_puncture_request,
-            chr(249): self.on_puncture,
-            chr(246): self.on_introduction_request,
-            chr(245): self.on_introduction_response,
+        self.add_message_handler(PunctureRequestPayload, self.on_puncture_request)
+        self.add_message_handler(PuncturePayload, self.on_puncture)
+        self.add_message_handler(IntroductionRequestPayload, self.on_introduction_request)
+        self.add_message_handler(IntroductionResponsePayload, self.on_introduction_response)
 
-            chr(255): self.on_deprecated_message,
-            chr(254): self.on_deprecated_message,
-            chr(253): self.on_deprecated_message,
-            chr(252): self.on_deprecated_message,
-            chr(251): self.on_deprecated_message,
-            chr(248): self.on_deprecated_message,
-            chr(247): self.on_deprecated_message,
-            chr(244): self.on_deprecated_message,
-            chr(243): self.on_deprecated_message,
-            chr(242): self.on_deprecated_message,
-            chr(241): self.on_deprecated_message,
-            chr(240): self.on_deprecated_message,
-            chr(239): self.on_deprecated_message,
-            chr(238): self.on_deprecated_message,
-            chr(237): self.on_deprecated_message,
-            chr(236): self.on_deprecated_message,
-            chr(235): self.on_deprecated_message
-        }
+        self.add_message_handler(255, self.on_deprecated_message)
+        self.add_message_handler(254, self.on_deprecated_message)
+        self.add_message_handler(253, self.on_deprecated_message)
+        self.add_message_handler(252, self.on_deprecated_message)
+        self.add_message_handler(251, self.on_deprecated_message)
+        self.add_message_handler(248, self.on_deprecated_message)
+        self.add_message_handler(247, self.on_deprecated_message)
+        self.add_message_handler(244, self.on_deprecated_message)
+        self.add_message_handler(243, self.on_deprecated_message)
+        self.add_message_handler(242, self.on_deprecated_message)
+        self.add_message_handler(241, self.on_deprecated_message)
+        self.add_message_handler(240, self.on_deprecated_message)
+        self.add_message_handler(239, self.on_deprecated_message)
+        self.add_message_handler(238, self.on_deprecated_message)
+        self.add_message_handler(237, self.on_deprecated_message)
+        self.add_message_handler(236, self.on_deprecated_message)
+        self.add_message_handler(235, self.on_deprecated_message)
 
         self.deprecated_message_names = {
             chr(255): "reserved-255",

--- a/ipv8/dht/payload.py
+++ b/ipv8/dht/payload.py
@@ -59,15 +59,16 @@ class BasePayload(Payload):
 
 
 class PingRequestPayload(BasePayload):
-    pass
+    msg_id = 7
 
 
 class PingResponsePayload(BasePayload):
-    pass
+    msg_id = 8
 
 
 class StoreRequestPayload(BasePayload):
 
+    msg_id = 9
     format_list = BasePayload.format_list + ['20s', '20s', 'varlenH']
 
     def __init__(self, identifier, token, target, values):
@@ -90,11 +91,12 @@ class StoreRequestPayload(BasePayload):
 
 
 class StoreResponsePayload(BasePayload):
-    pass
+    msg_id = 10
 
 
 class FindRequestPayload(BasePayload):
 
+    msg_id = 11
     format_list = BasePayload.format_list + ['varlenI', '20s', 'I', '?']
 
     def __init__(self, identifier, lan_address, target, offset, force_nodes):
@@ -123,6 +125,7 @@ class FindRequestPayload(BasePayload):
 
 class FindResponsePayload(BasePayload):
 
+    msg_id = 12
     format_list = BasePayload.format_list + ['20s', 'varlenH', 'varlenH']
 
     def __init__(self, identifier, token, values, nodes):
@@ -181,6 +184,7 @@ class SignedStrPayload(Payload):
 
 class StorePeerRequestPayload(BasePayload):
 
+    msg_id = 13
     format_list = BasePayload.format_list + ['20s', '20s']
 
     def __init__(self, identifier, token, target):
@@ -200,11 +204,12 @@ class StorePeerRequestPayload(BasePayload):
 
 
 class StorePeerResponsePayload(BasePayload):
-    pass
+    msg_id = 14
 
 
 class ConnectPeerRequestPayload(BasePayload):
 
+    msg_id = 15
     format_list = BasePayload.format_list + ['varlenI', '20s']
 
     def __init__(self, identifier, lan_address, target):
@@ -227,6 +232,7 @@ class ConnectPeerRequestPayload(BasePayload):
 
 class ConnectPeerResponsePayload(BasePayload):
 
+    msg_id = 16
     format_list = BasePayload.format_list + ['varlenH']
 
     def __init__(self, identifier, nodes):

--- a/ipv8/messaging/payload.py
+++ b/ipv8/messaging/payload.py
@@ -34,6 +34,7 @@ class Payload(Serializable):
 
 class IntroductionRequestPayload(Payload):
 
+    msg_id = 246
     format_list = ['4SH', '4SH', '4SH', 'bits', 'H', 'raw']
 
     def __init__(self, destination_address, source_lan_address, source_wan_address, advice, connection_type,
@@ -99,6 +100,7 @@ class IntroductionRequestPayload(Payload):
 
 class IntroductionResponsePayload(Payload):
 
+    msg_id = 245
     format_list = ['4SH', '4SH', '4SH', '4SH', '4SH', 'bits', 'H', 'raw']
 
     def __init__(self, destination_address, source_lan_address, source_wan_address, lan_introduction_address,
@@ -183,6 +185,7 @@ class IntroductionResponsePayload(Payload):
 
 class PunctureRequestPayload(Payload):
 
+    msg_id = 250
     format_list = ['4SH', '4SH', 'H']
 
     def __init__(self, lan_walker_address, wan_walker_address, identifier):
@@ -226,6 +229,7 @@ class PunctureRequestPayload(Payload):
 
 class PuncturePayload(Payload):
 
+    msg_id = 249
     format_list = ['4SH', '4SH', 'H']
 
     def __init__(self, source_lan_address, source_wan_address, identifier):

--- a/ipv8/peerdiscovery/community.py
+++ b/ipv8/peerdiscovery/community.py
@@ -64,12 +64,10 @@ class DiscoveryCommunity(Community):
 
         self.request_cache = RequestCache()
 
-        self.decode_map.update({
-            chr(1): self.on_similarity_request,
-            chr(2): self.on_similarity_response,
-            chr(3): self.on_ping,
-            chr(4): self.on_pong
-        })
+        self.add_message_handler(SimilarityRequestPayload, self.on_similarity_request)
+        self.add_message_handler(SimilarityResponsePayload, self.on_similarity_response)
+        self.add_message_handler(PingPayload, self.on_ping)
+        self.add_message_handler(PongPayload, self.on_pong)
 
     def get_available_strategies(self):
         return {'PeriodicSimilarity': PeriodicSimilarity, 'RandomChurn': RandomChurn}

--- a/ipv8/peerdiscovery/payload.py
+++ b/ipv8/peerdiscovery/payload.py
@@ -6,6 +6,7 @@ from ..messaging.payload import IntroductionRequestPayload, Payload, decode_conn
 
 class SimilarityRequestPayload(Payload):
 
+    msg_id = 1
     format_list = ['H', '4SH', '4SH', 'bits', 'raw']
 
     def __init__(self, identifier, lan_address, wan_address, connection_type, preference_list):
@@ -41,6 +42,7 @@ class SimilarityRequestPayload(Payload):
 
 class SimilarityResponsePayload(Payload):
 
+    msg_id = 2
     format_list = ['H', 'varlenHx20', 'raw']
 
     def __init__(self, identifier, preference_list, tb_overlap):
@@ -69,6 +71,7 @@ class SimilarityResponsePayload(Payload):
 
 class PingPayload(Payload):
 
+    msg_id = 3
     format_list = ['H']
 
     def __init__(self, identifier):
@@ -86,7 +89,7 @@ class PingPayload(Payload):
 
 
 class PongPayload(PingPayload):
-    pass
+    msg_id = 4
 
 
 class DiscoveryIntroductionRequestPayload(IntroductionRequestPayload):


### PR DESCRIPTION
This PR:

 - Updates all Payload instances to maintain their own message identifier.
 - Updates all internal message handler registration to use the Payload definitions.

This is all so we can easily change `decode_map` from a `{str -> function}` mapping to a `function[256]` list (this is possible because all decode_map entries are the `chr()` value of a single byte). This will be in a separate PR and save memory and improve speed.