### PR TITLE
Added 'q' format to Serializer defaults

### DIFF
--- a/ipv8/messaging/serialization.py
+++ b/ipv8/messaging/serialization.py
@@ -178,6 +178,7 @@ class Serializer(object):
             'I': DefaultStruct(">I"),
             'l': DefaultStruct(">l"),
             'LL': DefaultStruct(">LL"),
+            'q': DefaultStruct(">q"),
             'Q': DefaultStruct(">Q"),
             'QH': DefaultStruct(">QH"),
             'QL': DefaultStruct(">QL"),


### PR DESCRIPTION
Fixes #881

This PR:

 - Adds the `q` format (`>q`) to the Serializer's default loaded formats.
