### PR TITLE
Don't remove all other observers in AsyncioEndpoint

### DIFF
--- a/ipv8/REST/asyncio_endpoint.py
+++ b/ipv8/REST/asyncio_endpoint.py
@@ -72,8 +72,7 @@ class AsyncioEndpoint(BaseEndpoint):
             return False
         if self.strategy:
             with self.session.overlay_lock:
-                self.session.strategies = [s for s in self.session.strategies
-                                           if not isinstance(s[0], DriftMeasurementStrategy)]
+                self.session.strategies = [s for s in self.session.strategies if s[0] != self.strategy]
             self.strategy = None
             return True
         return True


### PR DESCRIPTION
Fixes #870

This PR:

 - Fixes the `AsyncioEndpoint` removing all subclasses of `DriftMeasurementStrategy` on disable.

