### PR TITLE
Added advanced identity doc to TOC

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -73,6 +73,7 @@ Table of contents
    :maxdepth: 2
    :caption: Further reading:
 
+   further-reading/advanced_identity.rst
    further-reading/trustchain.rst
    further-reading/anonymization.rst
 


### PR DESCRIPTION
Fixes #854

This PR:

 - Updates the documentation `index.rst` to include the advanced identity documentation.
 

