### PR TITLE
Updated the GitHub release script and its instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,9 @@ Only use them in the following situations:
  3. Allow testing of Pull Requests (type `ok to test` as a comment in the Pull Request).
  4. Merging Pull Requests, but only if the automated tests pass (or failure is properly ratified) and **all** reviewers are sufficiently satisfied with the change. **Never ever merge your own Pull Request** without approving reviews from others.
  5. Making a new branch on the main repository for **completed** changes that conflict with -or cannot be merged into- the `master` branch, but should not be lost. Feature branches that are still in development should not be in the main repository. 
- 6. Authoring releases. Make sure the version is incremented in `setup.py` (for which you can use `github_increment_version.py` in most cases) before authoring a release on GitHub. Next, create a release on PyPi with `python3 setup.py sdist bdist_wheel` and `python3 -m twine upload dist/*`.
+ 6. a. Authoring releases. Run `github_increment_version.py` to automatically generate a PR that increments the version entries and gives you a message and tag names you can paste into a GitHub release. GitHub Actions should automatically push this release to `pypi.org`.
+ 
+    b. Manually authoring releases (in case 6.a. does not work). Make sure the version is incremented in `setup.py`, `doc/conf.py` and `ipv8/REST/rest_manager.py` before authoring a release on GitHub. Next, create a release on PyPi with `python3 setup.py sdist bdist_wheel` and `python3 -m twine upload dist/*`.
 
 ### Common Q&A
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,8 @@ It's great that you want to contribute to IPv8. We would like you to take heed o
  2. We accept Pull Requests that are tied to issues or change a very small amount of lines. If you forget to open an issue with your Pull Request, the discussion will take place in the Pull Request - often leading to a very unstructured discussion. Contributions to the documentation are exempt from this rule, as they are quite literally self-documenting.
  3. It is better to make small changes than large ones, as smaller changes usually have less bugs.
  4. Make sure the automatic Pull Request tests pass or rationalize why it is O.K. that they do not.
- 5. When you deem it done, clearly mark your Pull Request as ready for review (prefix it with `READY:` for example) or ask an administrator to review your Pull Request.
+ 5. To your best ability, reflect your Pull Request's changes in your PR title (details go into the PR message). Follow this format: `Added|Fixed|Removed|Updated` `your feature` (for example, "Added PR instruction step 5").
+ 6. When you deem it done, clearly mark your Pull Request as ready for review (prefix it with `READY:` for example) or ask an administrator to review your Pull Request.
  
 ### I have administrator rights
 


### PR DESCRIPTION
This PR:

 - Adds alphabetical sorting for the GitHub release script.
 - Adds automated erroneous prefix stripping for the GitHub release script.
 - Updates `CONTRIBUTING.md` with the two-step release workflow for administrators.
 - Updates `CONTRIBUTING.md` with naming conventions for contributors.
 
