### PR TITLE
 Updated Serializer to be more efficient

### DIFF
--- a/doc/reference/serialization.rst
+++ b/doc/reference/serialization.rst
@@ -28,30 +28,26 @@ Each serializable class has to specify the following class members:
    :widths: 10, 20
 
    "format_list", "A list containing valid data type primitive names."
-   "optional_format_list", "A list containing valid data type primitive names. As the name implies, any number of arguments may be supplied."
    "names", "Only for VariablePayload classes, the instance fields to bind the data types to."
 
 
 As an example, we will now define three completely wire-format compatible messages using the three classes.
-Each of the messages will serialize to a (four byte) unsigned integer followed by an optional (two byte) unsigned short.
+Each of the messages will serialize to a (four byte) unsigned integer followed by an (two byte) unsigned short.
 Each instance will have two fields: ``field1`` and ``field2`` corresponding to the integer and short.
 
 .. code-block:: python
 
     class MySerializable(Serializable):
 
-        format_list = ['I']
-        optional_format_list = ['H']
+        format_list = ['I', 'H']
 
-        def __init__(self, field1, field2=None):
+        def __init__(self, field1, field2):
             self.field1 = field1
             self.field2 = field2
 
         def to_pack_list(self):
-            out = [('I', self.field1)]
-            if self.field2 is not None:
-                out += [('H', self.field2)]
-            return out
+            return [('I', self.field1),
+                    ('H', self.field2)]
 
         @classmethod
         def from_unpack_list(cls, *args):
@@ -60,18 +56,15 @@ Each instance will have two fields: ``field1`` and ``field2`` corresponding to t
 
     class MyPayload(Payload):
 
-        format_list = ['I']
-        optional_format_list = ['H']
+        format_list = ['I', 'H']
 
-        def __init__(self, field1, field2=None):
+        def __init__(self, field1, field2):
             self.field1 = field1
             self.field2 = field2
 
         def to_pack_list(self):
-            out = [('I', self.field1)]
-            if self.field2 is not None:
-                out += [('H', self.field2)]
-            return out
+            return [('I', self.field1),
+                    ('H', self.field2)]
 
         @classmethod
         def from_unpack_list(cls, *args):
@@ -80,15 +73,13 @@ Each instance will have two fields: ``field1`` and ``field2`` corresponding to t
 
     class MyVariablePayload(VariablePayload):
 
-        format_list = ['I']
-        optional_format_list = ['H']
+        format_list = ['I', 'H']
         names = ['field1', 'field2']
 
     @vp_compile
     class MyCVariablePayload(VariablePayload):
 
-        format_list = ['I']
-        optional_format_list = ['H']
+        format_list = ['I', 'H']
         names = ['field1', 'field2']
 
 
@@ -97,10 +88,10 @@ To show some of the differences, let's check out the output of the following scr
 
 .. code-block:: python
 
-    serializable1 = MySerializable(1)
-    serializable2 = MyPayload(1)
-    serializable3 = MyVariablePayload(1)
-    serializable4 = MyCVariablePayload(1)
+    serializable1 = MySerializable(1, 2)
+    serializable2 = MyPayload(1, 2)
+    serializable3 = MyVariablePayload(1, 2)
+    serializable4 = MyCVariablePayload(1, 2)
 
     print("As string:")
     print(serializable1)
@@ -126,44 +117,35 @@ To show some of the differences, let's check out the output of the following scr
     print(timeit.timeit('serializable3.from_unpack_list(1, 2)', number=1000, globals=locals()))
     print(timeit.timeit('serializable4.from_unpack_list(1, 2)', number=1000, globals=locals()))
 
-    print("Unserialization speed w/o optional:")
-    print(timeit.timeit('serializable1.from_unpack_list(1)', number=1000, globals=locals()))
-    print(timeit.timeit('serializable2.from_unpack_list(1)', number=1000, globals=locals()))
-    print(timeit.timeit('serializable3.from_unpack_list(1)', number=1000, globals=locals()))
-    print(timeit.timeit('serializable4.from_unpack_list(1)', number=1000, globals=locals()))
-
 
 .. code-block:: bash
 
     As string:
-    <__main__.MySerializable object at 0x7fb493a8b1d0>
+    <__main__.MySerializable object at 0x00000127F1B91F70>
     MyPayload
     | field1: 1
-    | field2: None
+    | field2: 2
     MyVariablePayload
     | field1: 1
+    | field2: 2
     MyCVariablePayload
     | field1: 1
+    | field2: 2
     Field values:
-    1 None
-    1 None
-    1 <undefined>
-    1 <undefined>
+    1 2
+    1 2
+    1 2
+    1 2
     Serialization speed:
-    0.0007182089993875707
-    0.0007311019999178825
-    0.006567462998646079
-    0.0008536430013919016
+    0.00020690000000000985
+    0.00020630000000000648
+    0.0015785999999999994
+    0.0002122999999999986
     Unserialization speed:
-    0.0013339410015760222
-    0.0014789169999858132
-    0.01917448600033822
-    0.0028652559994952753
-    Unserialization speed w/o optional:
-    0.001269377000426175
-    0.0012895309992018156
-    0.014515060998746776
-    0.0018252249992656289
+    0.0003621000000000041
+    0.00036540000000000183
+    0.0036703999999999903
+    0.00045059999999999545
 
 .. _Datatypes Section:
 

--- a/ipv8/REST/attestation_endpoint.py
+++ b/ipv8/REST/attestation_endpoint.py
@@ -12,7 +12,7 @@ from ..attestation.identity.community import IdentityCommunity, create_community
 from ..attestation.wallet.community import AttestationCommunity
 from ..keyvault.crypto import default_eccrypto
 from ..peer import Peer
-from ..util import cast_to_bin, strip_sha1_padding, succeed
+from ..util import strip_sha1_padding, succeed
 
 
 class AttestationEndpoint(BaseEndpoint):
@@ -315,7 +315,7 @@ class AttestationEndpoint(BaseEndpoint):
             if 'metadata' in args:
                 metadata_unicode = json.loads(b64decode(args['metadata']))
                 for k, v in metadata_unicode.items():
-                    metadata[cast_to_bin(k)] = cast_to_bin(v)
+                    metadata[k.encode()] = v.encode()
             blob = await request.read()
 
             self.attestation_overlay.dump_blob(attribute_name, id_format, blob, metadata)

--- a/ipv8/REST/isolation_endpoint.py
+++ b/ipv8/REST/isolation_endpoint.py
@@ -8,7 +8,6 @@ from .base_endpoint import BaseEndpoint, HTTP_BAD_REQUEST, Response
 from .schema import DefaultResponseSchema, schema
 from ..community import _DEFAULT_ADDRESSES
 from ..messaging.anonymization.community import TunnelCommunity
-from ..util import cast_to_chr
 
 
 class IsolationEndpoint(BaseEndpoint):
@@ -58,14 +57,9 @@ class IsolationEndpoint(BaseEndpoint):
         if 'exitnode' not in args and 'bootstrapnode' not in args:
             return Response({"success": False, "error": "Parameter 'exitnode' or 'bootstrapnode' is required"},
                             status=HTTP_BAD_REQUEST)
-        # Attempt to decode the address
-        try:
-            address_str = cast_to_chr(args['ip'])
-            port_str = cast_to_chr(args['port'])
-            fmt_address = (address_str, int(port_str))
-        except Exception:
-            import traceback
-            return Response({"success": False, "error": traceback.format_exc()}, status=HTTP_BAD_REQUEST)
+        address_str = args['ip']
+        port_num = args['port']
+        fmt_address = (address_str, port_num)
         # Actually add the address to the requested service
         if 'exitnode' in args:
             self.add_exit_node(fmt_address)

--- a/ipv8/attestation/trustchain/block.py
+++ b/ipv8/attestation/trustchain/block.py
@@ -202,7 +202,7 @@ class TrustChainBlock(object):
         args = [self.public_key, self.sequence_number, self.link_public_key, self.link_sequence_number,
                 self.previous_hash, self.signature if signature else EMPTY_SIG, self.type, self._transaction,
                 self.timestamp]
-        return self.serializer.pack_multiple(HalfBlockPayload(*args).to_pack_list())[0]
+        return self.serializer.pack_serializable(HalfBlockPayload(*args))
 
     def validate_transaction(self, database):
         """

--- a/ipv8/attestation/trustchain/community.py
+++ b/ipv8/attestation/trustchain/community.py
@@ -140,16 +140,16 @@ class TrustChainCommunity(Community):
         Send a block to a specific address, or do a broadcast to known peers if no peer is specified.
         """
         global_time = self.claim_global_time()
-        dist = GlobalTimeDistributionPayload(global_time).to_pack_list()
+        dist = GlobalTimeDistributionPayload(global_time)
 
         if address:
             self.logger.debug("Sending block to (%s:%d) (%s)", address[0], address[1], block)
-            payload = HalfBlockPayload.from_half_block(block).to_pack_list()
+            payload = HalfBlockPayload.from_half_block(block)
             packet = self._ez_pack(self._prefix, 1, [dist, payload], False)
             self.endpoint.send(address, packet)
         else:
             self.logger.debug("Broadcasting block %s", block)
-            payload = HalfBlockBroadcastPayload.from_half_block(block, ttl).to_pack_list()
+            payload = HalfBlockBroadcastPayload.from_half_block(block, ttl)
             packet = self._ez_pack(self._prefix, 5, [dist, payload], False)
             peers = self.get_peers()
             for peer in random.sample(peers, min(len(peers), self.settings.broadcast_fanout)):
@@ -161,16 +161,16 @@ class TrustChainCommunity(Community):
         Send a half block pair to a specific address, or do a broadcast to known peers if no peer is specified.
         """
         global_time = self.claim_global_time()
-        dist = GlobalTimeDistributionPayload(global_time).to_pack_list()
+        dist = GlobalTimeDistributionPayload(global_time)
 
         if address:
             self.logger.debug("Sending block pair to (%s:%d) (%s and %s)", address[0], address[1], block1, block2)
-            payload = HalfBlockPairPayload.from_half_blocks(block1, block2).to_pack_list()
+            payload = HalfBlockPairPayload.from_half_blocks(block1, block2)
             packet = self._ez_pack(self._prefix, 4, [dist, payload], False)
             self.endpoint.send(address, packet)
         else:
             self.logger.debug("Broadcasting blocks %s and %s", block1, block2)
-            payload = HalfBlockPairBroadcastPayload.from_half_blocks(block1, block2, ttl).to_pack_list()
+            payload = HalfBlockPairBroadcastPayload.from_half_blocks(block1, block2, ttl)
             packet = self._ez_pack(self._prefix, 6, [dist, payload], False)
             peers = self.get_peers()
             for peer in random.sample(peers, min(len(peers), self.settings.broadcast_fanout)):
@@ -464,9 +464,9 @@ class TrustChainCommunity(Community):
                          hexlify(peer.public_key.key_to_bin())[-8:], start_seq_num, end_seq_num, crawl_id)
 
         global_time = self.claim_global_time()
-        auth = BinMemberAuthenticationPayload(self.my_peer.public_key.key_to_bin()).to_pack_list()
-        payload = CrawlRequestPayload(public_key, start_seq_num, end_seq_num, crawl_id).to_pack_list()
-        dist = GlobalTimeDistributionPayload(global_time).to_pack_list()
+        auth = BinMemberAuthenticationPayload(self.my_peer.public_key.key_to_bin())
+        payload = CrawlRequestPayload(public_key, start_seq_num, end_seq_num, crawl_id)
+        dist = GlobalTimeDistributionPayload(global_time)
 
         packet = self._ez_pack(self._prefix, 2, [auth, dist, payload])
         self.endpoint.send(peer.address, packet)
@@ -562,8 +562,8 @@ class TrustChainCommunity(Community):
 
         if total_count == 0:
             global_time = self.claim_global_time()
-            response_payload = EmptyCrawlResponsePayload(payload.crawl_id).to_pack_list()
-            dist = GlobalTimeDistributionPayload(global_time).to_pack_list()
+            response_payload = EmptyCrawlResponsePayload(payload.crawl_id)
+            dist = GlobalTimeDistributionPayload(global_time)
             packet = self._ez_pack(self._prefix, 7, [dist, response_payload], False)
             self.endpoint.send(peer.address, packet)
         else:
@@ -627,8 +627,8 @@ class TrustChainCommunity(Community):
             return
 
         global_time = self.claim_global_time()
-        payload = CrawlResponsePayload.from_crawl(block, crawl_id, index, total_count).to_pack_list()
-        dist = GlobalTimeDistributionPayload(global_time).to_pack_list()
+        payload = CrawlResponsePayload.from_crawl(block, crawl_id, index, total_count)
+        dist = GlobalTimeDistributionPayload(global_time)
 
         packet = self._ez_pack(self._prefix, 3, [dist, payload], False)
         self.endpoint.send(peer.address, packet)

--- a/ipv8/attestation/wallet/community.py
+++ b/ipv8/attestation/wallet/community.py
@@ -18,7 +18,7 @@ from ...lazy_community import lazy_wrapper
 from ...messaging.payload_headers import BinMemberAuthenticationPayload, GlobalTimeDistributionPayload
 from ...peer import Peer
 from ...requestcache import RequestCache
-from ...util import cast_to_bin, cast_to_chr, maybe_coroutine
+from ...util import maybe_coroutine
 
 
 def synchronized(f):
@@ -151,7 +151,7 @@ class AttestationCommunity(Community):
 
         meta_dict = {
             "attribute": attribute_name,
-            "public_key": cast_to_chr(encodebytes(public_key.serialize())),
+            "public_key": encodebytes(public_key.serialize()).decode(),
             "id_format": id_format
         }
         meta_dict.update(metadata)
@@ -178,7 +178,7 @@ class AttestationCommunity(Community):
         """
         metadata = json.loads(payload.metadata)
         attribute = metadata.pop('attribute')
-        pubkey_b64 = cast_to_bin(metadata.pop('public_key'))
+        pubkey_b64 = metadata.pop('public_key').encode()
         id_format = metadata.pop('id_format')
         id_algorithm = self.get_id_algorithm(id_format)
 
@@ -198,7 +198,7 @@ class AttestationCommunity(Community):
         """
         We got an Attestation delivered to us.
         """
-        self.attestation_keys[cast_to_bin(attestation_hash)] = (secret_key, id_format)
+        self.attestation_keys[attestation_hash] = (secret_key, id_format)
         self.database.insert_attestation(unserialized, attestation_hash, secret_key, id_format)
         self.attestation_request_complete_callback(self.my_peer, name, attestation_hash, id_format, peer)
 

--- a/ipv8/attestation/wallet/community.py
+++ b/ipv8/attestation/wallet/community.py
@@ -158,9 +158,9 @@ class AttestationCommunity(Community):
         metadata = json.dumps(meta_dict).encode()
 
         global_time = self.claim_global_time()
-        auth = BinMemberAuthenticationPayload(self.my_peer.public_key.key_to_bin()).to_pack_list()
-        payload = RequestAttestationPayload(metadata).to_pack_list()
-        dist = GlobalTimeDistributionPayload(global_time).to_pack_list()
+        auth = BinMemberAuthenticationPayload(self.my_peer.public_key.key_to_bin())
+        payload = RequestAttestationPayload(metadata)
+        dist = GlobalTimeDistributionPayload(global_time)
 
         gtime_str = str(global_time).encode('utf-8')
         self.request_cache.add(ReceiveAttestationRequestCache(self, peer.mid + gtime_str, secret_key, attribute_name,
@@ -230,9 +230,9 @@ class AttestationCommunity(Community):
         self.request_cache.add(ReceiveAttestationVerifyCache(self, attestation_hash, id_format))
 
         global_time = self.claim_global_time()
-        auth = BinMemberAuthenticationPayload(self.my_peer.public_key.key_to_bin()).to_pack_list()
-        payload = VerifyAttestationRequestPayload(attestation_hash).to_pack_list()
-        dist = GlobalTimeDistributionPayload(global_time).to_pack_list()
+        auth = BinMemberAuthenticationPayload(self.my_peer.public_key.key_to_bin())
+        payload = VerifyAttestationRequestPayload(attestation_hash)
+        dist = GlobalTimeDistributionPayload(global_time)
 
         packet = self._ez_pack(self._prefix, 1, [auth, dist, payload])
         self.endpoint.send(socket_address, packet)
@@ -270,9 +270,9 @@ class AttestationCommunity(Community):
             self.logger.debug("Sending attestation chunk %d to %s", sequence_number, str(socket_address))
             if global_time is None:
                 global_time = self.claim_global_time()
-            auth = BinMemberAuthenticationPayload(self.my_peer.public_key.key_to_bin()).to_pack_list()
-            payload = AttestationChunkPayload(sha1(blob).digest(), sequence_number, blob_chunk).to_pack_list()
-            dist = GlobalTimeDistributionPayload(global_time).to_pack_list()
+            auth = BinMemberAuthenticationPayload(self.my_peer.public_key.key_to_bin())
+            payload = AttestationChunkPayload(sha1(blob).digest(), sequence_number, blob_chunk)
+            dist = GlobalTimeDistributionPayload(global_time)
             packet = self._ez_pack(self._prefix, 2, [auth, dist, payload])
             self.endpoint.send(socket_address, packet)
 
@@ -364,9 +364,9 @@ class AttestationCommunity(Community):
             self.request_cache.add(PendingChallengeCache(self, sha1(challenge).digest(), cache, cache.id_format))
 
             global_time = self.claim_global_time()
-            auth = BinMemberAuthenticationPayload(self.my_peer.public_key.key_to_bin()).to_pack_list()
-            payload = ChallengePayload(attestation_hash, challenge).to_pack_list()
-            dist = GlobalTimeDistributionPayload(global_time).to_pack_list()
+            auth = BinMemberAuthenticationPayload(self.my_peer.public_key.key_to_bin())
+            payload = ChallengePayload(attestation_hash, challenge)
+            dist = GlobalTimeDistributionPayload(global_time)
 
             packet = self._ez_pack(self._prefix, 3, [auth, dist, payload])
             self.endpoint.send(peer.address, packet)
@@ -382,11 +382,10 @@ class AttestationCommunity(Community):
         attestation = self.cached_attestation_blobs[payload.attestation_hash]
 
         global_time = self.claim_global_time()
-        auth = BinMemberAuthenticationPayload(self.my_peer.public_key.key_to_bin()).to_pack_list()
+        auth = BinMemberAuthenticationPayload(self.my_peer.public_key.key_to_bin())
         payload = ChallengeResponsePayload(challenge_hash,
-                                           algorithm.create_challenge_response(SK, attestation, payload.challenge)
-                                           ).to_pack_list()
-        dist = GlobalTimeDistributionPayload(global_time).to_pack_list()
+                                           algorithm.create_challenge_response(SK, attestation, payload.challenge))
+        dist = GlobalTimeDistributionPayload(global_time)
 
         packet = self._ez_pack(self._prefix, 4, [auth, dist, payload])
         self.endpoint.send(peer.address, packet)
@@ -450,9 +449,9 @@ class AttestationCommunity(Community):
                                                              cache.id_format, honesty_check_byte))
 
                 global_time = self.claim_global_time()
-                auth = BinMemberAuthenticationPayload(self.my_peer.public_key.key_to_bin()).to_pack_list()
-                payload = ChallengePayload(proving_cache.hash, challenge).to_pack_list()
-                dist = GlobalTimeDistributionPayload(global_time).to_pack_list()
+                auth = BinMemberAuthenticationPayload(self.my_peer.public_key.key_to_bin())
+                payload = ChallengePayload(proving_cache.hash, challenge)
+                dist = GlobalTimeDistributionPayload(global_time)
 
                 packet = self._ez_pack(self._prefix, 3, [auth, dist, payload])
                 self.endpoint.send(peer.address, packet)

--- a/ipv8/attestation/wallet/primitives/cryptography_wrapper.py
+++ b/ipv8/attestation/wallet/primitives/cryptography_wrapper.py
@@ -1,7 +1,5 @@
 from cryptography.hazmat.backends import default_backend
 
-from ....util import cast_to_bin
-
 
 def generate_safe_prime(bit_length, backend=default_backend()):
     """
@@ -46,7 +44,7 @@ def is_prime(number, backend=default_backend()):
     if hex_n.endswith('L'):
         hex_n = hex_n[:-1]
     # hex() outputs a unicode string in Python 3
-    hex_n = cast_to_bin(hex_n)
+    hex_n = hex_n.encode()
     generated = backend._lib.BN_new()
     bn_pp = backend._ffi.new("BIGNUM **", generated)
     err = backend._lib.BN_hex2bn(bn_pp, hex_n)

--- a/ipv8/community.py
+++ b/ipv8/community.py
@@ -335,7 +335,7 @@ class Community(EZPackOverlay):
                 self.logger.error("Exception occurred while handling packet!\n"
                                   + ''.join(format_exception(*sys.exc_info())))
         elif warn_unknown:
-            self.logger.warning("Received unknown message: %d from (%s, %d)", ord(msg_id), *source_address)
+            self.logger.warning("Received unknown message: %d from (%s, %d)", msg_id, *source_address)
 
     def walk_to(self, address):
         packet = self.create_introduction_request(address)

--- a/ipv8/community.py
+++ b/ipv8/community.py
@@ -187,9 +187,9 @@ class Community(EZPackOverlay):
                                              True,
                                              u"unknown",
                                              global_time,
-                                             extra_bytes).to_pack_list()
-        auth = BinMemberAuthenticationPayload(self.my_peer.public_key.key_to_bin()).to_pack_list()
-        dist = GlobalTimeDistributionPayload(global_time).to_pack_list()
+                                             extra_bytes)
+        auth = BinMemberAuthenticationPayload(self.my_peer.public_key.key_to_bin())
+        dist = GlobalTimeDistributionPayload(global_time)
 
         return self._ez_pack(self._prefix, 246, [auth, dist, payload])
 
@@ -217,9 +217,9 @@ class Community(EZPackOverlay):
                                               u"unknown",
                                               False,
                                               identifier,
-                                              extra_bytes).to_pack_list()
-        auth = BinMemberAuthenticationPayload(self.my_peer.public_key.key_to_bin()).to_pack_list()
-        dist = GlobalTimeDistributionPayload(global_time).to_pack_list()
+                                              extra_bytes)
+        auth = BinMemberAuthenticationPayload(self.my_peer.public_key.key_to_bin())
+        dist = GlobalTimeDistributionPayload(global_time)
 
         if introduced:
             packet = self.create_puncture_request(lan_socket_address, socket_address, identifier, prefix=prefix)
@@ -229,16 +229,16 @@ class Community(EZPackOverlay):
 
     def create_puncture(self, lan_walker, wan_walker, identifier):
         global_time = self.claim_global_time()
-        payload = PuncturePayload(lan_walker, wan_walker, identifier).to_pack_list()
-        auth = BinMemberAuthenticationPayload(self.my_peer.public_key.key_to_bin()).to_pack_list()
-        dist = GlobalTimeDistributionPayload(global_time).to_pack_list()
+        payload = PuncturePayload(lan_walker, wan_walker, identifier)
+        auth = BinMemberAuthenticationPayload(self.my_peer.public_key.key_to_bin())
+        dist = GlobalTimeDistributionPayload(global_time)
 
         return self._ez_pack(self._prefix, 249, [auth, dist, payload])
 
     def create_puncture_request(self, lan_walker, wan_walker, identifier, prefix=None):
         global_time = self.claim_global_time()
-        payload = PunctureRequestPayload(lan_walker, wan_walker, identifier).to_pack_list()
-        dist = GlobalTimeDistributionPayload(global_time).to_pack_list()
+        payload = PunctureRequestPayload(lan_walker, wan_walker, identifier)
+        dist = GlobalTimeDistributionPayload(global_time)
 
         return self._ez_pack(prefix or self._prefix, 250, [dist, payload], False)
 

--- a/ipv8/dht/community.py
+++ b/ipv8/dht/community.py
@@ -19,7 +19,6 @@ from ..peer import Peer
 from ..peerdiscovery.network import Network
 from ..requestcache import RandomNumberCache, RequestCache
 from ..taskmanager import task
-from ..util import cast_to_bin
 
 PING_INTERVAL = 25
 
@@ -509,7 +508,7 @@ class DHTCommunity(Community):
                 self.tokens.pop(node, None)
 
     def generate_token(self, node):
-        return hashlib.sha1(cast_to_bin(str(node)) + self.token_secrets[-1]).digest()
+        return hashlib.sha1(str(node).encode() + self.token_secrets[-1]).digest()
 
     def check_token(self, node, token):
-        return any([hashlib.sha1(cast_to_bin(str(node)) + secret).digest() == token for secret in self.token_secrets])
+        return any([hashlib.sha1(str(node).encode() + secret).digest() == token for secret in self.token_secrets])

--- a/ipv8/dht/provider.py
+++ b/ipv8/dht/provider.py
@@ -6,7 +6,6 @@ from struct import pack, unpack_from
 from . import DHTError
 from ..messaging.anonymization.tunnel import IntroductionPoint, PEER_SOURCE_DHT
 from ..peer import Peer
-from ..util import cast_to_bin
 
 
 class DHTCommunityProvider(object):
@@ -58,8 +57,8 @@ class DHTCommunityProvider(object):
 
         value = inet_aton(intro_point.peer.address[0]) + pack("!H", intro_point.peer.address[1])
         value += pack('!I', intro_point.last_seen)
-        value += pack('!H', len(intro_pk)) + cast_to_bin(intro_pk)
-        value += pack('!H', len(seeder_pk)) + cast_to_bin(seeder_pk)
+        value += pack('!H', len(intro_pk)) + intro_pk
+        value += pack('!H', len(seeder_pk)) + seeder_pk
 
         try:
             await self.dht_community.store_value(info_hash, value)

--- a/ipv8/lazy_community.py
+++ b/ipv8/lazy_community.py
@@ -4,7 +4,6 @@ from .keyvault.crypto import default_eccrypto
 from .messaging.payload_headers import BinMemberAuthenticationPayload, GlobalTimeDistributionPayload
 from .overlay import Overlay
 from .peer import Peer
-from .util import cast_to_bin
 
 
 def lazy_wrapper(*payloads):
@@ -189,7 +188,7 @@ class EZPackOverlay(Overlay):
         return self._ez_pack(self._prefix, msg_num, payloads, sig)
 
     def _ez_pack(self, prefix, msg_num, payloads, sig=True):
-        packet = prefix + cast_to_bin(chr(msg_num)) + self.serializer.pack_serializable_list(payloads)
+        packet = prefix + bytes([msg_num]) + self.serializer.pack_serializable_list(payloads)
         if sig:
             packet += default_eccrypto.create_signature(self.my_peer.key, packet)
         return packet

--- a/ipv8/lazy_community.py
+++ b/ipv8/lazy_community.py
@@ -28,9 +28,9 @@ def lazy_wrapper(*payloads):
         @wraps(func)
         def wrapper(self, source_address, data):
             # UNPACK
-            auth, remainder = self.serializer.unpack_to_serializables([BinMemberAuthenticationPayload, ], data[23:])
+            auth, _ = self.serializer.unpack_serializable(BinMemberAuthenticationPayload, data, offset=23)
             signature_valid, remainder = self._verify_signature(auth, data)
-            unpacked = self.serializer.ez_unpack_serializables(payloads, remainder[23:])
+            unpacked = self.serializer.unpack_serializable_list(payloads, remainder, offset=23)
             # ASSERT
             if not signature_valid:
                 raise PacketDecodingError("Incoming packet %s has an invalid signature" %
@@ -63,9 +63,9 @@ def lazy_wrapper_wd(*payloads):
         @wraps(func)
         def wrapper(self, source_address, data):
             # UNPACK
-            auth, remainder = self.serializer.unpack_to_serializables([BinMemberAuthenticationPayload, ], data[23:])
+            auth, _ = self.serializer.unpack_serializable(BinMemberAuthenticationPayload, data, offset=23)
             signature_valid, remainder = self._verify_signature(auth, data)
-            unpacked = self.serializer.ez_unpack_serializables(payloads, remainder[23:])
+            unpacked = self.serializer.unpack_serializable_list(payloads, remainder, offset=23)
             # ASSERT
             if not signature_valid:
                 raise PacketDecodingError("Incoming packet %s has an invalid signature" %
@@ -98,7 +98,7 @@ def lazy_wrapper_unsigned(*payloads):
         @wraps(func)
         def wrapper(self, source_address, data):
             # UNPACK
-            unpacked = self.serializer.ez_unpack_serializables(payloads, data[23:])
+            unpacked = self.serializer.unpack_serializable_list(payloads, data, offset=23)
             return func(self, source_address, *unpacked)
         return wrapper
     return decorator
@@ -184,16 +184,12 @@ class EZPackOverlay(Overlay):
         :rtype: bytes or str
         """
         sig = kwargs.get('sig', True)
-        format_list_list = ([BinMemberAuthenticationPayload(self.my_peer.public_key.key_to_bin()).to_pack_list()]
-                            if sig else [])
-        for payload in payloads:
-            format_list_list += [payload.to_pack_list()]
-        return self._ez_pack(self._prefix, msg_num, format_list_list, sig)
+        if sig:
+            payloads = (BinMemberAuthenticationPayload(self.my_peer.public_key.key_to_bin()),) + payloads
+        return self._ez_pack(self._prefix, msg_num, payloads, sig)
 
-    def _ez_pack(self, prefix, msg_num, format_list_list, sig=True):
-        packet = prefix + cast_to_bin(chr(msg_num))
-        for format_list in format_list_list:
-            packet += self.serializer.pack_multiple(format_list)[0]
+    def _ez_pack(self, prefix, msg_num, payloads, sig=True):
+        packet = prefix + cast_to_bin(chr(msg_num)) + self.serializer.pack_serializable_list(payloads)
         if sig:
             packet += default_eccrypto.create_signature(self.my_peer.key, packet)
         return packet
@@ -208,20 +204,20 @@ class EZPackOverlay(Overlay):
 
     def _ez_unpack_auth(self, payload_class, data):
         # UNPACK
-        auth, remainder = self.serializer.unpack_to_serializables([BinMemberAuthenticationPayload, ], data[23:])
+        auth, _ = self.serializer.unpack_serializable(BinMemberAuthenticationPayload, data, offset=23)
         signature_valid, remainder = self._verify_signature(auth, data)
         format = [GlobalTimeDistributionPayload, payload_class]
-        dist, payload = self.serializer.ez_unpack_serializables(format, remainder[23:])
+        unpacked = self.serializer.unpack_serializable_list(format, remainder, offset=23)
         # ASSERT
         if not signature_valid:
             raise PacketDecodingError("Incoming packet %s has an invalid signature" % payload_class.__name__)
         # PRODUCE
-        return auth, dist, payload
+        return auth, unpacked[0], unpacked[1]
 
     def _ez_unpack_noauth(self, payload_class, data, global_time=True):
         # UNPACK
         format = [GlobalTimeDistributionPayload, payload_class] if global_time else [payload_class]
-        unpacked = self.serializer.ez_unpack_serializables(format, data[23:])
+        unpacked = self.serializer.unpack_serializable_list(format, data, offset=23)
         # PRODUCE
         return unpacked if global_time else unpacked[0]
 

--- a/ipv8/messaging/anonymization/hidden_services.py
+++ b/ipv8/messaging/anonymization/hidden_services.py
@@ -243,7 +243,7 @@ class HiddenTunnelCommunity(TunnelCommunity):
         return super(HiddenTunnelCommunity, self).get_max_time(circuit_id)
 
     def tunnel_data(self, circuit, destination, payload):
-        packet = self._ez_pack(self._prefix, payload.msg_id, [payload.to_pack_list()], False)
+        packet = self._ez_pack(self._prefix, payload.msg_id, [payload], False)
         pre = ('0.0.0.0', 0)
         post = ('0.0.0.0', 0)
         if isinstance(circuit, TunnelExitSocket):
@@ -311,7 +311,7 @@ class HiddenTunnelCommunity(TunnelCommunity):
             self.send_cell(target_addr, payload)
         else:
             # Send back to exit node
-            packet = self._ez_pack(self._prefix, payload.msg_id, [payload.to_pack_list()], False)
+            packet = self._ez_pack(self._prefix, payload.msg_id, [payload], False)
             self.send_packet(target_addr, packet)
 
     @unpack_cell(PeersResponsePayload)

--- a/ipv8/messaging/anonymization/payload.py
+++ b/ipv8/messaging/anonymization/payload.py
@@ -9,7 +9,7 @@ from ...messaging.anonymization.tunnel import (CIRCUIT_TYPE_RP_DOWNLOADER, CIRCU
 from ...messaging.anonymization.tunnelcrypto import CryptoException
 from ...messaging.lazy_payload import VariablePayload, vp_compile
 from ...messaging.payload import Payload
-from ...util import cast_to_bin, cast_to_chr
+from ...util import cast_to_chr
 
 ADDRESS_TYPE_IPV4 = 0x01
 ADDRESS_TYPE_DOMAIN_NAME = 0x02
@@ -178,7 +178,7 @@ class CellPayload(object):
 
     def to_bin(self, prefix):
         return b''.join([prefix,
-                         cast_to_bin(chr(1)),
+                         bytes([1]),
                          pack('!I?', self.circuit_id, self.plaintext) + self.message])
 
     @classmethod

--- a/ipv8/messaging/deprecated/encoding.py
+++ b/ipv8/messaging/deprecated/encoding.py
@@ -2,8 +2,6 @@ import logging
 from json import dumps
 from urllib.parse import ParseResult, parse_qsl, unquote, urlencode, urlparse
 
-from ...util import cast_to_bin
-
 logger = logging.getLogger(__name__)
 
 
@@ -47,8 +45,8 @@ def _a_encode_bytes(value, mapping):
     """
     'foo-bar' --> ('7', 'b', 'foo-bar')
     """
-    assert isinstance(value, (bytes, str)), "VALUE has invalid type: %s" % type(value)
-    return str(len(value)).encode("UTF-8"), b"b", cast_to_bin(value)
+    assert isinstance(value, bytes), "VALUE has invalid type: %s" % type(value)
+    return str(len(value)).encode("UTF-8"), b"b", value
 
 
 def _a_encode_str(value, mapping):

--- a/ipv8/messaging/payload.py
+++ b/ipv8/messaging/payload.py
@@ -27,7 +27,7 @@ class Payload(Serializable):
         out = self.__class__.__name__
         for attribute in dir(self):
             if not (attribute.startswith('_') or callable(getattr(self, attribute))) \
-                    and attribute not in ['format_list', 'names', 'optional_format_list']:
+                    and attribute not in ['format_list', 'names']:
                 out += '\n| %s: %s' % (attribute, repr(getattr(self, attribute)))
         return out
 

--- a/ipv8/messaging/serialization.py
+++ b/ipv8/messaging/serialization.py
@@ -1,7 +1,6 @@
 import abc
-import itertools
 from binascii import hexlify
-from struct import Struct, pack, unpack, unpack_from
+from struct import Struct, pack, unpack_from
 
 
 class PackError(RuntimeError):
@@ -48,15 +47,14 @@ class NestedPayload(object):
 
         :param serializable: the Serializable instance which we should serialize.
         :type serializable: Serializable
-        :return: the serialized data and its size
-        :rtype: (str, int)
+        :return: the serialized data
+        :rtype: bytes
         """
-        data, size = self.serializer.pack_multiple(serializable.to_pack_list())
-        # We don't care about the inner size of the Serializable, we already have the outer size.
-        data, size = self.serializer.pack('varlenH', data)[0], size + 2
-        return data, size
+        data = self.serializer.pack_serializable(serializable)
+        data = pack('>H', len(data)) + data
+        return data
 
-    def unpack_from(self, serializable_class, data, offset):
+    def unpack(self, serializable_class, data, offset, unpack_list):
         """
         Unpack a Serializable using a class definition for some given data and offset.
         This is a special unpack_from which also takes a payload class.
@@ -67,42 +65,43 @@ class NestedPayload(object):
         :type data: str
         :param offset: the offset in the list of data to unpack from
         :type offset: int
-        :return: the output Serializable instance and the new offset delta
-        :rtype: (Serializable, int)
+        :param unpack_list: the list to which to append the Serializable
+        :type unpack_list: list
+        :return: the new offset
+        :rtype: int
         """
-        raw, size = self.serializer.unpack('varlenH', data, offset)
-        unpacked = self.serializer.ez_unpack_serializables([serializable_class], raw)
-        # We only ever have 1 serializable, only return item 0.
-        return unpacked[0], size
+        unpacked, offset = self.serializer.unpack_serializable(serializable_class, data, offset=offset + 2)
+        unpack_list.append(unpacked)
+        return offset
 
 
 class Bits(object):
 
-    def pack(self, bit_7=0, bit_6=0, bit_5=0, bit_4=0, bit_3=0, bit_2=0, bit_1=0, bit_0=0):
+    def pack(self, *data):
         """
         Pack multiple bits into a single byte.
 
-        :param bit_*: bit at position *
-        :type bit_*: True or False (or anything that maps to it in an if-statement)
+        :param *data: bit values
+        :type *data: list of 8 True or False values (or anything that maps to it in an if-statement)
         """
         byte = 0
-        byte |= 0x80 if bit_7 else 0x00
-        byte |= 0x40 if bit_6 else 0x00
-        byte |= 0x20 if bit_5 else 0x00
-        byte |= 0x10 if bit_4 else 0x00
-        byte |= 0x08 if bit_3 else 0x00
-        byte |= 0x04 if bit_2 else 0x00
-        byte |= 0x02 if bit_1 else 0x00
-        byte |= 0x01 if bit_0 else 0x00
-        return pack('>B', byte), 1
+        byte |= 0x80 if data[7] else 0x00
+        byte |= 0x40 if data[6] else 0x00
+        byte |= 0x20 if data[5] else 0x00
+        byte |= 0x10 if data[4] else 0x00
+        byte |= 0x08 if data[3] else 0x00
+        byte |= 0x04 if data[2] else 0x00
+        byte |= 0x02 if data[1] else 0x00
+        byte |= 0x01 if data[0] else 0x00
+        return pack('>B', byte)
 
-    def unpack_from(self, data, offset):
+    def unpack(self, data, offset, unpack_list):
         """
-        Unpack multiple bits from a single byte.
+        Unpack multiple bits from a single byte. The resulting bits are appended to unpack_list
 
-        :returns: list of 8 values in [0, 1] MSB first
+        :returns: the new offset
         """
-        byte, = unpack('>B', data[offset:offset + 1])
+        byte, = unpack_from('>B', data, offset)
         bit_7 = 1 if 0x80 & byte else 0
         bit_6 = 1 if 0x40 & byte else 0
         bit_5 = 1 if 0x20 & byte else 0
@@ -111,7 +110,8 @@ class Bits(object):
         bit_2 = 1 if 0x04 & byte else 0
         bit_1 = 1 if 0x02 & byte else 0
         bit_0 = 1 if 0x01 & byte else 0
-        return [bit_7, bit_6, bit_5, bit_4, bit_3, bit_2, bit_1, bit_0], 1
+        unpack_list += [bit_7, bit_6, bit_5, bit_4, bit_3, bit_2, bit_1, bit_0]
+        return offset + 1
 
 
 class Raw(object):
@@ -119,17 +119,12 @@ class Raw(object):
     Paste/unpack the remaining input without (un)packing.
     """
 
-    def pack(self, *data):
-        out = b''
-        size = 0
-        for piece in data:
-            out += piece
-            size += len(piece)
-        return out, size
+    def pack(self, packable):
+        return packable
 
-    def unpack_from(self, data, offset=0):
-        out = data[offset:]
-        return out, len(out)
+    def unpack(self, data, offset, unpack_list):
+        unpack_list.append(data[offset:])
+        return len(data)
 
 
 class VarLen(object):
@@ -137,40 +132,33 @@ class VarLen(object):
     Paste/unpack from an encoded length + data string.
     """
 
-    def __init__(self, format, base=1):
-        super(VarLen, self).__init__()
-        self.format = format
-        self.format_size = Struct(self.format).size
+    def __init__(self, length_format, base=1):
+        self.length_format = length_format
+        self.length_size = Struct(length_format).size
         self.base = base
 
-    def pack(self, *data):
-        raw = b''.join(data)
-        length = len(raw) // self.base
-        size = self.format_size + len(raw)
-        return pack('>%s%ds' % (self.format, len(raw)), length, raw), size
+    def pack(self, data):
+        return pack(self.length_format, len(data) // self.base) + data
 
-    def unpack_from(self, data, offset=0):
-        length, = unpack_from('>%s' % self.format, data, offset)
-        length *= self.base
-        out, = unpack_from('>%ds' % length, data, offset + self.format_size)
-        return out, self.format_size + length
+    def unpack(self, data, offset, unpack_list):
+        str_length = unpack_from(self.length_format, data, offset)[0] * self.base
+        unpack_list.append(data[offset + self.length_size: offset + self.length_size + str_length])
+        return offset + self.length_size + str_length
 
 
-class DefaultStruct(Struct):
+class DefaultStruct:
 
-    def __init__(self, format, single_value=False):
-        super(DefaultStruct, self).__init__(format)
-        self.single_value = single_value
+    def __init__(self, format_str):
+        self.format_str = format_str
+        self.size = Struct(format_str).size
 
     def pack(self, *data):
-        return super(DefaultStruct, self).pack(*data), self.size
+        return pack(self.format_str, *data)
 
-    def unpack_from(self, buffer, offset=0):
-        out = super(DefaultStruct, self).unpack_from(buffer, offset)
-        if self.single_value:
-            return out[0], self.size
-        else:
-            return list(out), self.size
+    def unpack(self, data, offset, unpack_list):
+        result = unpack_from(self.format_str, data, offset)
+        unpack_list.append(result if len(result) > 1 else result[0])
+        return offset + self.size
 
 
 class Serializer(object):
@@ -178,36 +166,36 @@ class Serializer(object):
     def __init__(self):
         super(Serializer, self).__init__()
         self._packers = {
-            '?': DefaultStruct(">?", True),
-            'B': DefaultStruct(">B", True),
+            '?': DefaultStruct(">?"),
+            'B': DefaultStruct(">B"),
             'BBH': DefaultStruct(">BBH"),
             'BH': DefaultStruct(">BH"),
-            'c': DefaultStruct(">c", True),
-            'f': DefaultStruct(">f", True),
-            'd': DefaultStruct(">d", True),
-            'H': DefaultStruct(">H", True),
+            'c': DefaultStruct(">c"),
+            'f': DefaultStruct(">f"),
+            'd': DefaultStruct(">d"),
+            'H': DefaultStruct(">H"),
             'HH': DefaultStruct(">HH"),
-            'I': DefaultStruct(">I", True),
-            'l': DefaultStruct(">l", True),
+            'I': DefaultStruct(">I"),
+            'l': DefaultStruct(">l"),
             'LL': DefaultStruct(">LL"),
-            'Q': DefaultStruct(">Q", True),
+            'Q': DefaultStruct(">Q"),
             'QH': DefaultStruct(">QH"),
             'QL': DefaultStruct(">QL"),
             'QQHHBH': DefaultStruct(">QQHHBH"),
             'ccB': DefaultStruct(">ccB"),
             '4SH': DefaultStruct(">4sH"),
-            '20s': DefaultStruct(">20s", True),
-            '32s': DefaultStruct(">32s", True),
-            '64s': DefaultStruct(">64s", True),
-            '74s': DefaultStruct(">74s", True),
+            '20s': DefaultStruct(">20s"),
+            '32s': DefaultStruct(">32s"),
+            '64s': DefaultStruct(">64s"),
+            '74s': DefaultStruct(">74s"),
             'c20s': DefaultStruct(">c20s"),
             'bits': Bits(),
             'raw': Raw(),
-            'varlenBx2': VarLen('B', 2),
-            'varlenH': VarLen('H'),
-            'varlenHx20': VarLen('H', 20),
-            'varlenI': VarLen('I'),
-            'doublevarlenH': VarLen('H'),
+            'varlenBx2': VarLen('>B', 2),
+            'varlenH': VarLen('>H'),
+            'varlenHx20': VarLen('>H', 20),
+            'varlenI': VarLen('>I'),
+            'doublevarlenH': VarLen('>H'),
             'payload': NestedPayload(self)
         }
 
@@ -232,138 +220,86 @@ class Serializer(object):
         """
         self._packers.update({name: DefaultStruct(format)})
 
-    def pack(self, format, *data):
+    def pack_serializable(self, serializable):
         """
-        Pack some data according to some format name.
+        Serialize a single Serializable instance.
 
-        :param format: the format name to use
-        :param data: the data to serialize
-        :returns: (packed, size)
+        :param serializable: the Serializable to pack
+        :type serializable: Serializable
+        :return: the serialized object
+        :rtype: bytes
         """
-        return self._packers[format].pack(*data)
-
-    def pack_multiple(self, pack_list):
-        """
-        Serialize multiple data tuples.
-
-        Each of the tuples in the pack_list are built as (format, arg1, arg2, .., argn)
-
-        :param pack_list: the list of packable tuples
-        :returns: (packed, size)
-        """
-        out = b""
-        index = 0
-        size = 0
-        for packable in pack_list:
+        packed = b''
+        for packable in serializable.to_pack_list():
             try:
-                packed, packed_size = self.pack(*packable)
-                out += packed
-                size += packed_size
+                packed += self._packers[packable[0]].pack(*packable[1:])
             except Exception as e:
-                raise PackError("Could not pack item %d: %s\n%s: %s" % (index, repr(packable),
-                                                                        type(e).__name__, str(e))) from e
-            index += 1
-        return out, size
+                raise PackError("Could not pack item: %s\n%s: %s" % (packable, type(e).__name__, str(e))) from e
+        return packed
 
-    def ez_pack_serializables(self, serializables):
+    def pack_serializable_list(self, serializables):
         """
         Serialize a list of Serializable instances.
 
         :param serializables: the Serializables to pack
         :type serializables: [Serializable]
         :return: the serialized list
-        :rtype: bytes or str
+        :rtype: bytes
         """
-        out, _ = self.pack_multiple(list(itertools.chain.from_iterable(serializable.to_pack_list()
-                                                                       for serializable in serializables)))
-        return out
+        return b''.join(self.pack_serializable(serializable) for serializable in serializables)
 
-    def unpack(self, format, data, offset=0):
+    def unpack_serializable(self, serializable, data, offset=0):
         """
-        Use a certain named format to unpack from some data.
+        Use the formats specified in a serializable object and unpack to it.
 
-        :param format: the format name to unpack with
+        :param serializable: the serializable classes to get the format from and unpack to
         :param data: the data to unpack from
         :param offset: the optional offset to unpack data from
         """
-        if format not in self._packers and issubclass(format, Serializable):
-            return NestedPayload(self).unpack_from(format, data, offset)
-        return self._packers[format].unpack_from(data, offset)
-
-    def unpack_multiple(self, unpack_list, data, optional_list=[], offset=0):
-        """
-        Unpack multiple variables from a data string.
-
-        Each of the tuples in the unpack_list are built as (format, arg1, arg2, .., argn)
-
-        :param unpack_list: the list of formats
-        :param data: the data to unpack from
-        :param optional_list: the list of optional parameters for this formatting
-        :param offset: the optional offset to unpack data from
-        """
-        current_offset = offset
-        out = []
         index = 0
-        required_length = len(unpack_list)
+        required_length = len(serializable.format_list)
         data_length = len(data)
-        for format in unpack_list + optional_list:
-            if index >= required_length and current_offset >= data_length:
+        unpack_list = []
+        for fmt in serializable.format_list + serializable.optional_format_list:
+            if index >= required_length and offset >= data_length:
                 # We can perform a clean break if we are in the optional set
                 break
-            try:
-                unpacked, unpacked_size = self.unpack(format, data, current_offset)
-                if format == 'bits':
-                    out.extend(unpacked)
-                else:
-                    out.append(unpacked)
-            except Exception as e:
-                raise PackError("Could not pack item %d: %s\n%s: %s" % (index, format,
-                                                                        type(e).__name__, str(e))) from e
-            current_offset += unpacked_size
             index += 1
-        return out, current_offset
-
-    def unpack_to_serializables(self, serializables, data):
-        """
-        Use the formats specified in a serializable object and unpack to it.
-
-        :param serializables: the serializable classes to get the format from and unpack to
-        :param data: the data to unpack from
-        :except PackError: if the data could not be fit into the specified serializables
-        :return: the list of Serializable instances, with the list of remaining data as the last element
-        :rtype: [Serializable] + [bytes or str]
-        """
-        offset = 0
-        out = []
-        for serializable in serializables:
             try:
-                unpack_list, offset = self.unpack_multiple(serializable.format_list, data,
-                                                           serializable.optional_format_list, offset)
+                offset = self._packers[fmt].unpack(data, offset, unpack_list)
+            except KeyError:
+                if not issubclass(fmt, Serializable):
+                    raise
+                offset = self._packers['payload'].unpack(fmt, data, offset, unpack_list)
             except Exception as e:
-                raise PackError("Failed to unserialize %s\n%s: %s" % (serializable.__name__,
-                                                                      type(e).__name__, str(e))) from e
-            out.append(serializable.from_unpack_list(*unpack_list))
-        out.append(data[offset:])
-        return out
+                raise PackError("Could not unpack item: %s\n%s: %s" % (fmt, type(e).__name__, str(e))) from e
+        return serializable.from_unpack_list(*unpack_list), offset
 
-    def ez_unpack_serializables(self, serializables, data):
+    def unpack_serializable_list(self, serializables, data, offset=0, consume_all=True):
         """
-        Use the formats specified in a serializable object and unpack to it.
+        Use the formats specified in a list of serializable objects and unpack to them.
 
         :param serializables: the serializable classes to get the format from and unpack to
         :param data: the data to unpack from
+        :param offset: position at which to start reading from data
+        :param consume_all: if having a non-empty remainder should throw an error
         :except PackError: if the data could not be fit into the specified serializables
-        :except PackError: if not all of the data was consumed when parsing the serializables
+        :except PackError: if consume_all is True and not all of the data was consumed when parsing the serializables
         :return: the list of Serializable instances
         :rtype: [Serializable]
         """
-        unpacked = self.unpack_to_serializables(serializables, data)
-        unknown_data = unpacked.pop()
-        if unknown_data:
+        unpacked = []
+        for serializable in serializables:
+            payload, offset = self.unpack_serializable(serializable, data, offset)
+            unpacked.append(payload)
+        remainder = data[offset:]
+        if not consume_all:
+            unpacked.append(remainder)
+        elif remainder:
             raise PackError("Incoming packet %s (%s) has extra data: (%s)" %
                             (str([serializable_class.__name__ for serializable_class in serializables]),
                              hexlify(data),
-                             hexlify(unknown_data)))
+                             hexlify(remainder)))
         return unpacked
 
 

--- a/ipv8/messaging/serialization.py
+++ b/ipv8/messaging/serialization.py
@@ -256,15 +256,8 @@ class Serializer(object):
         :param data: the data to unpack from
         :param offset: the optional offset to unpack data from
         """
-        index = 0
-        required_length = len(serializable.format_list)
-        data_length = len(data)
         unpack_list = []
-        for fmt in serializable.format_list + serializable.optional_format_list:
-            if index >= required_length and offset >= data_length:
-                # We can perform a clean break if we are in the optional set
-                break
-            index += 1
+        for fmt in serializable.format_list:
             try:
                 offset = self._packers[fmt].unpack(data, offset, unpack_list)
             except KeyError:
@@ -309,7 +302,6 @@ class Serializable(metaclass=abc.ABCMeta):
     """
 
     format_list = []
-    optional_format_list = []
 
     @abc.abstractmethod
     def to_pack_list(self):

--- a/ipv8/peerdiscovery/community.py
+++ b/ipv8/peerdiscovery/community.py
@@ -13,7 +13,6 @@ from ..messaging.payload_headers import BinMemberAuthenticationPayload, GlobalTi
 from ..messaging.serialization import PackError
 from ..peer import Peer
 from ..requestcache import NumberCache, RequestCache
-from ..util import cast_to_bin
 
 
 class PeriodicSimilarity(DiscoveryStrategy):
@@ -147,7 +146,7 @@ class DiscoveryCommunity(Community):
                 if overlay.my_peer == peer]
 
     def custom_pack(self, peer, msg_num, payloads):
-        packet = self._prefix + cast_to_bin(chr(msg_num))
+        packet = self._prefix + bytes([msg_num])
         packet += self.serializer.pack_serializable_list(payloads)
         packet += default_eccrypto.create_signature(peer.key, packet)
         return packet

--- a/ipv8/peerdiscovery/community.py
+++ b/ipv8/peerdiscovery/community.py
@@ -146,10 +146,9 @@ class DiscoveryCommunity(Community):
         return [service_id for service_id, overlay in self.network.service_overlays.items()
                 if overlay.my_peer == peer]
 
-    def custom_pack(self, peer, msg_num, format_list_list):
+    def custom_pack(self, peer, msg_num, payloads):
         packet = self._prefix + cast_to_bin(chr(msg_num))
-        for format_list in format_list_list:
-            packet += self.serializer.pack_multiple(format_list)[0]
+        packet += self.serializer.pack_serializable_list(payloads)
         packet += default_eccrypto.create_signature(peer.key, packet)
         return packet
 
@@ -159,24 +158,24 @@ class DiscoveryCommunity(Community):
                                            self.my_estimated_lan,
                                            self.my_estimated_wan,
                                            u"unknown",
-                                           self.get_my_overlays(peer)).to_pack_list()
-        auth = BinMemberAuthenticationPayload(peer.public_key.key_to_bin()).to_pack_list()
-        dist = GlobalTimeDistributionPayload(global_time).to_pack_list()
+                                           self.get_my_overlays(peer))
+        auth = BinMemberAuthenticationPayload(peer.public_key.key_to_bin())
+        dist = GlobalTimeDistributionPayload(global_time)
 
         return self.custom_pack(peer, 1, [auth, dist, payload])
 
     def create_similarity_response(self, identifier, peer):
         global_time = self.claim_global_time()
-        payload = SimilarityResponsePayload(identifier, self.get_my_overlays(peer), []).to_pack_list()
-        auth = BinMemberAuthenticationPayload(peer.public_key.key_to_bin()).to_pack_list()
-        dist = GlobalTimeDistributionPayload(global_time).to_pack_list()
+        payload = SimilarityResponsePayload(identifier, self.get_my_overlays(peer), [])
+        auth = BinMemberAuthenticationPayload(peer.public_key.key_to_bin())
+        dist = GlobalTimeDistributionPayload(global_time)
 
         return self.custom_pack(peer, 2, [auth, dist, payload])
 
     def send_ping(self, peer):
         global_time = self.claim_global_time()
-        payload = PingPayload(global_time).to_pack_list()
-        dist = GlobalTimeDistributionPayload(global_time).to_pack_list()
+        payload = PingPayload(global_time)
+        dist = GlobalTimeDistributionPayload(global_time)
 
         packet = self._ez_pack(self._prefix, 3, [dist, payload], False)
         self.request_cache.add(PingRequestCache(self.request_cache, global_time, peer, time()))
@@ -184,6 +183,6 @@ class DiscoveryCommunity(Community):
 
     def create_pong(self, identifier):
         global_time = self.claim_global_time()
-        payload = PongPayload(identifier).to_pack_list()
-        dist = GlobalTimeDistributionPayload(global_time).to_pack_list()
+        payload = PongPayload(identifier)
+        dist = GlobalTimeDistributionPayload(global_time)
         return self._ez_pack(self._prefix, 4, [dist, payload], False)

--- a/ipv8/test/dht/test_community.py
+++ b/ipv8/test/dht/test_community.py
@@ -166,8 +166,8 @@ class TestDHTCommunity(TestBase):
         dht_provider_1 = DHTCommunityProvider(self.nodes[0].overlay, 1337)
         dht_provider_2 = DHTCommunityProvider(self.nodes[1].overlay, 1338)
         dht_provider_3 = DHTCommunityProvider(self.nodes[2].overlay, 1338)
-        await dht_provider_1.announce(b'a' * 20, IntroductionPoint(self.nodes[0].overlay.my_peer, '\x01' * 20))
-        await dht_provider_2.announce(b'a' * 20, IntroductionPoint(self.nodes[1].overlay.my_peer, '\x02' * 20))
+        await dht_provider_1.announce(b'a' * 20, IntroductionPoint(self.nodes[0].overlay.my_peer, b'\x01' * 20))
+        await dht_provider_2.announce(b'a' * 20, IntroductionPoint(self.nodes[1].overlay.my_peer, b'\x02' * 20))
 
         await self.deliver_messages(.5)
 

--- a/ipv8/test/keyvault/test_signature.py
+++ b/ipv8/test/keyvault/test_signature.py
@@ -1,6 +1,5 @@
 from ..base import TestBase
 from ...keyvault.crypto import default_eccrypto
-from ...util import cast_to_bin
 
 
 class TestSignatures(TestBase):
@@ -11,7 +10,7 @@ class TestSignatures(TestBase):
     def setUp(self):
         super(TestSignatures, self).setUp()
         self.ec = default_eccrypto
-        self.data = cast_to_bin("".join([chr(i) for i in range(256)]))
+        self.data = bytes(range(256))
 
     def test_vlow(self):
         """

--- a/ipv8/test/messaging/anonymization/test_community.py
+++ b/ipv8/test/messaging/anonymization/test_community.py
@@ -11,7 +11,7 @@ from ....messaging.anonymization.endpoint import TunnelEndpoint
 from ....messaging.anonymization.tunnel import (CIRCUIT_STATE_EXTENDING, PEER_FLAG_EXIT_BT,
                                                 PEER_FLAG_EXIT_IPV8, PEER_FLAG_SPEED_TEST)
 from ....messaging.interfaces.udp.endpoint import UDPEndpoint
-from ....util import cast_to_bin, succeed
+from ....util import succeed
 
 # Map of info_hash -> peer list
 global_dht_services = defaultdict(list)
@@ -240,7 +240,7 @@ class TestTunnelCommunity(TestBase):
 
         # Construct a data packet
         prefix = b'\x00' * 23
-        data = prefix + cast_to_bin(''.join([chr(i) for i in range(256)]))
+        data = prefix + bytes(range(256))
 
         self.public_endpoint.assert_open()
 

--- a/ipv8/test/messaging/test_lazy_payload.py
+++ b/ipv8/test/messaging/test_lazy_payload.py
@@ -22,8 +22,7 @@ class B(VariablePayload):
     A VariablePayload with a nested Payload.
     """
     format_list = [A]
-    optional_format_list = ['Q']
-    names = ["a", "o"]
+    names = ["a"]
 
 
 @vp_compile
@@ -167,19 +166,6 @@ class TestVariablePayload(TestBase):
         self.assertEqual(a.b, 1337)
         self.assertEqual(deserialized.a, 42)
         self.assertEqual(deserialized.b, 1337)
-
-    def test_optional_format_list(self):
-        """
-        Check if the wrapper allows for nested payloads.
-        """
-        a = A(1, 2)
-        b = B(a, 3)
-
-        deserialized = self._pack_and_unpack(B, b)
-
-        self.assertEqual(b.a.a, deserialized.a.a)
-        self.assertEqual(b.a.b, deserialized.a.b)
-        self.assertEqual(b.o, deserialized.o)
 
     def test_inheritance(self):
         """

--- a/ipv8/test/messaging/test_lazy_payload.py
+++ b/ipv8/test/messaging/test_lazy_payload.py
@@ -112,9 +112,8 @@ class TestVariablePayload(TestBase):
         :type instance: Payload
         :return: the repacked instance
         """
-        plist = instance.to_pack_list()
-        serialized, _ = default_serializer.pack_multiple(plist)
-        deserialized, _ = default_serializer.unpack_to_serializables([payload], serialized)  # pylint: disable=E0632
+        serialized = default_serializer.pack_serializable(instance)
+        deserialized, _ = default_serializer.unpack_serializable(payload, serialized)  # pylint: disable=E0632
         return deserialized
 
     def test_base_unnamed(self):
@@ -168,6 +167,19 @@ class TestVariablePayload(TestBase):
         self.assertEqual(a.b, 1337)
         self.assertEqual(deserialized.a, 42)
         self.assertEqual(deserialized.b, 1337)
+
+    def test_optional_format_list(self):
+        """
+        Check if the wrapper allows for nested payloads.
+        """
+        a = A(1, 2)
+        b = B(a, 3)
+
+        deserialized = self._pack_and_unpack(B, b)
+
+        self.assertEqual(b.a.a, deserialized.a.a)
+        self.assertEqual(b.a.b, deserialized.a.b)
+        self.assertEqual(b.o, deserialized.o)
 
     def test_inheritance(self):
         """
@@ -287,7 +299,7 @@ class TestVariablePayload(TestBase):
         """
         d = D(0)
 
-        serialized, _ = default_serializer.pack_multiple(d.to_pack_list())
+        serialized = default_serializer.pack_serializable(d)
         deserialized = self._pack_and_unpack(D, d)
 
         self.assertEqual(d.a, 0)
@@ -300,7 +312,7 @@ class TestVariablePayload(TestBase):
         """
         d = CompiledD(0)
 
-        serialized, _ = default_serializer.pack_multiple(d.to_pack_list())
+        serialized = default_serializer.pack_serializable(d)
         deserialized = self._pack_and_unpack(CompiledD, d)
 
         self.assertEqual(d.a, 0)

--- a/ipv8/test/messaging/test_serialization.py
+++ b/ipv8/test/messaging/test_serialization.py
@@ -4,7 +4,7 @@ from ..base import TestBase
 from ...messaging.serialization import PackError, Serializable, Serializer
 
 
-class TestSerializable(Serializable):
+class Short(Serializable):
     format_list = ["H"]
 
     def __init__(self, number):
@@ -15,7 +15,21 @@ class TestSerializable(Serializable):
 
     @classmethod
     def from_unpack_list(cls, *args):
-        return TestSerializable(*args)
+        return Short(*args)
+
+
+class Byte(Serializable):
+    format_list = ["B"]
+
+    def __init__(self, byte):
+        self.byte = byte
+
+    def to_pack_list(self):
+        return [("B", self.byte)]
+
+    @classmethod
+    def from_unpack_list(cls, *args):
+        return Byte(*args)
 
 
 class TestSerializer(TestBase):
@@ -24,108 +38,64 @@ class TestSerializer(TestBase):
         super(TestSerializer, self).setUp()
         self.serializer = Serializer()
 
+    def check_pack_unpack(self, format_ser, format_unser, value):
+        packer = self.serializer.get_packer_for(format_ser)
+        values = (value,) if not isinstance(value, (list, tuple)) else value
+        serialized = packer.pack(*values)
+
+        unpack_list = []
+        packer = self.serializer.get_packer_for(format_unser)
+        packer.unpack(serialized, 0, unpack_list)
+
+        self.assertEqual(value, unpack_list[0])
+
     def test_pack_bool_true(self):
         """
         Check if 'true' booleans can be correctly packed and unpacked.
         """
-        value = True
-
-        serialized, _ = self.serializer.pack("?", value)
-        unserialized, _ = self.serializer.unpack("?", serialized)
-
-        self.assertEqual(value, unserialized)
+        self.check_pack_unpack('?', '?', True)
 
     def test_pack_bool_false(self):
         """
         Check if 'false' booleans can be correctly packed and unpacked.
         """
-        value = False
-
-        serialized, _ = self.serializer.pack("?", value)
-        unserialized, _ = self.serializer.unpack("?", serialized)
-
-        self.assertEqual(value, unserialized)
+        self.check_pack_unpack('?', '?', False)
 
     def test_pack_byte_0(self):
         """
         Check if a 0 (unsigned byte) can be correctly packed and unpacked.
         """
-        value = 0
-
-        serialized, _ = self.serializer.pack("B", value)
-        unserialized, _ = self.serializer.unpack("B", serialized)
-
-        self.assertEqual(value, unserialized)
+        self.check_pack_unpack('B', 'B', 0)
 
     def test_pack_byte_1(self):
         """
         Check if a 1 (unsigned byte) can be correctly packed and unpacked.
         """
-        value = 1
-
-        serialized, _ = self.serializer.pack("B", value)
-        unserialized, _ = self.serializer.unpack("B", serialized)
-
-        self.assertEqual(value, unserialized)
+        self.check_pack_unpack('B', 'B', 1)
 
     def test_pack_byte_255(self):
         """
         Check if a 255 (unsigned byte) can be correctly packed and unpacked.
         """
-        value = 255
-
-        serialized, _ = self.serializer.pack("B", value)
-        unserialized, _ = self.serializer.unpack("B", serialized)
-
-        self.assertEqual(value, unserialized)
+        self.check_pack_unpack('B', 'B', 255)
 
     def test_pack_byte_256(self):
         """
         Check if a 256 (unsigned byte) throws a struct.error.
         """
-        self.assertRaises(struct.error, self.serializer.pack, "B", 256)
+        self.assertRaises(struct.error, self.check_pack_unpack, 'B', 'B', 256)
 
     def test_unpack_short_truncated(self):
         """
         Check if 1 byte string cannot be unpacked as a short.
         """
-        serialized, _ = self.serializer.pack("B", 255)
-
-        self.assertRaises(struct.error, self.serializer.unpack, "H", serialized)
+        self.assertRaises(struct.error, self.check_pack_unpack, 'B', 'H', 255)
 
     def test_pack_list(self):
         """
         Check if a list of shorts is correctly packed and unpacked.
         """
-        value0 = 0
-        value1 = 1337
-
-        serialized, _ = self.serializer.pack("HH", value0, value1)
-        unserialized, _ = self.serializer.unpack("HH", serialized)
-
-        self.assertListEqual([value0, value1], unserialized)
-
-    def test_pack_multiple_byte_256(self):
-        """
-        Check if pack_multiple of a 256 (unsigned byte) raises a PackError.
-        """
-        self.assertRaises(PackError, self.serializer.pack_multiple, [("B", 256)])
-
-    def test_unpack_multiple_short_from_byte(self):
-        """
-        Check if a unpack_multiple of a short from a byte raises a PackError.
-        """
-        serialized, _ = self.serializer.pack_multiple([("B", 1)])
-
-        self.assertRaises(PackError, self.serializer.unpack_multiple, ["H"], serialized)
-
-    def test_unpack_serializables_list_short_from_byte(self):
-        """
-        Check if a unpack_to_serializables of a short from a byte raises a PackError.
-        """
-        serialized, _ = self.serializer.pack_multiple([("B", 1)])
-
-        self.assertRaises(PackError, self.serializer.unpack_to_serializables, [TestSerializable], serialized)
+        self.check_pack_unpack('HH', 'HH', (0, 1337))
 
     def test_get_formats(self):
         """
@@ -138,56 +108,68 @@ class TestSerializer(TestBase):
             pack_name = "%s(%s)" % (packer.__class__.__name__, format)
             self.assertTrue(hasattr(packer, 'pack'), msg='%s has no pack() method' % pack_name)
             self.assertTrue(callable(getattr(packer, 'pack')), msg='%s.pack is not a method' % pack_name)
-            self.assertTrue(hasattr(packer, 'unpack_from'), msg='%s has no unpack_from() method' % pack_name)
-            self.assertTrue(callable(getattr(packer, 'unpack_from')), msg='%s.unpack_from is not a method' % pack_name)
+            self.assertTrue(hasattr(packer, 'unpack'), msg='%s has no unpack() method' % pack_name)
+            self.assertTrue(callable(getattr(packer, 'unpack')), msg='%s.unpack is not a method' % pack_name)
 
     def test_add_format(self):
         """
         Check if we can add a format on the fly.
         """
-        self.serializer.add_packing_format("my_cool_format", "<H")  # little-endian
+        self.serializer.add_packing_format("H_LE", "<H")  # little-endian
 
-        serialized, _ = self.serializer.pack("my_cool_format", 1)  # Packed as 01 00
-        [unserialized], _ = self.serializer.unpack("my_cool_format", serialized)  # little-endian, unpacked as 00 01 = 1
-        unpack_other_end, _ = self.serializer.unpack("H", serialized)  # big-endian, unpacked as 01 00 = 256
+        serialized = self.serializer.get_packer_for("H_LE").pack(1)  # Packed as 01 00
 
-        self.assertEqual(1, unserialized)
-        self.assertEqual(256, unpack_other_end)
+        unpacked = []
+        self.serializer.get_packer_for("H_LE").unpack(serialized, 0, unpacked)  # little-endian, unpacked as 00 01 = 1
+        self.serializer.get_packer_for("H").unpack(serialized, 0, unpacked)  # big-endian, unpacked as 01 00 = 256
+
+        self.assertEqual([1, 256], unpacked)
 
     def test_nested_serializable(self):
         """
         Check if we can unpack nested serializables.
         """
-        instance = TestSerializable(123)
+        instance = Short(123)
 
-        data, _ = self.serializer.pack('payload', instance)
-        output, _ = self.serializer.unpack(TestSerializable, data, 0)
+        data = self.serializer.pack_serializable(instance)
+        output, _ = self.serializer.unpack_serializable(Short, data)
 
         self.assertEqual(instance.number, output.number)
 
-    def test_ez_pack_serializables(self):
+    def test_serializable_byte_256(self):
+        """
+        Check if pack_serializable of a 256 (unsigned byte) raises a PackError.
+        """
+        self.assertRaises(PackError, self.serializer.pack_serializable, Byte(256))
+
+    def test_serializable_short_from_byte(self):
+        """
+        Check if a unpack_serializable of a short from a byte raises a PackError.
+        """
+        serialized = self.serializer.pack_serializable(Byte(1))
+        self.assertRaises(PackError, self.serializer.unpack_serializable, Short, serialized)
+
+    def test_serializable_list(self):
         """
         Check if we can (un)pack serializables easily.
         """
-        instance1 = TestSerializable(123)
-        instance2 = TestSerializable(456)
+        instance1 = Short(123)
+        instance2 = Short(456)
 
-        data = self.serializer.ez_pack_serializables([instance1, instance2])
-        deserialized1, deserialized2 = self.serializer.ez_unpack_serializables([TestSerializable, TestSerializable],
-                                                                               data)
+        data = self.serializer.pack_serializable_list([instance1, instance2])
+        deserialized = self.serializer.unpack_serializable_list([Short, Short], data)
 
         self.assertEqual(instance1.number, 123)
-        self.assertEqual(instance1.number, deserialized1.number)
+        self.assertEqual(instance1.number, deserialized[0].number)
         self.assertEqual(instance2.number, 456)
-        self.assertEqual(instance2.number, deserialized2.number)
+        self.assertEqual(instance2.number, deserialized[1].number)
 
-    def test_ez_unpack_serializables_extra_data(self):
+    def test_serializable_list_extra_data(self):
         """
         Check if we throw an error when we have too much data to unpack.
         """
-        instance1 = TestSerializable(123)
-        instance2 = TestSerializable(456)
+        instance1 = Short(123)
+        instance2 = Short(456)
 
-        data = self.serializer.ez_pack_serializables([instance1, instance2])
-        self.assertRaises(PackError, self.serializer.ez_unpack_serializables, [TestSerializable, TestSerializable],
-                          data + b"Nope.avi")
+        data = self.serializer.pack_serializable_list([instance1, instance2])
+        self.assertRaises(PackError, self.serializer.unpack_serializable_list, [Short, Short], data + b"Nope.avi")

--- a/ipv8/test/peerdiscovery/test_community.py
+++ b/ipv8/test/peerdiscovery/test_community.py
@@ -41,9 +41,9 @@ class TestDiscoveryCommunity(TestBase):
                                                       True,
                                                       u"unknown",
                                                       global_time,
-                                                      b'').to_pack_list()
-        auth = BinMemberAuthenticationPayload(self.overlays[0].my_peer.public_key.key_to_bin()).to_pack_list()
-        dist = GlobalTimeDistributionPayload(global_time).to_pack_list()
+                                                      b'')
+        auth = BinMemberAuthenticationPayload(self.overlays[0].my_peer.public_key.key_to_bin())
+        dist = GlobalTimeDistributionPayload(global_time)
 
         packet = self.overlays[0]._ez_pack(self.overlays[0]._prefix, 246, [auth, dist, payload])
         self.overlays[1].on_introduction_request(self.overlays[0].endpoint.wan_address, packet)

--- a/ipv8/util.py
+++ b/ipv8/util.py
@@ -18,12 +18,6 @@ def cast_to_unicode(obj):
     return str(obj)
 
 
-def cast_to_bin(obj):
-    if isinstance(obj, bytes):
-        return obj
-    return bytes(ord(c) for c in obj)
-
-
 def cast_to_chr(obj):
     return "".join(chr(c) for c in obj)
 


### PR DESCRIPTION
This PR:
* Updates `Serializer` to make it more efficient
* Updates `EZPackOverlay` so that there is less string slicing and fewer lists are being created
* Renames the (un)packing functions that take a `Serializable` as an argument
* Removes `pack(_multiple)`/`unpack(_multiple)` functions
* Removes `optional_format_list` as its use is limited, and it's hurting unpacking performance. I've intentionally put this in a separate commit, so it's easy to undo in case we decide to keep it.

With the updated serializer, the time spent (un)serializing typically decreases by 20+%.
For instance, for intro-request/responses the decrease varies between 21-38%. Currently:
```
Serializing 1,000,000 intro-request packets: 5.6937067 s
Serializing 1,000,000 intro-response packets: 7.4839985 s
Unserializing 1,000,000 intro-request packets: 7.712827699999998 s
Unserializing 1,000,000 intro-response packets: 9.7632044 s
```

With this PR:
```
Serializing 1,000,000 intro-request packets: 4.4311537 s
Serializing 1,000,000 intro-response packets: 5.894732000000001 s
Unserializing 1,000,000 intro-request packets: 4.850328299999999 s
Unserializing 1,000,000 intro-response packets: 6.008891500000001 s
```