### PR TITLE
Fixed pylintrc regular expression

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -10,7 +10,7 @@
 # Add files or directories to the blacklist. They should be base names, not
 # paths.
 ignore=.git,dispersy,pymdht,libnacl,data
-ignore-patterns=**/doc/**/*.py
+ignore-patterns=^ipv8/doc/.*\.py
 
 # Pickle collected data for later comparisons.
 persistent=yes


### PR DESCRIPTION
Fixes #875

This PR:

 - Fixes `ignore-patterns` expecting a regular expression.

