### PR TITLE
Extracted documentation examples into Python files

### DIFF
--- a/doc/basics/identity_tutorial.rst
+++ b/doc/basics/identity_tutorial.rst
@@ -41,36 +41,7 @@ Running the IPv8 service
 
 Fill your ``main.py`` file with the following code (runnable with ``python3 main.py``\ ):
 
-.. code-block:: python
-
-    from base64 import b64encode
-
-    from asyncio import ensure_future, get_event_loop
-
-    from pyipv8.ipv8.configuration import get_default_configuration
-    from pyipv8.ipv8.REST.rest_manager import RESTManager
-    from pyipv8.ipv8_service import IPv8
-
-
-    async def start_community():
-        for peer_id in [1, 2]:
-            configuration = get_default_configuration()
-            configuration['keys'] = [{'alias': "anonymous id", 'generation': u"curve25519", 'file': f"keyfile_{peer_id}.pem"}]
-            configuration['working_directory'] = f"state_{peer_id}"
-            configuration['overlays'] = []
-
-            # Start the IPv8 service
-            ipv8 = IPv8(configuration)
-            await ipv8.start()
-            rest_manager = RESTManager(ipv8)
-            await rest_manager.start(14410 + peer_id)
-
-            # Print the peer for reference
-            print("Starting peer", b64encode(ipv8.keys["anonymous id"].mid))
-
-
-    ensure_future(start_community())
-    get_event_loop().run_forever()
+.. literalinclude:: identity_tutorial_1.py
 
 Running the service should yield something like the following output in your terminal:
 

--- a/doc/basics/identity_tutorial_1.py
+++ b/doc/basics/identity_tutorial_1.py
@@ -1,0 +1,28 @@
+from asyncio import ensure_future, get_event_loop
+from base64 import b64encode
+
+from pyipv8.ipv8.REST.rest_manager import RESTManager
+from pyipv8.ipv8.configuration import get_default_configuration
+from pyipv8.ipv8_service import IPv8
+
+
+async def start_community():
+    for peer_id in [1, 2]:
+        configuration = get_default_configuration()
+        configuration['keys'] = [
+            {'alias': "anonymous id", 'generation': u"curve25519", 'file': f"keyfile_{peer_id}.pem"}]
+        configuration['working_directory'] = f"state_{peer_id}"
+        configuration['overlays'] = []
+
+        # Start the IPv8 service
+        ipv8 = IPv8(configuration)
+        await ipv8.start()
+        rest_manager = RESTManager(ipv8)
+        await rest_manager.start(14410 + peer_id)
+
+        # Print the peer for reference
+        print("Starting peer", b64encode(ipv8.keys["anonymous id"].mid))
+
+
+ensure_future(start_community())
+get_event_loop().run_forever()

--- a/doc/basics/overlay_tutorial_1.py
+++ b/doc/basics/overlay_tutorial_1.py
@@ -1,0 +1,18 @@
+from asyncio import ensure_future, get_event_loop
+
+from pyipv8.ipv8.configuration import get_default_configuration
+from pyipv8.ipv8_service import IPv8
+
+
+async def start_ipv8():
+    # Create an IPv8 object with the default settings.
+    ipv8 = IPv8(get_default_configuration())
+    await ipv8.start()
+
+# Create a task that runs an IPv8 instance.
+# The task will run as soon as the event loop has started.
+ensure_future(start_ipv8())
+
+# Start the asyncio event loop: this is the engine scheduling all of the
+# asynchronous calls.
+get_event_loop().run_forever()

--- a/doc/basics/overlay_tutorial_2.py
+++ b/doc/basics/overlay_tutorial_2.py
@@ -1,0 +1,16 @@
+from asyncio import ensure_future, get_event_loop
+
+from pyipv8.ipv8.configuration import get_default_configuration
+from pyipv8.ipv8_service import IPv8
+
+
+async def start_ipv8():
+    # The first IPv8 will attempt to claim a port.
+    await IPv8(get_default_configuration()).start()
+    # The second IPv8 will attempt to claim a port.
+    # It cannot claim the same port and will end up claiming a different one.
+    await IPv8(get_default_configuration()).start()
+
+
+ensure_future(start_ipv8())
+get_event_loop().run_forever()

--- a/doc/basics/overlay_tutorial_3.py
+++ b/doc/basics/overlay_tutorial_3.py
@@ -1,0 +1,37 @@
+import os
+from asyncio import ensure_future, get_event_loop
+
+from pyipv8.ipv8.community import Community
+from pyipv8.ipv8.configuration import ConfigBuilder, Strategy, WalkerDefinition
+from pyipv8.ipv8_service import IPv8
+
+
+class MyCommunity(Community):
+    # Register this community with a randomly generated community ID.
+    # Other peers will connect to this community based on this identifier.
+    community_id = os.urandom(20)
+
+
+async def start_communities():
+    for i in [1, 2]:
+        builder = ConfigBuilder().clear_keys().clear_overlays()
+        # If we actually want to communicate between two different peers
+        # we need to assign them different keys.
+        # We will generate an EC key called 'my peer' which has 'medium'
+        # security and will be stored in file 'ecI.pem' where 'I' is replaced
+        # by the peer number (1 or 2).
+        builder.add_key("my peer", "medium", f"ec{i}.pem")
+        # Instruct IPv8 to load our custom overlay, registered in _COMMUNITIES.
+        # We use the 'my peer' key, which we registered before.
+        # We will attempt to find other peers in this overlay using the
+        # RandomWalk strategy, until we find 10 peers.
+        # We do not provide additional startup arguments or a function to run
+        # once the overlay has been initialized.
+        builder.add_overlay("MyCommunity", "my peer", [WalkerDefinition(Strategy.RandomWalk, 10, {'timeout': 3.0})], {},
+                            [])
+        ipv8 = IPv8(builder.finalize(), extra_communities={'MyCommunity': MyCommunity})
+        await ipv8.start()
+
+
+ensure_future(start_communities())
+get_event_loop().run_forever()

--- a/doc/basics/overlay_tutorial_4.py
+++ b/doc/basics/overlay_tutorial_4.py
@@ -1,0 +1,35 @@
+import os
+from asyncio import ensure_future, get_event_loop
+
+from pyipv8.ipv8.community import Community
+from pyipv8.ipv8.configuration import ConfigBuilder, Strategy, WalkerDefinition
+from pyipv8.ipv8_service import IPv8
+
+
+class MyCommunity(Community):
+    community_id = os.urandom(20)
+
+    def started(self):
+        async def print_peers():
+            print("I am:", self.my_peer, "\nI know:", [str(p) for p in self.get_peers()])
+
+        # We register a asyncio task with this overlay.
+        # This makes sure that the task ends when this overlay is unloaded.
+        # We call the 'print_peers' function every 5.0 seconds, starting now.
+        self.register_task("print_peers", print_peers, interval=5.0, delay=0)
+
+
+async def start_communities():
+    for i in [1, 2]:
+        builder = ConfigBuilder().clear_keys().clear_overlays()
+        builder.add_key("my peer", "medium", f"ec{i}.pem")
+        # We provide the 'started' function to the 'on_start'.
+        # We will call the overlay's 'started' function without any
+        # arguments once IPv8 is initialized.
+        builder.add_overlay("MyCommunity", "my peer", [WalkerDefinition(Strategy.RandomWalk, 10, {'timeout': 3.0})], {},
+                            [('started',)])
+        await IPv8(builder.finalize(), extra_communities={'MyCommunity': MyCommunity}).start()
+
+
+ensure_future(start_communities())
+get_event_loop().run_forever()

--- a/doc/basics/overlay_tutorial_5.py
+++ b/doc/basics/overlay_tutorial_5.py
@@ -1,0 +1,60 @@
+import os
+from asyncio import ensure_future, get_event_loop
+
+from pyipv8.ipv8.community import Community
+from pyipv8.ipv8.configuration import ConfigBuilder, Strategy, WalkerDefinition
+from pyipv8.ipv8.lazy_community import lazy_wrapper
+from pyipv8.ipv8.messaging.lazy_payload import VariablePayload, vp_compile
+from pyipv8.ipv8_service import IPv8
+
+
+@vp_compile
+class MyMessage(VariablePayload):
+    msg_id = 1  # The byte identifying this message, must be unique per community.
+    format_list = ['I']  # When reading data, we unpack an unsigned integer from it.
+    names = ["clock"]  # We will name this unsigned integer "clock"
+
+
+class MyCommunity(Community):
+    community_id = os.urandom(20)
+
+    def __init__(self, my_peer, endpoint, network):
+        super().__init__(my_peer, endpoint, network)
+        # Register the message handler for messages with the identifier "1".
+        self.add_message_handler(1, self.on_message)
+        # The Lamport clock this peer maintains.
+        # This is for the example of global clock synchronization.
+        self.lamport_clock = 0
+
+    def started(self):
+        async def start_communication():
+            if not self.lamport_clock:
+                # If we have not started counting, try boostrapping
+                # communication with our other known peers.
+                for p in self.get_peers():
+                    self.ez_send(p, MyMessage(self.lamport_clock))
+            else:
+                self.cancel_pending_task("start_communication")
+
+        self.register_task("start_communication", start_communication, interval=5.0, delay=0)
+
+    @lazy_wrapper(MyMessage)
+    def on_message(self, peer, payload):
+        # Update our Lamport clock.
+        self.lamport_clock = max(self.lamport_clock, payload.clock) + 1
+        print(self.my_peer, "current clock:", self.lamport_clock)
+        # Then synchronize with the rest of the network again.
+        self.ez_send(peer, MyMessage(self.lamport_clock))
+
+
+async def start_communities():
+    for i in [1, 2, 3]:
+        builder = ConfigBuilder().clear_keys().clear_overlays()
+        builder.add_key("my peer", "medium", f"ec{i}.pem")
+        builder.add_overlay("MyCommunity", "my peer", [WalkerDefinition(Strategy.RandomWalk, 10, {'timeout': 3.0})], {},
+                            [('started',)])
+        await IPv8(builder.finalize(), extra_communities={'MyCommunity': MyCommunity}).start()
+
+
+ensure_future(start_communities())
+get_event_loop().run_forever()

--- a/doc/deprecated/attestation_tutorial.rst
+++ b/doc/deprecated/attestation_tutorial.rst
@@ -41,53 +41,7 @@ Running the IPv8 service
 
 Fill your ``main.py`` file with the following code (runnable with ``python3 main.py``\ ):
 
-.. code-block:: python
-
-   from base64 import b64encode
-
-   from asyncio import ensure_future, get_event_loop
-
-   from pyipv8.ipv8.configuration import get_default_configuration
-   from pyipv8.ipv8.REST.rest_manager import RESTManager
-   from pyipv8.ipv8_service import IPv8
-
-
-   async def start_communities():
-       # Launch two IPv8 services.
-       # We run REST endpoints for these services on:
-       #  - http://localhost:14411/
-       #  - http://localhost:14412/
-       # This script also prints the peer ids for reference with:
-       #  - http://localhost:1441*/attestation?type=peers
-       for i in [1, 2]:
-           configuration = get_default_configuration()
-           configuration['logger']['level'] = "ERROR"
-           configuration['keys'] = [
-               {'alias': "anonymous id", 'generation': u"curve25519", 'file': u"ec%d_multichain.pem" % i},
-           ]
-
-           # Only load the basic communities
-           requested_overlays = ['DiscoveryCommunity', 'AttestationCommunity', 'IdentityCommunity']
-           configuration['overlays'] = [o for o in configuration['overlays'] if o['class'] in requested_overlays]
-
-           # Give each peer a separate working directory
-           working_directory_overlays = ['AttestationCommunity', 'IdentityCommunity']
-           for overlay in configuration['overlays']:
-               if overlay['class'] in working_directory_overlays:
-                   overlay['initialize'] = {'working_directory': 'state_%d' % i}
-
-           # Start the IPv8 service
-           ipv8 = IPv8(configuration)
-           await ipv8.start()
-           rest_manager = RESTManager(ipv8)
-           await rest_manager.start(14410 + i)
-
-           # Print the peer for reference
-           print("Starting peer", b64encode(ipv8.keys["anonymous id"].mid))
-
-
-   ensure_future(start_communities())
-   get_event_loop().run_forever()
+.. literalinclude:: attestation_tutorial_1.py
 
 Running the service should yield something like the following output in your terminal:
 

--- a/doc/deprecated/attestation_tutorial_1.py
+++ b/doc/deprecated/attestation_tutorial_1.py
@@ -1,0 +1,44 @@
+from asyncio import ensure_future, get_event_loop
+from base64 import b64encode
+
+from pyipv8.ipv8.REST.rest_manager import RESTManager
+from pyipv8.ipv8.configuration import get_default_configuration
+from pyipv8.ipv8_service import IPv8
+
+
+async def start_communities():
+    # Launch two IPv8 services.
+    # We run REST endpoints for these services on:
+    #  - http://localhost:14411/
+    #  - http://localhost:14412/
+    # This script also prints the peer ids for reference with:
+    #  - http://localhost:1441*/attestation?type=peers
+    for i in [1, 2]:
+        configuration = get_default_configuration()
+        configuration['logger']['level'] = "ERROR"
+        configuration['keys'] = [
+            {'alias': "anonymous id", 'generation': u"curve25519", 'file': u"ec%d_multichain.pem" % i},
+        ]
+
+        # Only load the basic communities
+        requested_overlays = ['DiscoveryCommunity', 'AttestationCommunity', 'IdentityCommunity']
+        configuration['overlays'] = [o for o in configuration['overlays'] if o['class'] in requested_overlays]
+
+        # Give each peer a separate working directory
+        working_directory_overlays = ['AttestationCommunity', 'IdentityCommunity']
+        for overlay in configuration['overlays']:
+            if overlay['class'] in working_directory_overlays:
+                overlay['initialize'] = {'working_directory': 'state_%d' % i}
+
+        # Start the IPv8 service
+        ipv8 = IPv8(configuration)
+        await ipv8.start()
+        rest_manager = RESTManager(ipv8)
+        await rest_manager.start(14410 + i)
+
+        # Print the peer for reference
+        print("Starting peer", b64encode(ipv8.keys["anonymous id"].mid))
+
+
+ensure_future(start_communities())
+get_event_loop().run_forever()

--- a/doc/further-reading/advanced_identity.rst
+++ b/doc/further-reading/advanced_identity.rst
@@ -19,24 +19,16 @@ Enabling anonymization
 
 In the basic identity tutorial we created the following configuration:
 
-.. code-block:: python
-
-    for peer_id in [1, 2]:
-        configuration = get_default_configuration()
-        configuration['keys'] = [{'alias': "anonymous id", 'generation': u"curve25519", 'file': f"keyfile_{peer_id}.pem"}]
-        configuration['working_directory'] = f"state_{peer_id}"
-        configuration['overlays'] = []
+.. literalinclude:: ../basics/identity_tutorial_1.py
+   :lines: 10-15
+   :dedent: 4
 
 To enable anonymization of all traffic through the identity layer we need to load the anonymization overlay.
 This is done by editing the loaded overlays through ``configuration['overlays']``, as follows:
 
-.. code-block:: python
-
-    for peer_id in [1, 2]:
-        configuration = get_default_configuration()
-        configuration['keys'] = [{'alias': "anonymous id", 'generation': u"curve25519", 'file': f"keyfile_{peer_id}.pem"}]
-        configuration['working_directory'] = f"state_{peer_id}"
-        configuration['overlays'] = [overlay for overlay in configuration['overlays'] if overlay['class'] == 'HiddenTunnelCommunity']
+.. literalinclude:: advanced_identity_1.py
+   :lines: 10-16
+   :dedent: 4
 
 Inclusion of the ``'HiddenTunnelCommunity'`` overlay automatically enables anonymization of identity traffic.
 Note that this anonymization:
@@ -51,23 +43,15 @@ Setting a REST API key
 
 In the basic identity tutorial we started the REST API as follows:
 
-.. code-block:: python
-
-    for peer_id in [1, 2]:
-        ipv8 = IPv8(configuration)
-        await ipv8.start()
-        rest_manager = RESTManager(ipv8)
-        await rest_manager.start(14410 + peer_id)
+.. literalinclude:: ../basics/identity_tutorial_1.py
+   :lines: 17-21
+   :dedent: 4
 
 To set a REST API key, we will have to pass it to the ``RESTManager`` constructor, as follows (replacing ``"my secret key"`` with your key):
 
-.. code-block:: python
-
-    for peer_id in [1, 2]:
-        ipv8 = IPv8(configuration)
-        await ipv8.start()
-        rest_manager = RESTManager(ipv8, api_key="my secret key")
-        await rest_manager.start(14410 + peer_id)
+.. literalinclude:: advanced_identity_1.py
+   :lines: 18-22
+   :dedent: 4
 
 All requests to the core will then have to use either:
 
@@ -83,25 +67,15 @@ Using a REST API X509 certificate
 
 In the basic identity tutorial we started the REST API as follows:
 
-.. code-block:: python
-
-    for peer_id in [1, 2]:
-        ipv8 = IPv8(configuration)
-        await ipv8.start()
-        rest_manager = RESTManager(ipv8)
-        await rest_manager.start(14410 + peer_id)
+.. literalinclude:: ../basics/identity_tutorial_1.py
+   :lines: 17-21
+   :dedent: 4
 
 To use a certificate file, we will have to pass it to the ``RESTManager`` constructor, as follows (replacing ``cert_fileX`` with the file path of your certificate file for the particular IPv8 instance):
 
-.. code-block:: python
-
-    for peer_id in [1, 2]:
-        ipv8 = IPv8(configuration)
-        await ipv8.start()
-        ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
-        ssl_context.load_cert_chain(cert_fileX)
-        rest_manager = RESTManager(ipv8, ssl_context=ssl_context)
-        await rest_manager.start(14410 + peer_id)
+.. literalinclude:: advanced_identity_2.py
+   :lines: 22-28
+   :dedent: 4
 
 This can (and should) be combined with an API key.
 Also note that if you start two IPv8 instances, you would normally want them to have different certificates.

--- a/doc/further-reading/advanced_identity_1.py
+++ b/doc/further-reading/advanced_identity_1.py
@@ -1,0 +1,29 @@
+from asyncio import ensure_future, get_event_loop
+from base64 import b64encode
+
+from pyipv8.ipv8.REST.rest_manager import RESTManager
+from pyipv8.ipv8.configuration import get_default_configuration
+from pyipv8.ipv8_service import IPv8
+
+
+async def start_community():
+    for peer_id in [1, 2]:
+        configuration = get_default_configuration()
+        configuration['keys'] = [
+            {'alias': "anonymous id", 'generation': u"curve25519", 'file': f"keyfile_{peer_id}.pem"}]
+        configuration['working_directory'] = f"state_{peer_id}"
+        configuration['overlays'] = [overlay for overlay in configuration['overlays']
+                                     if overlay['class'] == 'HiddenTunnelCommunity']
+
+        # Start the IPv8 service
+        ipv8 = IPv8(configuration)
+        await ipv8.start()
+        rest_manager = RESTManager(ipv8, api_key="my secret key")
+        await rest_manager.start(14410 + peer_id)
+
+        # Print the peer for reference
+        print("Starting peer", b64encode(ipv8.keys["anonymous id"].mid))
+
+
+ensure_future(start_community())
+get_event_loop().run_forever()

--- a/doc/further-reading/advanced_identity_2.py
+++ b/doc/further-reading/advanced_identity_2.py
@@ -1,0 +1,35 @@
+import ssl
+from asyncio import ensure_future, get_event_loop
+from base64 import b64encode
+
+from pyipv8.ipv8.REST.rest_manager import RESTManager
+from pyipv8.ipv8.configuration import get_default_configuration
+from pyipv8.ipv8_service import IPv8
+
+
+cert_fileX = "certfile.pem"
+
+
+async def start_community():
+    for peer_id in [1, 2]:
+        configuration = get_default_configuration()
+        configuration['keys'] = [
+            {'alias': "anonymous id", 'generation': u"curve25519", 'file': f"keyfile_{peer_id}.pem"}]
+        configuration['working_directory'] = f"state_{peer_id}"
+        configuration['overlays'] = [overlay for overlay in configuration['overlays']
+                                     if overlay['class'] == 'HiddenTunnelCommunity']
+
+        # Start the IPv8 service
+        ipv8 = IPv8(configuration)
+        await ipv8.start()
+        ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+        ssl_context.load_cert_chain(cert_fileX)
+        rest_manager = RESTManager(ipv8, ssl_context=ssl_context)
+        await rest_manager.start(14410 + peer_id)
+
+        # Print the peer for reference
+        print("Starting peer", b64encode(ipv8.keys["anonymous id"].mid))
+
+
+ensure_future(start_community())
+get_event_loop().run_forever()

--- a/doc/reference/serialization.rst
+++ b/doc/reference/serialization.rst
@@ -37,85 +37,15 @@ Each instance will have two fields: ``field1`` and ``field2`` corresponding to t
 
 .. code-block:: python
 
-    class MySerializable(Serializable):
-
-        format_list = ['I', 'H']
-
-        def __init__(self, field1, field2):
-            self.field1 = field1
-            self.field2 = field2
-
-        def to_pack_list(self):
-            return [('I', self.field1),
-                    ('H', self.field2)]
-
-        @classmethod
-        def from_unpack_list(cls, *args):
-            return cls(*args)
-
-
-    class MyPayload(Payload):
-
-        format_list = ['I', 'H']
-
-        def __init__(self, field1, field2):
-            self.field1 = field1
-            self.field2 = field2
-
-        def to_pack_list(self):
-            return [('I', self.field1),
-                    ('H', self.field2)]
-
-        @classmethod
-        def from_unpack_list(cls, *args):
-            return cls(*args)
-
-
-    class MyVariablePayload(VariablePayload):
-
-        format_list = ['I', 'H']
-        names = ['field1', 'field2']
-
-    @vp_compile
-    class MyCVariablePayload(VariablePayload):
-
-        format_list = ['I', 'H']
-        names = ['field1', 'field2']
+.. literalinclude:: serialization_1.py
+   :lines: 8-48
 
 
 To show some of the differences, let's check out the output of the following script using these definitions:
 
 
-.. code-block:: python
-
-    serializable1 = MySerializable(1, 2)
-    serializable2 = MyPayload(1, 2)
-    serializable3 = MyVariablePayload(1, 2)
-    serializable4 = MyCVariablePayload(1, 2)
-
-    print("As string:")
-    print(serializable1)
-    print(serializable2)
-    print(serializable3)
-    print(serializable4)
-
-    print("Field values:")
-    print(serializable1.field1, serializable1.field2)
-    print(serializable2.field1, serializable2.field2)
-    print(serializable3.field1, getattr(serializable3, 'field2', '<undefined>'))
-    print(serializable4.field1, getattr(serializable4, 'field2', '<undefined>'))
-
-    print("Serialization speed:")
-    print(timeit.timeit('serializable1.to_pack_list()', number=1000, globals=locals()))
-    print(timeit.timeit('serializable2.to_pack_list()', number=1000, globals=locals()))
-    print(timeit.timeit('serializable3.to_pack_list()', number=1000, globals=locals()))
-    print(timeit.timeit('serializable4.to_pack_list()', number=1000, globals=locals()))
-
-    print("Unserialization speed:")
-    print(timeit.timeit('serializable1.from_unpack_list(1, 2)', number=1000, globals=locals()))
-    print(timeit.timeit('serializable2.from_unpack_list(1, 2)', number=1000, globals=locals()))
-    print(timeit.timeit('serializable3.from_unpack_list(1, 2)', number=1000, globals=locals()))
-    print(timeit.timeit('serializable4.from_unpack_list(1, 2)', number=1000, globals=locals()))
+.. literalinclude:: serialization_1.py
+   :lines: 51-78
 
 
 .. code-block:: bash
@@ -231,38 +161,13 @@ Once you register the message handler and have the appropriate decorator on the 
 In practice, given a ``COMMUNITY_ID`` and the payload definitions ``MyMessagePayload1`` and ``MyMessagePayload2``, this will look something like this example (see `the overlay tutorial <../../basics/overlay_tutorial>`_ for a complete runnable example):
 
 
-.. code-block:: python
+.. literalinclude:: serialization_2.py
+   :lines: 23-39
 
-    class MyCommunity(Community):
+It is recommended (but not obligatory) to have single payload messages store the message identifier inside the ``Payload.msg_id`` field, as this improves readability:
 
-        community_id = COMMUNITY_ID
-
-        def __init__(*args, **kwargs):
-            super(MyCommunity, self).__init__(*args, **kwargs)
-
-            self.add_message_handler(1, self.on_message)
-
-        @lazy_wrapper(MyMessagePayload1, MyMessagePayload2)
-        def on_message(self, peer, payload1, payload2):
-            print("Got a message from:", peer)
-            print("The message includes the first payload:\n", payload1)
-            print("The message includes the second payload:\n", payload2)
-
-        def send_message(self, peer):
-            packet = self.ezr_pack(1, MyMessagePayload1(), MyMessagePayload2())
-            self.endpoint.send(peer.address, packet)
-
-
-It is recommended (but not obligatory) to have single payload messages store the message identifier inside the ``Payload`` instance, as this improves readability:
-
-.. code-block:: python
-
-    self.add_message_handler(MyMessage1.msg_id, self.on_message)
-    self.add_message_handler(MyMessage2.msg_id, self.on_message)
-
-    self.ezr_pack(MyMessage1.msg_id, MyMessage1(42))
-    self.ezr_pack(MyMessage2.msg_id, MyMessage2(7))
-
+.. literalinclude:: serialization_3.py
+   :lines: 31,32,53,56
+   :dedent: 4
 
 Of course, IPv8 also ships with various ``Community`` subclasses of its own, if you need inspiration.
-

--- a/doc/reference/serialization_1.py
+++ b/doc/reference/serialization_1.py
@@ -1,0 +1,78 @@
+import timeit
+
+from pyipv8.ipv8.messaging.lazy_payload import VariablePayload, vp_compile
+from pyipv8.ipv8.messaging.payload import Payload
+from pyipv8.ipv8.messaging.serialization import Serializable
+
+
+class MySerializable(Serializable):
+    format_list = ['I', 'H']
+
+    def __init__(self, field1, field2):
+        self.field1 = field1
+        self.field2 = field2
+
+    def to_pack_list(self):
+        return [('I', self.field1),
+                ('H', self.field2)]
+
+    @classmethod
+    def from_unpack_list(cls, *args):
+        return cls(*args)
+
+
+class MyPayload(Payload):
+    format_list = ['I', 'H']
+
+    def __init__(self, field1, field2):
+        self.field1 = field1
+        self.field2 = field2
+
+    def to_pack_list(self):
+        return [('I', self.field1),
+                ('H', self.field2)]
+
+    @classmethod
+    def from_unpack_list(cls, *args):
+        return cls(*args)
+
+
+class MyVariablePayload(VariablePayload):
+    format_list = ['I', 'H']
+    names = ['field1', 'field2']
+
+
+@vp_compile
+class MyCVariablePayload(VariablePayload):
+    format_list = ['I', 'H']
+    names = ['field1', 'field2']
+
+
+serializable1 = MySerializable(1, 2)
+serializable2 = MyPayload(1, 2)
+serializable3 = MyVariablePayload(1, 2)
+serializable4 = MyCVariablePayload(1, 2)
+
+print("As string:")
+print(serializable1)
+print(serializable2)
+print(serializable3)
+print(serializable4)
+
+print("Field values:")
+print(serializable1.field1, serializable1.field2)
+print(serializable2.field1, serializable2.field2)
+print(serializable3.field1, getattr(serializable3, 'field2', '<undefined>'))
+print(serializable4.field1, getattr(serializable4, 'field2', '<undefined>'))
+
+print("Serialization speed:")
+print(timeit.timeit('serializable1.to_pack_list()', number=1000, globals=locals()))
+print(timeit.timeit('serializable2.to_pack_list()', number=1000, globals=locals()))
+print(timeit.timeit('serializable3.to_pack_list()', number=1000, globals=locals()))
+print(timeit.timeit('serializable4.to_pack_list()', number=1000, globals=locals()))
+
+print("Unserialization speed:")
+print(timeit.timeit('serializable1.from_unpack_list(1, 2)', number=1000, globals=locals()))
+print(timeit.timeit('serializable2.from_unpack_list(1, 2)', number=1000, globals=locals()))
+print(timeit.timeit('serializable3.from_unpack_list(1, 2)', number=1000, globals=locals()))
+print(timeit.timeit('serializable4.from_unpack_list(1, 2)', number=1000, globals=locals()))

--- a/doc/reference/serialization_2.py
+++ b/doc/reference/serialization_2.py
@@ -1,0 +1,39 @@
+import os
+
+from pyipv8.ipv8.community import Community
+from pyipv8.ipv8.lazy_community import lazy_wrapper
+from pyipv8.ipv8.messaging.lazy_payload import VariablePayload, vp_compile
+
+
+@vp_compile
+class MyMessagePayload1(VariablePayload):
+    format_list = []
+    names = []
+
+
+@vp_compile
+class MyMessagePayload2(VariablePayload):
+    format_list = []
+    names = []
+
+
+COMMUNITY_ID = os.urandom(20)
+
+
+class MyCommunity(Community):
+    community_id = COMMUNITY_ID
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.add_message_handler(1, self.on_message)
+
+    @lazy_wrapper(MyMessagePayload1, MyMessagePayload2)
+    def on_message(self, peer, payload1, payload2):
+        print("Got a message from:", peer)
+        print("The message includes the first payload:\n", payload1)
+        print("The message includes the second payload:\n", payload2)
+
+    def send_message(self, peer):
+        packet = self.ezr_pack(1, MyMessagePayload1(), MyMessagePayload2())
+        self.endpoint.send(peer.address, packet)

--- a/doc/reference/serialization_3.py
+++ b/doc/reference/serialization_3.py
@@ -1,0 +1,56 @@
+import os
+
+from pyipv8.ipv8.community import Community
+from pyipv8.ipv8.lazy_community import lazy_wrapper
+from pyipv8.ipv8.messaging.lazy_payload import VariablePayload, vp_compile
+
+
+@vp_compile
+class MyMessage1(VariablePayload):
+    msg_id = 1
+    format_list = ['I']
+    names = ['unsigned_integer_field']
+
+
+@vp_compile
+class MyMessage2(VariablePayload):
+    msg_id = 2
+    format_list = ['I']
+    names = ['unsigned_integer_field']
+
+
+COMMUNITY_ID = os.urandom(20)
+
+
+class MyCommunity(Community):
+    community_id = COMMUNITY_ID
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.add_message_handler(MyMessage1, self.on_message1)
+        self.add_message_handler(MyMessage2, self.on_message2)
+
+    @lazy_wrapper(MyMessage1)
+    def on_message1(self, peer, payload):
+        print("Got a message from:", peer)
+        print("The message includes the first payload:\n", payload)
+
+    @lazy_wrapper(MyMessage2)
+    def on_message2(self, peer, payload):
+        print("Got a message from:", peer)
+        print("The message includes the first payload:\n", payload)
+
+    def send_message1(self, peer):
+        packet = self.ezr_pack(MyMessage1.msg_id, MyMessage1(42))
+        self.endpoint.send(peer.address, packet)
+
+    def send_message2(self, peer):
+        packet = self.ezr_pack(MyMessage2.msg_id, MyMessage2(7))
+        self.endpoint.send(peer.address, packet)
+
+    def better_send_message_1(self, peer):
+        self.ez_send(peer, MyMessage1(42))
+
+    def better_send_message_2(self, peer):
+        self.ez_send(peer, MyMessage2(7))


### PR DESCRIPTION
First step for #872.

This PR:

 - Updates the documentation to include examples from stand-alone files, instead of embedding them.
 - Updates the serialization documentation to prefer `ez_send` over `ezr_pack`.

This is the "easy" part of #872. In a following PR I will add new functionality to run these examples and check for errors.
