### PR TITLE
Added easy way to reset Endpoint byte counters

### DIFF
--- a/ipv8/messaging/interfaces/dispatcher/endpoint.py
+++ b/ipv8/messaging/interfaces/dispatcher/endpoint.py
@@ -140,3 +140,7 @@ class DispatcherEndpoint(Endpoint):
     def close(self) -> None:
         for interface in self.interfaces.values():
             interface.close()
+
+    def reset_byte_counters(self) -> None:
+        for interface in self.interfaces.values():
+            interface.reset_byte_counters()

--- a/ipv8/messaging/interfaces/endpoint.py
+++ b/ipv8/messaging/interfaces/endpoint.py
@@ -108,6 +108,10 @@ class Endpoint(metaclass=abc.ABCMeta):
     def close(self):
         pass
 
+    @abc.abstractmethod
+    def reset_byte_counters(self):
+        pass
+
 
 class EndpointListener(metaclass=abc.ABCMeta):
     """

--- a/ipv8/messaging/interfaces/udp/endpoint.py
+++ b/ipv8/messaging/interfaces/udp/endpoint.py
@@ -114,6 +114,13 @@ class UDPEndpoint(Endpoint, asyncio.DatagramProtocol):
         """
         return self._running
 
+    def reset_byte_counters(self):
+        """
+        Set bytes_up and bytes_down to 0.
+        """
+        self.bytes_up = 0
+        self.bytes_down = 0
+
 
 class UDPv6Endpoint(UDPEndpoint):
 

--- a/ipv8/test/mocking/endpoint.py
+++ b/ipv8/test/mocking/endpoint.py
@@ -44,6 +44,9 @@ class MockEndpoint(Endpoint):
     def close(self, timeout=0.0):
         self._open = False
 
+    def reset_byte_counters(self):
+        pass
+
 
 class AddressTester(EndpointListener):
 


### PR DESCRIPTION
Fixes #851

This PR:

 - Adds `Endpoint.reset_byte_counters` to reset the `bytes_up` and `bytes_down` counters back to `0`.

