### PR TITLE
Added pytest support

### DIFF
--- a/ipv8/test/base.py
+++ b/ipv8/test/base.py
@@ -1,10 +1,9 @@
 import os
-import random
 import shutil
-import string
 import sys
 import threading
 import time
+import uuid
 from asyncio import all_tasks, get_event_loop, sleep
 
 import asynctest
@@ -155,7 +154,7 @@ class TestBase(asynctest.TestCase):
         await self.deliver_messages()
 
     def temporary_directory(self):
-        rndstr = '_temp_' + ''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(10))
+        rndstr = '_temp_' + uuid.uuid4().hex
         d = os.path.abspath(self.__class__.__name__ + rndstr)
         self._tempdirs.append(d)
         os.makedirs(d)

--- a/ipv8/test/base.py
+++ b/ipv8/test/base.py
@@ -63,39 +63,41 @@ class TestBase(asynctest.TestCase):
     def setUpClass(cls):
         TestBase.__lockup_timestamp__ = time.time()
 
-        def check_loop():
-            while time.time() - TestBase.__lockup_timestamp__ < cls.MAX_TEST_TIME:
-                time.sleep(2)
-                # If the test class completed normally, exit
-                if not cls.__testing__:
-                    return
-            # If we made it here, there is a serious issue which we cannot recover from.
-            # Most likely the threadpool got into a deadlock while shutting down.
-            import traceback
-            print("The test-suite locked up! Force quitting! Thread dump:", file=sys.stderr)
-            for tid, stack in sys._current_frames().items():
-                if tid != threading.currentThread().ident:
-                    print("THREAD#%d" % tid, file=sys.stderr)
-                    for line in traceback.format_list(traceback.extract_stack(stack)):
-                        print("|", line[:-1].replace('\n', '\n|   '), file=sys.stderr)
+        # pytest has its own timeout.
+        if "PYTEST_CURRENT_TEST" not in os.environ:
+            def check_loop():
+                while time.time() - TestBase.__lockup_timestamp__ < cls.MAX_TEST_TIME:
+                    time.sleep(2)
+                    # If the test class completed normally, exit
+                    if not cls.__testing__:
+                        return
+                # If we made it here, there is a serious issue which we cannot recover from.
+                # Most likely the threadpool got into a deadlock while shutting down.
+                import traceback
+                print("The test-suite locked up! Force quitting! Thread dump:", file=sys.stderr)
+                for tid, stack in sys._current_frames().items():
+                    if tid != threading.currentThread().ident:
+                        print("THREAD#%d" % tid, file=sys.stderr)
+                        for line in traceback.format_list(traceback.extract_stack(stack)):
+                            print("|", line[:-1].replace('\n', '\n|   '), file=sys.stderr)
 
-            tasks = all_tasks(get_event_loop())
-            if tasks:
-                print("Pending tasks:")
-                for task in tasks:
-                    print(">     %s" % task)
+                tasks = all_tasks(get_event_loop())
+                if tasks:
+                    print("Pending tasks:")
+                    for task in tasks:
+                        print(">     %s" % task)
 
-            # Our test suite catches the SIGINT signal, this allows it to print debug information before force exiting.
-            # If we were to hard exit here (through os._exit) we would lose this additional information.
-            import signal
-            os.kill(os.getpid(), signal.SIGINT)
-            # But sometimes it just flat out refuses to die (sys.exit will also not work in this case).
-            # So we double kill ourselves:
-            time.sleep(5.0)  # Just in case anyone is listening to our signal and wishes to log some stats quickly.
-            os._exit(1)  # pylint: disable=W0212
-        t = threading.Thread(target=check_loop)
-        t.daemon = True
-        t.start()
+                # Our test suite catches the SIGINT signal, this allows it to print information before force exiting.
+                # If we were to hard exit here (through os._exit) we would lose this additional information.
+                import signal
+                os.kill(os.getpid(), signal.SIGINT)
+                # But sometimes it just flat out refuses to die (sys.exit will also not work in this case).
+                # So we double kill ourselves:
+                time.sleep(5.0)  # Just in case anyone is listening to our signal and wishes to log some stats quickly.
+                os._exit(1)  # pylint: disable=W0212
+            t = threading.Thread(target=check_loop)
+            t.daemon = True
+            t.start()
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
Fixes #864
Fixes #865 

This PR:

 - Updates `TestBase.setUpClass` to detect `pytest` and disable the class lock-up detection.
 - Updates `TestBase.temporary_directory` to use `uuid` instead of 10x `random.choice`.

Note: the body of the if-statement for the first change is the same as before.
