### PR TITLE
Replaced master_peer with a 20-byte community_id

### DIFF
--- a/doc/basics/overlay_tutorial.rst
+++ b/doc/basics/overlay_tutorial.rst
@@ -106,6 +106,7 @@ To do this, fill your ``main.py`` file with the following code:
 
 .. code-block:: python
 
+    import os
     from asyncio import ensure_future, get_event_loop
 
     from pyipv8.ipv8.community import Community
@@ -116,11 +117,9 @@ To do this, fill your ``main.py`` file with the following code:
 
 
     class MyCommunity(Community):
-       # Register this community with a master peer.
-       # This peer defines the service identifier of this community.
-       # Other peers will connect to this community based on the sha-1
-       # hash of this peer's public key.
-       master_peer = Peer(ECCrypto().generate_key(u"medium"))
+       # Register this community with a randomly generated community ID.
+       # Other peers will connect to this community based on this identifier.
+       community_id = os.urandom(20)
 
 
     async def start_communities():
@@ -157,6 +156,7 @@ We will now modify ``main.py`` again to print the current amount of peers:
 
 .. code-block:: python
 
+    import os
     from asyncio import ensure_future, get_event_loop
 
     from pyipv8.ipv8.community import Community
@@ -167,7 +167,7 @@ We will now modify ``main.py`` again to print the current amount of peers:
 
 
     class MyCommunity(Community):
-       master_peer = Peer(ECCrypto().generate_key(u"medium"))
+       community_id = os.urandom(20)
 
        def started(self):
            async def print_peers():
@@ -213,6 +213,7 @@ Update your ``main.py`` once again to contain the following code:
 
 .. code-block:: python
 
+    import os
     from asyncio import ensure_future, get_event_loop
 
     from pyipv8.ipv8.community import Community
@@ -232,7 +233,7 @@ Update your ``main.py`` once again to contain the following code:
 
 
     class MyCommunity(Community):
-        master_peer = Peer(ECCrypto().generate_key(u"medium"))
+        community_id = os.urandom(20)
 
         def __init__(self, my_peer, endpoint, network):
             super(MyCommunity, self).__init__(my_peer, endpoint, network)

--- a/doc/reference/serialization.rst
+++ b/doc/reference/serialization.rst
@@ -228,14 +228,14 @@ Simply supply the payload classes you wish to unserialize to, to the decorator.
 
 As some internal messages and deprecated messages use some of the message range, you have the messages identifiers from 0 through 234 available for your custom message definitions.
 Once you register the message handler and have the appropriate decorator on the specified handler method your overlay can communicate with the Internet.
-In practice, given a ``MASTER_KEY`` and the payload definitions ``MyMessagePayload1`` and ``MyMessagePayload2``, this will look something like this example (see `the overlay tutorial <../../basics/overlay_tutorial>`_ for a complete runnable example):
+In practice, given a ``COMMUNITY_ID`` and the payload definitions ``MyMessagePayload1`` and ``MyMessagePayload2``, this will look something like this example (see `the overlay tutorial <../../basics/overlay_tutorial>`_ for a complete runnable example):
 
 
 .. code-block:: python
 
     class MyCommunity(Community):
 
-        master_peer = Peer(MASTER_KEY)
+        community_id = COMMUNITY_ID
 
         def __init__(*args, **kwargs):
             super(MyCommunity, self).__init__(*args, **kwargs)

--- a/ipv8/REST/attestation_endpoint.py
+++ b/ipv8/REST/attestation_endpoint.py
@@ -198,7 +198,7 @@ class AttestationEndpoint(BaseEndpoint):
             return Response(formatted)
 
         elif request.query['type'] == 'peers':
-            peers = self.session.network.get_peers_for_service(self.identity_overlay.master_peer.mid)
+            peers = self.session.network.get_peers_for_service(self.identity_overlay.community_id)
             return Response([b64encode(p.mid).decode('utf-8') for p in peers])
 
         elif request.query['type'] == 'attributes':

--- a/ipv8/REST/overlays_endpoint.py
+++ b/ipv8/REST/overlays_endpoint.py
@@ -48,7 +48,7 @@ class OverlaysEndpoint(BaseEndpoint):
             statistics = self.session.endpoint.get_aggregate_statistics(overlay.get_prefix()) \
                 if isinstance(self.session.endpoint, StatisticsEndpoint) else {}
             overlay_stats.append({
-                "id": hexlify(overlay.master_peer.mid).decode('utf-8'),
+                "id": hexlify(overlay.community_id).decode('utf-8'),
                 "my_peer": hexlify(overlay.my_peer.public_key.key_to_bin()).decode('utf-8'),
                 "global_time": overlay.global_time,
                 "peers": [{'ip': peer.address[0],
@@ -57,9 +57,6 @@ class OverlaysEndpoint(BaseEndpoint):
                 "overlay_name": overlay.__class__.__name__,
                 "statistics": statistics
             })
-
-            if hasattr(overlay.master_peer, 'public_key'):
-                overlay_stats[-1]['master_peer'] = hexlify(overlay.master_peer.public_key.key_to_bin()).decode('utf-8')
         return Response({"overlays": overlay_stats})
 
     @docs(

--- a/ipv8/REST/schema.py
+++ b/ipv8/REST/schema.py
@@ -40,7 +40,7 @@ class OverlayStatisticsSchema(Schema):
 
 
 class OverlaySchema(Schema):
-    master_peer = String()
+    id = String()
     my_peer = String()
     global_time = Integer()
     peers = List(String)

--- a/ipv8/attestation/identity/community.py
+++ b/ipv8/attestation/identity/community.py
@@ -23,8 +23,7 @@ SAFE_UDP_PACKET_LENGTH = 1296
 
 class IdentityCommunity(Community):
 
-    master_peer = Peer(unhexlify("4c69624e61434c504b3aabacc18bacd5abd4c93dc867759474f619e24b460fede1668a880297b19"
-                                 "4a0433324a0902192e7b853bda54b6e1b18e670d9ad4bd8f7e7e1dac71723989add3a"))
+    community_id = unhexlify('d5889074c1e4c50423cdb6e9307ee0ca5695ead7')
 
     def __init__(self, my_peer, endpoint, network=None, max_peers=DEFAULT_MAX_PEERS,
                  anonymize=True, identity_manager=None, working_directory="."):
@@ -297,9 +296,9 @@ async def create_community(private_key: PrivateKey, ipv8, identity_manager: Iden
     if rendezvous_token is not None:
         token_str = hexlify(rendezvous_token).decode()
         rendezvous_id = bytes(b ^ rendezvous_token[i] if i < len(rendezvous_token) else b
-                              for i, b in enumerate(IdentityCommunity.master_peer.mid))
+                              for i, b in enumerate(IdentityCommunity.community_id))
         overlay_cls = type(f"IdentityCommunity-{token_str}", (IdentityCommunity, ), {
-            'master_peer': type(f"RendezvousID-{token_str}", (object, ), {'mid': rendezvous_id})
+            'community_id': rendezvous_id
         })
     community = overlay_cls(my_peer, endpoint, identity_manager=identity_manager,
                             working_directory=working_directory, anonymize=anonymize)

--- a/ipv8/attestation/trustchain/community.py
+++ b/ipv8/attestation/trustchain/community.py
@@ -41,8 +41,7 @@ class TrustChainCommunity(Community):
     """
     Community for reputation based on TrustChain tamper proof interaction history.
     """
-    master_peer = Peer(unhexlify("4c69624e61434c504b3a5730f52156615ecbcedb36c442992ea8d3c26b418edd8bd00e01dce26028cd"
-                                 "1ebe5f7dce59f4ed59f8fcee268fd7f1c6dc2fa2af8c22e3170e00cdecca487745"))
+    community_id = unhexlify('5ad767b05ae592a02488272ca2a86b847d4562e1')
 
     UNIVERSAL_BLOCK_LISTENER = b'UNIVERSAL_BLOCK_LISTENER'
     DB_CLASS = TrustChainDB
@@ -711,5 +710,4 @@ class TrustChainTestnetCommunity(TrustChainCommunity):
     """
     DB_NAME = 'trustchain_testnet'
 
-    master_peer = Peer(unhexlify("4c69624e61434c504b3aa90c1e65d68e9f0ccac1385b58e4a605add2406aff9952b1b6435ab07e5385"
-                                 "5eb07b062ca33af9ec55b45446dbbefc3752523a4fd3b659ecd1d8e172b7b7f30d"))
+    community_id = unhexlify('5e97ff4ef08998ee2fd2ce6b7a569cc4f7d27c37')

--- a/ipv8/attestation/wallet/community.py
+++ b/ipv8/attestation/wallet/community.py
@@ -16,7 +16,6 @@ from ..schema.manager import SchemaManager
 from ...community import Community
 from ...lazy_community import lazy_wrapper
 from ...messaging.payload_headers import BinMemberAuthenticationPayload, GlobalTimeDistributionPayload
-from ...peer import Peer
 from ...requestcache import RequestCache
 from ...util import maybe_coroutine
 
@@ -38,11 +37,7 @@ class AttestationCommunity(Community):
 
     Note that the logic for giving out Attestations is in the TrustChain.
     """
-    master_peer = Peer(unhexlify("3081a7301006072a8648ce3d020106052b810400270381920004057a009787f66ea54d5082ea2f56a8"
-                                 "42488e319c14c98967c39286433233f769a73e9c894149cf9053a9a0c2548f07171df9c46c3bdb106a"
-                                 "fa9e9a8a06926e0ec35871c91f2ab1a20651d0a7b5fda209a3500a09b630a193b281a266230472ef0c"
-                                 "c0622c793dc18eed6c57d7bcd1eeca33e2e38277ea99c28d4c62f850f81b5eb3eb19fcb601747bd87a"
-                                 "a0b04e360ae9"))
+    community_id = unhexlify('b42c93d167a0fc4a0843f917d4bf1e9ebb340ec4')
 
     def __init__(self, *args, **kwargs):
         working_directory = kwargs.pop('working_directory', '')

--- a/ipv8/database.py
+++ b/ipv8/database.py
@@ -12,8 +12,6 @@ from abc import ABCMeta, abstractmethod
 from collections import defaultdict
 from threading import RLock
 
-from .util import cast_to_unicode
-
 if sys.platform == "darwin":
     # Workaround for annoying MacOS Sierra bug: https://bugs.python.org/issue27126
     # As fix, we are using pysqlite2 so we can supply our own version of sqlite3.
@@ -158,9 +156,10 @@ class Database(metaclass=ABCMeta):
                      "Database.close() has been called or Database.open() has not been called")
 
         # collect current database configuration
-        page_size = int(next(self._cursor.execute(u"PRAGMA page_size"))[0])
-        journal_mode = cast_to_unicode(next(self._cursor.execute(u"PRAGMA journal_mode"))[0]).upper()
-        synchronous = cast_to_unicode(next(self._cursor.execute(u"PRAGMA synchronous"))[0]).upper()
+        page_size = int(next(self._cursor.execute("PRAGMA page_size"))[0])
+        journal_mode = next(self._cursor.execute("PRAGMA journal_mode"))[0].decode().upper()
+        synchronous = next(self._cursor.execute("PRAGMA synchronous"))[0]
+        synchronous = synchronous.decode().upper() if isinstance(synchronous, bytes) else synchronous
 
         #
         # PRAGMA page_size = bytes;
@@ -173,11 +172,11 @@ class Database(metaclass=ABCMeta):
             self._logger.debug("PRAGMA page_size = 8192 (previously: %s) [%s]", page_size, self._file_path)
 
             # it is not possible to change page_size when WAL is enabled
-            if journal_mode == u"WAL":
-                self._cursor.executescript(u"PRAGMA journal_mode = DELETE")
-                journal_mode = u"DELETE"
-            self._cursor.execute(u"PRAGMA page_size = 8192")
-            execute_or_script(self._cursor, u"VACUUM")
+            if journal_mode == "WAL":
+                self._cursor.executescript("PRAGMA journal_mode = DELETE")
+                journal_mode = "DELETE"
+            self._cursor.execute("PRAGMA page_size = 8192")
+            execute_or_script(self._cursor, "VACUUM")
             page_size = 8192
 
         else:
@@ -187,10 +186,10 @@ class Database(metaclass=ABCMeta):
         # PRAGMA journal_mode = DELETE | TRUNCATE | PERSIST | MEMORY | WAL | OFF
         # http://www.sqlite.org/pragma.html#pragma_page_size
         #
-        if not (journal_mode == u"WAL" or self._file_path == u":memory:"):
+        if not (journal_mode == "WAL" or self._file_path == ":memory:"):
             self._logger.debug("PRAGMA journal_mode = WAL (previously: %s) [%s]", journal_mode, self._file_path)
-            self._cursor.execute(u"PRAGMA locking_mode = EXCLUSIVE")
-            execute_or_script(self._cursor, u"PRAGMA journal_mode = WAL")
+            self._cursor.execute("PRAGMA locking_mode = EXCLUSIVE")
+            execute_or_script(self._cursor, "PRAGMA journal_mode = WAL")
 
         else:
             self._logger.debug("PRAGMA journal_mode = %s (no change) [%s]", journal_mode, self._file_path)
@@ -199,9 +198,9 @@ class Database(metaclass=ABCMeta):
         # PRAGMA synchronous = 0 | OFF | 1 | NORMAL | 2 | FULL;
         # http://www.sqlite.org/pragma.html#pragma_synchronous
         #
-        if synchronous not in (u"NORMAL", u"1"):
+        if synchronous not in ("NORMAL", 1):
             self._logger.debug("PRAGMA synchronous = NORMAL (previously: %s) [%s]", synchronous, self._file_path)
-            execute_or_script(self._cursor, u"PRAGMA synchronous = NORMAL")
+            execute_or_script(self._cursor, "PRAGMA synchronous = NORMAL")
 
         else:
             self._logger.debug("PRAGMA synchronous = %s (no change) [%s]", synchronous, self._file_path)
@@ -214,14 +213,14 @@ class Database(metaclass=ABCMeta):
 
         # check is the database contains an 'option' table
         try:
-            count, = next(self.execute(u"SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'option'"))
+            count, = next(self.execute("SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'option'"))
         except StopIteration:
             raise RuntimeError()
 
         if count:
             # get version from required 'option' table
             try:
-                version, = next(self.execute(u"SELECT value FROM option WHERE key == 'database_version' LIMIT 1"))
+                version, = next(self.execute("SELECT value FROM option WHERE key == 'database_version' LIMIT 1"))
             except StopIteration:
                 # the 'database_version' key was not found
                 version = b"0"

--- a/ipv8/dht/churn.py
+++ b/ipv8/dht/churn.py
@@ -29,7 +29,7 @@ class PingChurn(DiscoveryStrategy):
                     if node not in self.overlay.get_peers():
                         peer = Peer(node.key, node.address)
                         self.overlay.network.add_verified_peer(peer)
-                        self.overlay.network.discover_services(peer, [self.overlay.master_peer.mid])
+                        self.overlay.network.discover_services(peer, [self.overlay.community_id])
 
             now = time()
             for bucket in self.overlay.routing_table.trie.values():

--- a/ipv8/dht/community.py
+++ b/ipv8/dht/community.py
@@ -15,7 +15,6 @@ from .storage import Storage
 from ..community import Community, _DEFAULT_ADDRESSES
 from ..lazy_community import lazy_wrapper, lazy_wrapper_wd
 from ..messaging.payload_headers import BinMemberAuthenticationPayload, GlobalTimeDistributionPayload
-from ..peer import Peer
 from ..peerdiscovery.network import Network
 from ..requestcache import RandomNumberCache, RequestCache
 from ..taskmanager import task
@@ -146,8 +145,7 @@ class DHTCommunity(Community):
     """
     Community for storing/finding key-value pairs.
     """
-    master_peer = Peer(unhexlify('4c69624e61434c504b3a4c99f04cef9ba4ca645401cd51b8ef634e63e2ad0d3209eca958ce0293d7cf668'
-                                 '2059469c1a253e66191bd3b96a082a8e11cc35962b9b6f8434e21518a0344af'))
+    community_id = unhexlify('40d796da96ef4e58fc34ff6cea856d90d8e642cb')
 
     def __init__(self, *args, **kwargs):
         super(DHTCommunity, self).__init__(*args, **kwargs)

--- a/ipv8/messaging/anonymization/community.py
+++ b/ipv8/messaging/anonymization/community.py
@@ -91,8 +91,7 @@ class TunnelSettings(object):
 class TunnelCommunity(Community):
 
     version = b'\x02'
-    master_peer = Peer(unhexlify("4c69624e61434c504b3adbd575f1902f1d39debeb3d7b576dff1652ab6cede21c14545d134219b57b"
-                                 "413a597c87c2e37b8c9f99938e0d4db3cd4a79d6b53fb5bc0cb7d222d5c6eabfaa9"))
+    community_id = unhexlify('81ded07332bdc775aa5a46f96de9f8f390bbc9f3')
 
     def __init__(self, *args, **kwargs):
         self.settings = kwargs.pop('settings', TunnelSettings())

--- a/ipv8/messaging/anonymization/payload.py
+++ b/ipv8/messaging/anonymization/payload.py
@@ -9,7 +9,6 @@ from ...messaging.anonymization.tunnel import (CIRCUIT_TYPE_RP_DOWNLOADER, CIRCU
 from ...messaging.anonymization.tunnelcrypto import CryptoException
 from ...messaging.lazy_payload import VariablePayload, vp_compile
 from ...messaging.payload import Payload
-from ...util import cast_to_chr
 
 ADDRESS_TYPE_IPV4 = 0x01
 ADDRESS_TYPE_DOMAIN_NAME = 0x02
@@ -18,8 +17,6 @@ NO_CRYPTO_PACKETS = [2, 3]
 
 
 def encode_address(host, port):
-    if not isinstance(host, str):
-        host = cast_to_chr(host)
     try:
         ip = socket.inet_aton(host)
         is_ip = True

--- a/ipv8/messaging/anonymization/pex.py
+++ b/ipv8/messaging/anonymization/pex.py
@@ -8,15 +8,10 @@ from ...messaging.deprecated.encoding import decode, encode
 from ...peer import Peer
 
 
-class PexMasterPeer(object):
-    def __init__(self, info_hash):
-        self.mid = info_hash
-
-
 class PexCommunity(Community):
     def __init__(self, *args, **kwargs):
-        self.master_peer = PexMasterPeer(kwargs.pop('info_hash'))
-        self._prefix = b'\x00' + self.version + self.master_peer.mid
+        self.community_id = kwargs.pop('info_hash')
+        self._prefix = b'\x00' + self.version + self.community_id
         super(PexCommunity, self).__init__(*args, **kwargs)
 
         self.intro_points = deque(maxlen=20)

--- a/ipv8/overlay.py
+++ b/ipv8/overlay.py
@@ -12,11 +12,11 @@ class Overlay(EndpointListener, TaskManager, metaclass=abc.ABCMeta):
     Interface for an Internet overlay.
     """
 
-    def __init__(self, master_peer, my_peer, endpoint, network):
+    def __init__(self, community_id, my_peer, endpoint, network):
         """
         Create a new overlay for the Internet.
 
-        :param master_peer: the (public key) peer of the owner of this overlay.
+        :param community_id: the byte-string used to identify this overlay.
         :param my_peer: the (private key) peer of this peer
         :param endpoint: the endpoint to use for messaging
         :param network: the network graph backend
@@ -26,7 +26,7 @@ class Overlay(EndpointListener, TaskManager, metaclass=abc.ABCMeta):
         self.serializer = self.get_serializer()
         self.crypto = default_eccrypto
 
-        self.master_peer = master_peer
+        self.community_id = community_id
         self.my_peer = my_peer
 
         self.endpoint.add_listener(self)

--- a/ipv8/peerdiscovery/community.py
+++ b/ipv8/peerdiscovery/community.py
@@ -51,12 +51,7 @@ class PingRequestCache(NumberCache):
 class DiscoveryCommunity(Community):
 
     version = b'\x02'
-    master_peer = Peer(unhexlify("3081a7301006072a8648ce3d020106052b81040027038192000403b3ab059ced"
-                                 "9b20646ab5e01762b3595c5e8855227ae1e424cff38a1e4edee73734ff2e2e82"
-                                 "9eb4f39bab20d7578284fcba7251acd74e7daf96f21d01ea17077faf4d27a655"
-                                 "837d072baeb671287a88554e1191d8904b0dc572d09ff95f10ff092c8a5e2a01"
-                                 "cd500624376aec875a6e3028aab784cfaf0bac6527245db8d93900d904ac2a92"
-                                 "2a02716ccef5a22f7968"))
+    community_id = unhexlify('7e313685c1912a141279f8248fc8db5899c5df5a')
 
     def __init__(self, my_peer, endpoint, network, max_peers=DEFAULT_MAX_PEERS, anonymize=False):
         super(DiscoveryCommunity, self).__init__(my_peer, endpoint, network, max_peers=max_peers, anonymize=anonymize)
@@ -88,7 +83,7 @@ class DiscoveryCommunity(Community):
 
         peer = Peer(auth.public_key_bin, source_address)
         self.network.add_verified_peer(peer)
-        self.network.discover_services(peer, [self.master_peer.mid, ])
+        self.network.discover_services(peer, [self.community_id, ])
 
         introduce_to = getattr(payload, 'introduce_to', None)
         introduction = None

--- a/ipv8/peerdiscovery/network.py
+++ b/ipv8/peerdiscovery/network.py
@@ -3,8 +3,6 @@ from socket import inet_aton, inet_ntoa
 from struct import pack, unpack
 from threading import RLock
 
-from ..util import cast_to_chr
-
 
 class Network(object):
 
@@ -258,8 +256,7 @@ class Network(object):
             out = b""
             for peer in self.verified_peers:
                 if peer.address and peer.address != ('0.0.0.0', 0):
-                    out += inet_aton(cast_to_chr(peer.address[0]) if isinstance(peer.address[0], bytes)
-                                     else peer.address[0]) + pack(">H", peer.address[1])
+                    out += inet_aton(peer.address[0]) + pack(">H", peer.address[1])
             return out
 
     def load_snapshot(self, snapshot):

--- a/ipv8/test/REST/rest_base.py
+++ b/ipv8/test/REST/rest_base.py
@@ -84,7 +84,7 @@ class RESTTestBase(TestBase):
                 private_peer = other.my_peer
                 public_peer = Peer(private_peer.public_key, private_peer.address)
                 for overlay_class in overlay_classes:
-                    node.network.discover_services(public_peer, overlay_class.master_peer.mid)
+                    node.network.discover_services(public_peer, overlay_class.community_id)
 
     async def create_node(self, *args, **kwargs):
         ipv8 = MockRestIPv8(u"curve25519", overlay_classes=self.overlay_classes, *args, **kwargs)

--- a/ipv8/test/base.py
+++ b/ipv8/test/base.py
@@ -42,7 +42,7 @@ class TestBase(asynctest.TestCase):
                 private_peer = other.my_peer
                 public_peer = Peer(private_peer.public_key, private_peer.address)
                 node.network.add_verified_peer(public_peer)
-                node.network.discover_services(public_peer, [overlay_class.master_peer.mid])
+                node.network.discover_services(public_peer, [overlay_class.community_id])
 
     def setUp(self):
         super(TestBase, self).setUp()
@@ -113,7 +113,7 @@ class TestBase(asynctest.TestCase):
             private_peer = other.my_peer
             public_peer = Peer(private_peer.public_key, private_peer.address)
             node.network.add_verified_peer(public_peer)
-            node.network.discover_services(public_peer, node.overlay.master_peer.mid)
+            node.network.discover_services(public_peer, node.overlay.community_id)
         self.nodes.append(node)
 
     @staticmethod

--- a/ipv8/test/messaging/anonymization/test_hiddenservices.py
+++ b/ipv8/test/messaging/anonymization/test_hiddenservices.py
@@ -111,7 +111,7 @@ class TestHiddenServices(TestBase):
         exit_node.overlay.settings.peer_flags.add(PEER_FLAG_EXIT_BT)
         public_peer = Peer(exit_node.my_peer.public_key, exit_node.my_peer.address)
         self.nodes[node_nr].network.add_verified_peer(public_peer)
-        self.nodes[node_nr].network.discover_services(public_peer, exit_node.overlay.master_peer.mid)
+        self.nodes[node_nr].network.discover_services(public_peer, exit_node.overlay.community_id)
         self.nodes[node_nr].overlay.candidates[public_peer] = exit_node.overlay.settings.peer_flags
         self.nodes[node_nr].overlay.build_tunnels(1)
         await self.deliver_messages()

--- a/ipv8/test/peerdiscovery/test_edge_discovery.py
+++ b/ipv8/test/peerdiscovery/test_edge_discovery.py
@@ -28,9 +28,9 @@ class TestEdgeWalk(TestBase):
           NODE0 <-> NODE1 <-> NODE2
         """
         self.overlays[0].network.add_verified_peer(self.overlays[1].my_peer)
-        self.overlays[0].network.discover_services(self.overlays[1].my_peer, [self.overlays[1].master_peer.mid, ])
+        self.overlays[0].network.discover_services(self.overlays[1].my_peer, [self.overlays[1].community_id, ])
         self.overlays[1].network.add_verified_peer(self.overlays[2].my_peer)
-        self.overlays[1].network.discover_services(self.overlays[2].my_peer, [self.overlays[2].master_peer.mid, ])
+        self.overlays[1].network.discover_services(self.overlays[2].my_peer, [self.overlays[2].community_id, ])
         # We expect NODE1 to introduce NODE0 to NODE2
         self.strategies[0].take_step()  # First it's added in the neighborhood
         self.strategies[0].take_step()  # Second it introduces its neighbor
@@ -48,7 +48,7 @@ class TestEdgeWalk(TestBase):
         """
         self.strategies[0].edge_timeout = 0.0  # Finish the edge immediately
         self.overlays[0].network.add_verified_peer(self.overlays[1].my_peer)
-        self.overlays[0].network.discover_services(self.overlays[1].my_peer, [self.overlays[1].master_peer.mid, ])
+        self.overlays[0].network.discover_services(self.overlays[1].my_peer, [self.overlays[1].community_id, ])
 
         # We expect NODE0 will add NODE1 to its neighborhood and start constructing an edge from it.
         # Don't allow that right now.
@@ -58,7 +58,7 @@ class TestEdgeWalk(TestBase):
 
         # Now we give NODE2 to NODE1, which it can forward to NODE0 to make an edge
         self.overlays[1].network.add_verified_peer(self.overlays[2].my_peer)
-        self.overlays[1].network.discover_services(self.overlays[2].my_peer, [self.overlays[2].master_peer.mid, ])
+        self.overlays[1].network.discover_services(self.overlays[2].my_peer, [self.overlays[2].community_id, ])
 
         # In order:
         # 1. Add root (NODE1) and query for nodes
@@ -89,7 +89,7 @@ class TestEdgeWalk(TestBase):
 
         # Now we give NODE2 to NODE1, which it can forward to NODE0 to make an edge
         self.overlays[1].network.add_verified_peer(self.overlays[2].my_peer)
-        self.overlays[1].network.discover_services(self.overlays[2].my_peer, [self.overlays[2].master_peer.mid, ])
+        self.overlays[1].network.discover_services(self.overlays[2].my_peer, [self.overlays[2].community_id, ])
 
         # In order:
         # 1. Add root (NODE1) and query for nodes
@@ -109,7 +109,7 @@ class TestEdgeWalk(TestBase):
         self.strategies[0].edge_length = 2  # Finish with one other node
         self.strategies[0].edge_timeout = 1.0  # Finish the edge, but allow the network to walk
         self.overlays[0].network.add_verified_peer(self.overlays[1].my_peer)
-        self.overlays[0].network.discover_services(self.overlays[1].my_peer, [self.overlays[1].master_peer.mid, ])
+        self.overlays[0].network.discover_services(self.overlays[1].my_peer, [self.overlays[1].community_id, ])
 
         # We expect NODE0 will add NODE1 to its neighborhood and start constructing an edge from it.
         # Don't allow that right now.
@@ -119,7 +119,7 @@ class TestEdgeWalk(TestBase):
 
         # Now we give NODE2 to NODE1, which it can forward to NODE0 to make an edge
         self.overlays[1].network.add_verified_peer(self.overlays[2].my_peer)
-        self.overlays[1].network.discover_services(self.overlays[2].my_peer, [self.overlays[2].master_peer.mid, ])
+        self.overlays[1].network.discover_services(self.overlays[2].my_peer, [self.overlays[2].community_id, ])
 
         # In order:
         # 1. Add root (NODE1) and query for nodes

--- a/ipv8/test/peerdiscovery/test_edge_discovery.py
+++ b/ipv8/test/peerdiscovery/test_edge_discovery.py
@@ -15,6 +15,10 @@ class TestEdgeWalk(TestBase):
         self.overlays = [MockCommunity() for _ in range(node_count)]
         self.strategies = [EdgeWalk(self.overlays[i], neighborhood_size=1) for i in range(node_count)]
 
+        # Prevent LAN IPs from ending up in Network
+        for overlay in self.overlays:
+            overlay.address_is_lan = lambda _: False
+
     async def tearDown(self):
         for overlay in self.overlays:
             await overlay.unload()

--- a/ipv8/test/peerdiscovery/test_random_discovery.py
+++ b/ipv8/test/peerdiscovery/test_random_discovery.py
@@ -28,9 +28,9 @@ class TestRandomWalk(TestBase):
           NODE0 <-> NODE1 <-> NODE2
         """
         self.overlays[0].network.add_verified_peer(self.overlays[1].my_peer)
-        self.overlays[0].network.discover_services(self.overlays[1].my_peer, [self.overlays[1].master_peer.mid, ])
+        self.overlays[0].network.discover_services(self.overlays[1].my_peer, [self.overlays[1].community_id, ])
         self.overlays[1].network.add_verified_peer(self.overlays[2].my_peer)
-        self.overlays[1].network.discover_services(self.overlays[2].my_peer, [self.overlays[2].master_peer.mid, ])
+        self.overlays[1].network.discover_services(self.overlays[2].my_peer, [self.overlays[2].community_id, ])
         # We expect NODE1 to introduce NODE0 to NODE2
         self.strategies[0].take_step()
         await self.deliver_messages()
@@ -49,8 +49,8 @@ class TestRandomWalk(TestBase):
         """
         self.overlays[0].network.add_verified_peer(self.overlays[1].my_peer)
         self.overlays[0].network.discover_address(self.overlays[1].my_peer, self.overlays[2].endpoint.wan_address,
-                                                  MockCommunity.master_peer.mid)
-        self.overlays[0].network.discover_services(self.overlays[1].my_peer, [self.overlays[1].master_peer.mid, ])
+                                                  MockCommunity.community_id)
+        self.overlays[0].network.discover_services(self.overlays[1].my_peer, [self.overlays[1].community_id, ])
         # We expect NODE0 to visit NODE2
         self.strategies[0].take_step()
         await self.deliver_messages()
@@ -69,8 +69,8 @@ class TestRandomWalk(TestBase):
         """
         self.overlays[0].network.add_verified_peer(self.overlays[1].my_peer)
         self.overlays[0].network.discover_address(self.overlays[1].my_peer, self.overlays[2].endpoint.wan_address,
-                                                  MockCommunity.master_peer.mid)
-        self.overlays[0].network.discover_services(self.overlays[1].my_peer, [self.overlays[1].master_peer.mid, ])
+                                                  MockCommunity.community_id)
+        self.overlays[0].network.discover_services(self.overlays[1].my_peer, [self.overlays[1].community_id, ])
         # Fail immediately when unreachable
         self.strategies[0].node_timeout = 0.0
 
@@ -98,8 +98,8 @@ class TestRandomWalk(TestBase):
         """
         self.overlays[0].network.add_verified_peer(self.overlays[1].my_peer)
         self.overlays[0].network.discover_address(self.overlays[1].my_peer, self.overlays[2].endpoint.wan_address,
-                                                  MockCommunity.master_peer.mid)
-        self.overlays[0].network.discover_services(self.overlays[1].my_peer, [self.overlays[1].master_peer.mid, ])
+                                                  MockCommunity.community_id)
+        self.overlays[0].network.discover_services(self.overlays[1].my_peer, [self.overlays[1].community_id, ])
         self.strategies[0].node_timeout = 100000.0
 
         # NODE0 attempts to reach NODE2

--- a/ipv8/util.py
+++ b/ipv8/util.py
@@ -1,25 +1,11 @@
-import logging
 import operator
 import struct
 from asyncio import Future, iscoroutine
 
-logger = logging.getLogger(__name__)
 maximum_integer = 2147483647
 
 int2byte = struct.Struct(">B").pack
 byte2int = operator.itemgetter(0)
-
-
-def cast_to_unicode(obj):
-    if isinstance(obj, (bytes, bytearray)):
-        return "".join(chr(c) for c in obj)
-    if isinstance(obj, str):
-        return obj
-    return str(obj)
-
-
-def cast_to_chr(obj):
-    return "".join(chr(c) for c in obj)
 
 
 def succeed(result):

--- a/scripts/tracker_plugin.py
+++ b/scripts/tracker_plugin.py
@@ -4,6 +4,7 @@ This script enables to start the tracker.
 Select the port you want to use by setting the `listen_port` command line argument.
 """
 import argparse
+import os
 import random
 import signal
 import sys
@@ -49,7 +50,7 @@ class EndpointServer(Community):
     Make some small modifications to the Community to allow it a dynamic prefix.
     We will also only answer introduction requests.
     """
-    master_peer = Peer(default_eccrypto.generate_key(u"very-low"))
+    community_id = os.urandom(20)
 
     def __init__(self, endpoint):
         my_peer = Peer(default_eccrypto.generate_key(u"very-low"))

--- a/scripts/trustchain_crawler_plugin.py
+++ b/scripts/trustchain_crawler_plugin.py
@@ -23,7 +23,6 @@ from ipv8.REST.rest_manager import RESTManager
 from ipv8.attestation.trustchain.community import TrustChainCommunity
 from ipv8.attestation.trustchain.database import TrustChainDB
 from ipv8.attestation.trustchain.settings import TrustChainSettings
-from ipv8.peer import Peer
 
 from ipv8_service import IPv8
 
@@ -85,11 +84,7 @@ class TrustChainBackwardsCrawlerCommunity(TrustChainCrawlerCommunity):
     """
     Backwards-compatible TrustChain community.
     """
-    master_peer = Peer(unhexlify("3081a7301006072a8648ce3d020106052b8104002703819200040672297aa47c7bb2648ba0385275bc"
-                                 "8ade5aedc3677a615f5f9ca83b9b28c75e543342875f7f353bbf74baff7e3dae895ee9c9a9f80df023"
-                                 "dbfb72362426b50ce35549e6f0e0a319015a2fd425e2e34c92a3fb33b26929bcabb73e14f63684129b"
-                                 "66f0373ca425015cc9fad75b267de0cfb46ed798796058b23e12fc4c42ce9868f1eb7d59cc2023c039"
-                                 "14175ebb9703"))
+    community_id = unhexlify('223eb544cd6c4814f4db710618b2ad5bc8b9d541')
 
 
 crawler_config = {

--- a/stresstest/bootstrap_rtt.py
+++ b/stresstest/bootstrap_rtt.py
@@ -1,3 +1,4 @@
+import os
 import time
 from asyncio import ensure_future, get_event_loop
 from random import randint
@@ -14,8 +15,6 @@ except ImportError:
 
 from ipv8.community import Community, _DEFAULT_ADDRESSES, _DNS_ADDRESSES
 from ipv8.configuration import get_default_configuration
-from ipv8.keyvault.crypto import ECCrypto
-from ipv8.peer import Peer
 from ipv8.requestcache import NumberCache, RequestCache
 
 from ipv8_service import IPv8, _COMMUNITIES
@@ -46,7 +45,7 @@ class PingCache(NumberCache):
 
 
 class MyCommunity(Community):
-    master_peer = Peer(ECCrypto().generate_key(u"medium"))
+    community_id = os.urandom(20)
 
     def __init__(self, *args, **kwargs):
         super(MyCommunity, self).__init__(*args, **kwargs)

--- a/stresstest/peer_discovery.py
+++ b/stresstest/peer_discovery.py
@@ -1,3 +1,4 @@
+import os
 import time
 from asyncio import ensure_future, get_event_loop
 from random import randint
@@ -12,8 +13,6 @@ except ImportError:
 
 from ipv8.community import Community
 from ipv8.configuration import get_default_configuration
-from ipv8.keyvault.crypto import ECCrypto
-from ipv8.peer import Peer
 
 from ipv8_service import IPv8, _COMMUNITIES
 
@@ -25,7 +24,7 @@ INSTANCES = []
 
 
 class MyCommunity(Community):
-    master_peer = Peer(ECCrypto().generate_key(u"medium"))
+    community_id = os.urandom(20)
 
     def started(self):
         async def check_peers():

--- a/stresstest/peer_discovery_defaults.py
+++ b/stresstest/peer_discovery_defaults.py
@@ -1,3 +1,4 @@
+import os
 import sys
 import time
 from asyncio import ensure_future, get_event_loop, sleep
@@ -14,8 +15,6 @@ except ImportError:
 
 
 from ipv8.configuration import get_default_configuration  # pylint: disable=ungrouped-imports
-from ipv8.keyvault.crypto import ECCrypto  # pylint: disable=ungrouped-imports
-from ipv8.peer import Peer  # pylint: disable=ungrouped-imports
 
 from ipv8_service import IPv8, _COMMUNITIES, _WALKERS  # pylint: disable=ungrouped-imports
 
@@ -48,7 +47,7 @@ async def start_communities():
     # Override the Community master peers so we don't interfere with the live network
     # Also hook in our custom logic for introduction responses
     for community_cls in _COMMUNITIES.values():
-        community_cls.master_peer = Peer(ECCrypto().generate_key(u"medium"))
+        community_cls.community_id = os.urandom(20)
         community_cls.introduction_response_callback = custom_intro_response_cb
 
     # Create two peers with separate working directories


### PR DESCRIPTION
This PR:
* Replaces the `master_peer` of every `Community` with a byte string. In the past, this was used by `Dispersy` as part of a mechanism to remotely shutdown a `Community`. However, since we no longer have this feature, we can easily replace this with a byte string.
* Removes `cast_to_chr` and `char_to_unicode` that were used while porting from Python 2 to 3.
* Possibly fixes intermittent "unregistered address" error during `EdgeWalk` tests.