### PR TITLE
Automated Version Update

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -24,9 +24,9 @@ copyright = '2017-2020, Tribler'  # Do not change manually! Handled by github_in
 author = u'Tribler'
 
 # The short X.Y version
-version = '2.3'  # Do not change manually! Handled by github_increment_version.py
+version = '2.4'  # Do not change manually! Handled by github_increment_version.py
 # The full version, including alpha/beta/rc tags
-release = '2.3.0'  # Do not change manually! Handled by github_increment_version.py
+release = '2.4.0'  # Do not change manually! Handled by github_increment_version.py
 
 
 # -- General configuration ---------------------------------------------------

--- a/ipv8/REST/rest_manager.py
+++ b/ipv8/REST/rest_manager.py
@@ -84,7 +84,7 @@ class RESTManager:
         aiohttp_apispec = AiohttpApiSpec(
             app=self.root_endpoint.app,
             title="IPv8 REST API documentation",
-            version="v2.3",  # Do not change manually! Handled by github_increment_version.py
+            version="v2.4",  # Do not change manually! Handled by github_increment_version.py
             url="/docs/swagger.json",
             swagger_path="/docs",
         )

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     description='The Python implementation of the IPV8 library',
     long_description=long_description,
     long_description_content_type='text/markdown',
-    version='2.3.0',  # Do not change manually! Handled by github_increment_version.py
+    version='2.4.0',  # Do not change manually! Handled by github_increment_version.py
     url='https://github.com/Tribler/py-ipv8',
     package_data={'': ['*.*']},
     packages=find_packages(),


### PR DESCRIPTION
Suggested release message
---
Tag version: 2.4
Release title: IPv8 v2.4.1535 release
Body:
Includes the first 1535 commits (+31 since v2.3) for IPv8, containing:

 -  Updated Serializer to be more efficient
 - Added CommunityLauncher (from Gumby)
 - Added pytest support
 - Added unit tests for DispatcherEndpoint
 - Don't remove all other observers in AsyncioEndpoint
 - Fixed EndpointListener accessing Endpoint._port
 - Fixed pylintrc regular expression
 - Fixed sending to unsupported guessed interface
 - Replaced master_peer with a 20-byte community_id
 - Updated the GitHub release script and its instructions