### PR TITLE
Added hiddenimports to CommunityLauncher

### DIFF
--- a/ipv8/loader.py
+++ b/ipv8/loader.py
@@ -123,6 +123,10 @@ def overlay(str_module_or_class, str_definition=None):
     """
     def decorator(instance):
         if isinstance(str_module_or_class, str):
+            if not hasattr(instance, "hiddenimports"):
+                setattr(instance, "hiddenimports", set())
+            instance.hiddenimports.add(str_module_or_class)
+
             def get_overlay_class(_):
                 return getattr(__import__(str_module_or_class, fromlist=[str_definition]), str_definition)
         else:
@@ -165,6 +169,9 @@ def walk_strategy(str_module_or_class, str_definition=None, target_peers=20, kw_
         old_get_walk_strategies = instance.get_walk_strategies
 
         if isinstance(str_module_or_class, str):
+            if not hasattr(instance, "hiddenimports"):
+                setattr(instance, "hiddenimports", set())
+            instance.hiddenimports.add(str_module_or_class)
             strategy_class = getattr(__import__(str_module_or_class, fromlist=[str_definition]), str_definition)
         else:
             strategy_class = str_module_or_class

--- a/ipv8/test/test_loader.py
+++ b/ipv8/test/test_loader.py
@@ -146,6 +146,7 @@ class TestCommunityLauncher(TestBase):
             pass
 
         self.assertEqual(self.staged_launcher.get_overlay_class(), DecoratedCommunityLauncher().get_overlay_class())
+        self.assertSetEqual({self.__class__.__module__}, DecoratedCommunityLauncher.hiddenimports)
 
     def test_overlay_class_from_class(self):
         """
@@ -167,6 +168,7 @@ class TestCommunityLauncher(TestBase):
 
         self.assertListEqual(self.staged_launcher.get_walk_strategies(),
                              DecoratedCommunityLauncher().get_walk_strategies())
+        self.assertSetEqual({self.__class__.__module__}, DecoratedCommunityLauncher.hiddenimports)
 
     def test_walk_strategy_from_class(self):
         """
@@ -190,6 +192,7 @@ class TestCommunityLauncher(TestBase):
 
         self.assertListEqual([(MockWalk, {'some_attribute': 4}, 20), (MockWalk2, {}, -1)],
                              DecoratedCommunityLauncher().get_walk_strategies())
+        self.assertSetEqual({self.__class__.__module__}, DecoratedCommunityLauncher.hiddenimports)
 
     def test_set_in_session(self):
         """


### PR DESCRIPTION
Related to https://github.com/Tribler/tribler/issues/5647

This PR:

 - Adds a `hiddenimports` field to all `CommunityLauncher` classes to provide hints to PyInstaller about what modules will be lazy-loaded.

