### PR TITLE
Automated Version Update

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -24,9 +24,9 @@ copyright = '2017-2020, Tribler'  # Do not change manually! Handled by github_in
 author = u'Tribler'
 
 # The short X.Y version
-version = '2.2'  # Do not change manually! Handled by github_increment_version.py
+version = '2.3'  # Do not change manually! Handled by github_increment_version.py
 # The full version, including alpha/beta/rc tags
-release = '2.2.0'  # Do not change manually! Handled by github_increment_version.py
+release = '2.3.0'  # Do not change manually! Handled by github_increment_version.py
 
 
 # -- General configuration ---------------------------------------------------

--- a/ipv8/REST/rest_manager.py
+++ b/ipv8/REST/rest_manager.py
@@ -84,7 +84,7 @@ class RESTManager:
         aiohttp_apispec = AiohttpApiSpec(
             app=self.root_endpoint.app,
             title="IPv8 REST API documentation",
-            version="v2.2",  # Do not change manually! Handled by github_increment_version.py
+            version="v2.3",  # Do not change manually! Handled by github_increment_version.py
             url="/docs/swagger.json",
             swagger_path="/docs",
         )

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     description='The Python implementation of the IPV8 library',
     long_description=long_description,
     long_description_content_type='text/markdown',
-    version='2.2.0',  # Do not change manually! Handled by github_increment_version.py
+    version='2.3.0',  # Do not change manually! Handled by github_increment_version.py
     url='https://github.com/Tribler/py-ipv8',
     package_data={'': ['*.*']},
     packages=find_packages(),


### PR DESCRIPTION
Suggested release message
---
Tag version: 2.3
Release title: IPv8 v2.3.1504 release
Body:
Includes the first 1504 commits (+110 since v2.2) for IPv8, containing:

 - Added convenience add strategy method
 - Fixed MockDHTProvider
 - Added settings for the sign timeouts
 - Filter relay_candidates based on public_key
 - Added issue templates
 - Fixed Swagger docs when api_key is set
 - Fixed IPv8 exit node script
 - Add advanced attestation tutorial
 - Fixed TaskManagers not being shutdown
 - Fix for encoding hostnames in TunnelCommunity
 - Fixed issue with missing public keys in OverlaysEndpoint
 - Don't load database on CommunicationManager start
 - Make pseudonym directory in working directory
 - Added a Pull Request template
 - Fixed PR template folder
 - Added mutation test badge to README
 - Removed log statement
 - Added PyPi release GitHub action
 - Added a code of conduct
 - Removed check_num_packets from TunnelExitSocket
 - Removed Endpoint stresstest
 - Updates to documentation
 - Removed identity communities from default configuration
 - Removed json_util
 - Simplified Getting Started in README.md
 - Added NetworkEndpoint REST API tests
 - Added EndpointDispatcher
 - Added multiple Peer interfaces support
 - Made RootEndpoint configurable
 - Added HTTP status code verification to make_request
 - Added bytes_up and bytes_down to DispatcherEndpoint
 - Added speed test functionality to TunnelCommunity
 - Undeprecated Peer.address
 - Add message ID to tunnel payload classes
 - Catch CancelledError in on_ip_address
 - Removed unnecessary ord calls
 - Fixed EndpointListener LAN estimation
 - Fixed M2CryptoSK.verify
 - Don't use decode_map directly for message handlers
 - Switch decode_map to list
 - Added easy way to reset Endpoint byte counters
 - Fixed wrong error in MockTunnelExitSocket
 - Added advanced identity doc to TOC
 - Fixed GitHub version incrementer script