### PR TITLE
Switch decode_map to list

### DIFF
--- a/ipv8/REST/overlays_endpoint.py
+++ b/ipv8/REST/overlays_endpoint.py
@@ -88,8 +88,8 @@ class OverlaysEndpoint(BaseEndpoint):
     def statistics_by_name(self, statistics, overlay):
         named_statistics = {}
         for message_id, network_stats in statistics.items():
-            if overlay.decode_map.get(chr(message_id)):
-                mapped_name = str(message_id) + ":" + overlay.decode_map[chr(message_id)].__name__
+            if overlay.decode_map[message_id]:
+                mapped_name = str(message_id) + ":" + overlay.decode_map[message_id].__name__
             else:
                 mapped_name = str(message_id) + ":unknown"
             mapped_value = network_stats.to_dict()


### PR DESCRIPTION
This PR:

 - Fixes `deprecated_message_names` indexing on `chr` and being looked-up with `int`.
 - Updates `decode_map` to be a list instead of a dictionary.

This _should_ be faster and more memory efficient. I'll produce some perfomance results soon, if this is not faster I'll close this PR again.
