### PR TITLE
Updated DHTCommunity serialization

### DIFF
--- a/doc/reference/serialization.rst
+++ b/doc/reference/serialization.rst
@@ -84,7 +84,7 @@ Datatypes
 
 Next to the unsigned integer and unsigned short data types, the default Serializer has many more data types to offer.
 The following table lists all data types available by default, all values are big-endian and most follow the default Python ``struct`` format.
-A ``Serializer`` can be extended with arbitrary ``struct`` formats by calling ``serializer.add_packing_format(name, format)`` (for example ``serializer.add_packing_format("I", ">I")``).
+A ``Serializer`` can be extended with additional data types by calling ``serializer.add_packer(name, packer)``, where ``packer`` represent the object responsible for (un)packing the data type. The most commonly used packer is ``DefaultStruct``, which can be used with arbitrary ``struct`` formats (for example ``serializer.add_packer("I", DefaultStruct(">I"))``).
 
 .. csv-table:: Available data types
    :header: "member", "bytes", "unserialized type"
@@ -102,6 +102,7 @@ A ``Serializer`` can be extended with arbitrary ``struct`` formats by calling ``
    "I", 4, "unsigned integer"
    "l", 4, "signed long"
    "LL", 8, "[unsigned long, unsigned long]"
+   "q", 8, "signed long long"
    "Q", 8, "unsigned long long"
    "QH", 10, "[unsigned long long, unsigned short]"
    "QL", 12, "[unsigned long long, unsigned long]"
@@ -114,10 +115,12 @@ A ``Serializer`` can be extended with arbitrary ``struct`` formats by calling ``
    "74s", 20, "str (length 74)"
    "c20s", 21, "[unsigned byte, str (length 20)]"
    "bits", 1, "[bit 0, bit 1, bit 2, bit 3, bit 4, bit 5, bit 6, bit 7]"
+   "ipv4", 6, "[str (length 7-15), unsigned short]"
    "raw", "?", "str (length ?)"
    "varlenBx2", "1 + ? * 2", "[str (length = 2), \.\.\. ] (length < 256)"
    "varlenH", "2 + ?", "str (length ? < 65356)"
    "varlenHx20", "2 + ? * 20", "[str (length = 20), \.\.\. ] (length < 65356)"
+   "varlenH-list", "1 + ? * (2 + ??)", "[str (length < 65356)] (length < 256)"
    "varlenI", "4 + ?", "str (length < 4294967295)"
    "doublevarlenH", "2 + ?", "str (length ? < 65356)"
    "payload", "2 + ?", "Serializable"

--- a/ipv8/dht/community.py
+++ b/ipv8/dht/community.py
@@ -8,12 +8,13 @@ from itertools import zip_longest
 
 from . import DHTError
 from .churn import PingChurn
-from .payload import (FindRequestPayload, FindResponsePayload, PingRequestPayload, PingResponsePayload,
+from .payload import (FindRequestPayload, FindResponsePayload, NodePacker, PingRequestPayload, PingResponsePayload,
                       SignedStrPayload, StoreRequestPayload, StoreResponsePayload, StrPayload)
 from .routing import Node, RoutingTable, calc_node_id, distance
 from .storage import Storage
 from ..community import Community, _DEFAULT_ADDRESSES
 from ..lazy_community import lazy_wrapper, lazy_wrapper_wd
+from ..messaging.serialization import ListOf
 from ..peerdiscovery.network import Network
 from ..requestcache import RandomNumberCache, RequestCache
 from ..taskmanager import task
@@ -171,6 +172,11 @@ class DHTCommunity(Community):
         self.add_message_handler(FindResponsePayload, self.on_find_response)
 
         self.logger.info('DHT community initialized (peer mid %s)', hexlify(self.my_peer.mid))
+
+    def get_serializer(self):
+        serializer = super().get_serializer()
+        serializer.add_packer('node-list', ListOf(NodePacker()))
+        return serializer
 
     def get_available_strategies(self):
         return {'PingChurn': PingChurn}

--- a/ipv8/dht/discovery.py
+++ b/ipv8/dht/discovery.py
@@ -8,7 +8,6 @@ from .payload import (ConnectPeerRequestPayload, ConnectPeerResponsePayload, Pin
                       StorePeerRequestPayload, StorePeerResponsePayload)
 from .routing import NODE_STATUS_BAD, Node
 from ..lazy_community import lazy_wrapper, lazy_wrapper_wd
-from ..messaging.payload_headers import GlobalTimeDistributionPayload
 
 
 class DHTDiscoveryCommunity(DHTCommunity):
@@ -30,15 +29,15 @@ class DHTDiscoveryCommunity(DHTCommunity):
         self.register_task('store_peer', self.store_peer, interval=30)
         self.register_task('ping_all', self.ping_all, interval=10)
 
-    @lazy_wrapper_wd(GlobalTimeDistributionPayload, PingRequestPayload)
-    def on_ping_request(self, peer, dist, payload, data):
+    @lazy_wrapper_wd(PingRequestPayload)
+    def on_ping_request(self, peer, payload, data):
         super(DHTDiscoveryCommunity, self).on_ping_request(peer.address, data)
         node = self.find_node_in_dict(peer.key.key_to_bin(), self.store)
         if node:
             node.last_queries.append(time.time())
 
-    @lazy_wrapper_wd(GlobalTimeDistributionPayload, PingResponsePayload)
-    def on_ping_response(self, peer, dist, payload, data):
+    @lazy_wrapper_wd(PingResponsePayload)
+    def on_ping_response(self, peer, payload, data):
         super(DHTDiscoveryCommunity, self).on_ping_response(peer.address, data)
         node = self.find_node_in_dict(peer.key.key_to_bin(), self.store_for_me)
         if node:
@@ -75,8 +74,7 @@ class DHTDiscoveryCommunity(DHTCommunity):
             if node in self.tokens:
                 cache = self.request_cache.add(Request(self, 'store-peer', node, [key]))
                 futures.append(cache.future)
-                self.send_message(node.address, StorePeerRequestPayload.msg_id, StorePeerRequestPayload,
-                                  (cache.number, self.tokens[node][1], key))
+                self.ez_send(node, StorePeerRequestPayload(cache.number, self.tokens[node][1], key))
             else:
                 self.logger.debug('Not sending store-peer-request to %s (no token available)', node)
 
@@ -116,14 +114,13 @@ class DHTDiscoveryCommunity(DHTCommunity):
         for node in nodes:
             cache = self.request_cache.add(Request(self, 'connect-peer', node))
             futures.append(cache.future)
-            self.send_message(node.address, ConnectPeerRequestPayload.msg_id,
-                              ConnectPeerRequestPayload, (cache.number, self.my_estimated_lan, key))
+            self.ez_send(node, ConnectPeerRequestPayload(cache.number, self.my_estimated_lan, key))
 
         node_lists = await gather_without_errors(*futures)
         return list(set(sum(node_lists, [])))
 
-    @lazy_wrapper(GlobalTimeDistributionPayload, StorePeerRequestPayload)
-    def on_store_peer_request(self, peer, dist, payload):
+    @lazy_wrapper(StorePeerRequestPayload)
+    def on_store_peer_request(self, peer, payload):
         self.logger.debug('Got store-peer-request from %s', peer.address)
 
         node = Node(peer.key, peer.address)
@@ -140,11 +137,10 @@ class DHTDiscoveryCommunity(DHTCommunity):
             self.logger.debug('Storing peer %s (key %s)', node, hexlify(payload.target))
             self.store[payload.target].append(node)
 
-        self.send_message(node.address, StorePeerResponsePayload.msg_id,
-                          StorePeerResponsePayload, (payload.identifier,))
+        self.ez_send(node, StorePeerResponsePayload(payload.indentifier))
 
-    @lazy_wrapper(GlobalTimeDistributionPayload, StorePeerResponsePayload)
-    def on_store_peer_response(self, peer, dist, payload):
+    @lazy_wrapper(StorePeerResponsePayload)
+    def on_store_peer_response(self, peer, payload):
         if not self.request_cache.has('store-peer', payload.identifier):
             self.logger.error('Got store-peer-response with unknown identifier, dropping packet')
             return
@@ -160,8 +156,8 @@ class DHTDiscoveryCommunity(DHTCommunity):
 
         cache.future.set_result(cache.node)
 
-    @lazy_wrapper(GlobalTimeDistributionPayload, ConnectPeerRequestPayload)
-    def on_connect_peer_request(self, peer, dist, payload):
+    @lazy_wrapper(ConnectPeerRequestPayload)
+    def on_connect_peer_request(self, peer, payload):
         self.logger.debug('Got connect-peer-request from %s', peer.address)
 
         nodes = self.store[payload.target][:MAX_NODES_IN_FIND]
@@ -170,11 +166,10 @@ class DHTDiscoveryCommunity(DHTCommunity):
             self.endpoint.send(node.address, packet)
 
         self.logger.debug('Returning peers %s (key %s)', nodes, hexlify(payload.target))
-        self.send_message(peer.address, ConnectPeerResponsePayload.msg_id,
-                          ConnectPeerResponsePayload, (payload.identifier, nodes))
+        self.ez_send(peer, ConnectPeerResponsePayload(payload.identifier, nodes))
 
-    @lazy_wrapper(GlobalTimeDistributionPayload, ConnectPeerResponsePayload)
-    def on_connect_peer_response(self, peer, dist, payload):
+    @lazy_wrapper(ConnectPeerResponsePayload)
+    def on_connect_peer_response(self, peer, payload):
         if not self.request_cache.has('connect-peer', payload.identifier):
             self.logger.error('Got connect-peer-response with unknown identifier, dropping packet')
             return

--- a/ipv8/dht/discovery.py
+++ b/ipv8/dht/discovery.py
@@ -72,7 +72,8 @@ class DHTDiscoveryCommunity(DHTCommunity):
         futures = []
         for node in nodes:
             if node in self.tokens:
-                cache = self.request_cache.add(Request(self, 'store-peer', node, [key]))
+                cache = Request(self, 'store-peer', node, [key])
+                self.request_cache.add(cache)
                 futures.append(cache.future)
                 self.ez_send(node, StorePeerRequestPayload(cache.number, self.tokens[node][1], key))
             else:
@@ -112,7 +113,8 @@ class DHTDiscoveryCommunity(DHTCommunity):
 
         futures = []
         for node in nodes:
-            cache = self.request_cache.add(Request(self, 'connect-peer', node))
+            cache = Request(self, 'connect-peer', node)
+            self.request_cache.add(cache)
             futures.append(cache.future)
             self.ez_send(node, ConnectPeerRequestPayload(cache.number, self.my_estimated_lan, key))
 

--- a/ipv8/dht/payload.py
+++ b/ipv8/dht/payload.py
@@ -1,249 +1,100 @@
 from socket import inet_aton, inet_ntoa
-from struct import calcsize, pack, unpack, unpack_from
+from struct import pack, unpack_from
 
 from .routing import Node
-from ..messaging.payload import Payload
+from ..messaging.lazy_payload import VariablePayload, vp_compile
 
 
-def encode_values(values):
-    return b''.join([pack('!H', len(value)) + value for value in values])
-
-
-def decode_values(values_str):
-    values = []
-    index = 0
-    while index < len(values_str):
-        length = unpack_from('!H', values_str, offset=index)[0]
-        index += calcsize('!H')
-        values.append(values_str[index:index + length])
-        index += length
-    return values
-
-
-def encode_nodes(nodes):
-    nodes_str = b''
-    for node in nodes:
-        key = node.public_key.key_to_bin()
-        nodes_str += inet_aton(node.address[0]) + pack("!H", node.address[1])
-        nodes_str += pack('!H', len(key)) + key
-    return nodes_str
-
-
-def decode_nodes(nodes_str):
-    nodes = []
-    index = 0
-    while index < len(nodes_str):
-        ip, port, key_length = unpack('!4sHH', nodes_str[index:index + 8])
-        index += 8
-        address = (inet_ntoa(ip), port)
-        key = nodes_str[index:index + key_length]
-        index += key_length
-        nodes.append(Node(key, address=address))
-    return nodes
-
-
-class BasePayload(Payload):
-
+@vp_compile
+class PingRequestPayload(VariablePayload):
+    msg_id = 1
+    names = ['identifier']
     format_list = ['I']
 
-    def __init__(self, identifier):
-        super(BasePayload, self).__init__()
-        self.identifier = identifier
 
-    def to_pack_list(self):
-        return [('I', self.identifier)]
-
-    @classmethod
-    def from_unpack_list(cls, identifier):
-        return BasePayload(identifier)
+@vp_compile
+class PingResponsePayload(VariablePayload):
+    msg_id = 2
+    names = ['identifier']
+    format_list = ['I']
 
 
-class PingRequestPayload(BasePayload):
+@vp_compile
+class StoreRequestPayload(VariablePayload):
+    msg_id = 3
+    names = ['identifier', 'token', 'target', 'values']
+    format_list = ['I', '20s', '20s', 'varlenH-list']
+
+
+@vp_compile
+class StoreResponsePayload(VariablePayload):
+    msg_id = 4
+    names = ['identifier']
+    format_list = ['I']
+
+
+@vp_compile
+class FindRequestPayload(VariablePayload):
+    msg_id = 5
+    names = ['identifier', 'lan_address', 'target', 'offset', 'force_nodes']
+    format_list = ['I', 'ipv4', '20s', 'I', '?']
+
+
+@vp_compile
+class FindResponsePayload(VariablePayload):
+    msg_id = 6
+    names = ['identifier', 'token', 'values', 'nodes']
+    format_list = ['I', '20s', 'varlenH-list', 'node-list']
+
+
+@vp_compile
+class StorePeerRequestPayload(VariablePayload):
     msg_id = 7
+    names = ['identifier', 'token', 'target']
+    format_list = ['I', '20s', '20s']
 
 
-class PingResponsePayload(BasePayload):
+@vp_compile
+class StorePeerResponsePayload(VariablePayload):
     msg_id = 8
+    names = ['identifier']
+    format_list = ['I']
 
 
-class StoreRequestPayload(BasePayload):
-
+@vp_compile
+class ConnectPeerRequestPayload(VariablePayload):
     msg_id = 9
-    format_list = BasePayload.format_list + ['20s', '20s', 'varlenH']
-
-    def __init__(self, identifier, token, target, values):
-        super(StoreRequestPayload, self).__init__(identifier)
-        self.token = token
-        self.target = target
-        self.values = values
-
-    def to_pack_list(self):
-        data = super(StoreRequestPayload, self).to_pack_list()
-        data.append(('20s', self.token))
-        data.append(('20s', self.target))
-        data.append(('varlenH', encode_values(self.values)))
-        return data
-
-    @classmethod
-    def from_unpack_list(cls, identifier, token, target, values_str):
-        values = decode_values(values_str)
-        return StoreRequestPayload(identifier, token, target, values)
+    names = ['identifier', 'lan_address', 'target']
+    format_list = ['I', 'ipv4', '20s']
 
 
-class StoreResponsePayload(BasePayload):
+@vp_compile
+class ConnectPeerResponsePayload(VariablePayload):
     msg_id = 10
+    names = ['identifier', 'nodes']
+    format_list = ['I', 'node-list']
 
 
-class FindRequestPayload(BasePayload):
-
-    msg_id = 11
-    format_list = BasePayload.format_list + ['varlenI', '20s', 'I', '?']
-
-    def __init__(self, identifier, lan_address, target, offset, force_nodes):
-        super(FindRequestPayload, self).__init__(identifier)
-        self.lan_address = lan_address
-        self.target = target
-        self.offset = offset
-        self.force_nodes = force_nodes
-
-    def to_pack_list(self):
-        data = super(FindRequestPayload, self).to_pack_list()
-        data.append(('varlenI', inet_aton(self.lan_address[0]) + pack("!H", self.lan_address[1])))
-        data.append(('20s', self.target))
-        data.append(('I', self.offset))
-        data.append(('?', self.force_nodes))
-        return data
-
-    @classmethod
-    def from_unpack_list(cls, identifier, lan_address, target, offset, force_nodes):
-        return FindRequestPayload(identifier,
-                                  (inet_ntoa(lan_address[:4]), unpack('!H', lan_address[4:6])[0]),
-                                  target,
-                                  offset,
-                                  force_nodes)
-
-
-class FindResponsePayload(BasePayload):
-
-    msg_id = 12
-    format_list = BasePayload.format_list + ['20s', 'varlenH', 'varlenH']
-
-    def __init__(self, identifier, token, values, nodes):
-        super(FindResponsePayload, self).__init__(identifier)
-        self.token = token
-        self.values = values
-        self.nodes = nodes
-
-    def to_pack_list(self):
-        data = super(FindResponsePayload, self).to_pack_list()
-        data.append(('20s', self.token))
-        data.append(('varlenH', encode_values(self.values)))
-        data.append(('varlenH', encode_nodes(self.nodes)))
-        return data
-
-    @classmethod
-    def from_unpack_list(cls, identifier, token, values_str, nodes_str):
-        return FindResponsePayload(identifier, token, decode_values(values_str), decode_nodes(nodes_str))
-
-
-class StrPayload(Payload):
-
+@vp_compile
+class StrPayload(VariablePayload):
+    names = ['data']
     format_list = ['raw']
 
-    def __init__(self, data):
-        super(StrPayload, self).__init__()
-        self.data = data
 
-    def to_pack_list(self):
-        return [('raw', self.data)]
-
-    @classmethod
-    def from_unpack_list(cls, data):
-        return StrPayload(data)
-
-
-class SignedStrPayload(Payload):
-
+@vp_compile
+class SignedStrPayload(VariablePayload):
+    names = ['data', 'version', 'public_key']
     format_list = ['varlenH', 'I', 'varlenH']
 
-    def __init__(self, data, version, public_key):
-        super(SignedStrPayload, self).__init__()
-        self.data = data
-        self.version = version
-        self.public_key = public_key
 
-    def to_pack_list(self):
-        return [('varlenH', self.data),
-                ('I', self.version),
-                ('varlenH', self.public_key)]
+class NodePacker:
 
-    @classmethod
-    def from_unpack_list(cls, data, version, public_key):
-        return SignedStrPayload(data, version, public_key)
+    def pack(self, node):
+        key = node.public_key.key_to_bin()
+        return pack('>4sHH', inet_aton(node.address[0]), node.address[1], len(key)) + key
 
-
-class StorePeerRequestPayload(BasePayload):
-
-    msg_id = 13
-    format_list = BasePayload.format_list + ['20s', '20s']
-
-    def __init__(self, identifier, token, target):
-        super(StorePeerRequestPayload, self).__init__(identifier)
-        self.token = token
-        self.target = target
-
-    def to_pack_list(self):
-        data = super(StorePeerRequestPayload, self).to_pack_list()
-        data.append(('20s', self.token))
-        data.append(('20s', self.target))
-        return data
-
-    @classmethod
-    def from_unpack_list(cls, identifier, token, target):
-        return StorePeerRequestPayload(identifier, token, target)
-
-
-class StorePeerResponsePayload(BasePayload):
-    msg_id = 14
-
-
-class ConnectPeerRequestPayload(BasePayload):
-
-    msg_id = 15
-    format_list = BasePayload.format_list + ['varlenI', '20s']
-
-    def __init__(self, identifier, lan_address, target):
-        super(ConnectPeerRequestPayload, self).__init__(identifier)
-        self.lan_address = lan_address
-        self.target = target
-
-    def to_pack_list(self):
-        data = super(ConnectPeerRequestPayload, self).to_pack_list()
-        data.append(('varlenI', inet_aton(self.lan_address[0]) + pack("!H", self.lan_address[1])))
-        data.append(('20s', self.target))
-        return data
-
-    @classmethod
-    def from_unpack_list(cls, identifier, lan_address, target):
-        return ConnectPeerRequestPayload(identifier,
-                                         (inet_ntoa(lan_address[:4]), unpack('!H', lan_address[4:6])[0]),
-                                         target)
-
-
-class ConnectPeerResponsePayload(BasePayload):
-
-    msg_id = 16
-    format_list = BasePayload.format_list + ['varlenH']
-
-    def __init__(self, identifier, nodes):
-        super(ConnectPeerResponsePayload, self).__init__(identifier)
-        self.nodes = nodes
-
-    def to_pack_list(self):
-        data = super(ConnectPeerResponsePayload, self).to_pack_list()
-        data.append(('varlenH', encode_nodes(self.nodes)))
-        return data
-
-    @classmethod
-    def from_unpack_list(cls, identifier, nodes):
-        return ConnectPeerResponsePayload(identifier, decode_nodes(nodes))
+    def unpack(self, data, offset, unpack_list):
+        ip, port, key_length = unpack_from('>4sHH', data, offset)
+        offset += 8
+        unpack_list.append(Node(data[offset:offset + key_length], address=(inet_ntoa(ip), port)))
+        return offset + key_length

--- a/ipv8/lazy_community.py
+++ b/ipv8/lazy_community.py
@@ -49,7 +49,7 @@ def lazy_wrapper_wd(*payloads):
 
     ::
 
-        @lazy_wrapper(IntroductionRequestPayload, IntroductionResponsePayload)
+        @lazy_wrapper_wd(IntroductionRequestPayload, IntroductionResponsePayload)
         def on_message(peer, payload1, payload2, data):
             '''
             :type peer: Peer

--- a/ipv8/messaging/serialization.py
+++ b/ipv8/messaging/serialization.py
@@ -212,14 +212,14 @@ class Serializer(object):
         """
         return self._packers[name]
 
-    def add_packing_format(self, name, format):
+    def add_packer(self, name, packer):
         """
-        Register a new struct packing format with a certain name.
+        Register a new packer with a certain name.
 
         :param name: the name to register
-        :param format: the format to use for it
+        :param packer: the packer to use for it
         """
-        self._packers.update({name: DefaultStruct(format)})
+        self._packers[name] = packer
 
     def pack_serializable(self, serializable):
         """

--- a/ipv8/messaging/serialization.py
+++ b/ipv8/messaging/serialization.py
@@ -1,5 +1,6 @@
 import abc
 from binascii import hexlify
+from socket import inet_aton, inet_ntoa
 from struct import Struct, pack, unpack_from
 
 
@@ -129,7 +130,7 @@ class Raw(object):
 
 class VarLen(object):
     """
-    Paste/unpack from an encoded length + data string.
+    Pack/unpack from an encoded length + data string.
     """
 
     def __init__(self, length_format, base=1):
@@ -144,6 +145,41 @@ class VarLen(object):
         str_length = unpack_from(self.length_format, data, offset)[0] * self.base
         unpack_list.append(data[offset + self.length_size: offset + self.length_size + str_length])
         return offset + self.length_size + str_length
+
+
+class IPv4:
+    """
+    Pack/unpack an IPv4 address
+    """
+
+    def pack(self, data):
+        return pack('>4sH', inet_aton(data[0]), data[1])
+
+    def unpack(self, data, offset, unpack_list):
+        host_bytes, port = unpack_from('>4sH', data, offset)
+        unpack_list.append((inet_ntoa(host_bytes), port))
+        return offset + 6
+
+
+class ListOf:
+
+    def __init__(self, packer, length_format='>B'):
+        self.packer = packer
+        self.length_format = length_format
+        self.length_size = Struct(length_format).size
+
+    def pack(self, data):
+        return pack(self.length_format, len(data)) + b''.join([self.packer.pack(item) for item in data])
+
+    def unpack(self, data, offset, unpack_list):
+        length, = unpack_from(self.length_format, data, offset)
+        offset += self.length_size
+
+        result = []
+        unpack_list.append(result)
+        for _ in range(length):
+            offset = self.packer.unpack(data, offset, result)
+        return offset
 
 
 class DefaultStruct:
@@ -191,10 +227,12 @@ class Serializer(object):
             '74s': DefaultStruct(">74s"),
             'c20s': DefaultStruct(">c20s"),
             'bits': Bits(),
+            'ipv4': IPv4(),
             'raw': Raw(),
             'varlenBx2': VarLen('>B', 2),
             'varlenH': VarLen('>H'),
             'varlenHx20': VarLen('>H', 20),
+            'varlenH-list': ListOf(VarLen('>H')),
             'varlenI': VarLen('>I'),
             'doublevarlenH': VarLen('>H'),
             'payload': NestedPayload(self)

--- a/ipv8/test/messaging/test_serialization.py
+++ b/ipv8/test/messaging/test_serialization.py
@@ -1,7 +1,7 @@
 import struct
 
 from ..base import TestBase
-from ...messaging.serialization import PackError, Serializable, Serializer
+from ...messaging.serialization import DefaultStruct, PackError, Serializable, Serializer
 
 
 class Short(Serializable):
@@ -111,11 +111,11 @@ class TestSerializer(TestBase):
             self.assertTrue(hasattr(packer, 'unpack'), msg='%s has no unpack() method' % pack_name)
             self.assertTrue(callable(getattr(packer, 'unpack')), msg='%s.unpack is not a method' % pack_name)
 
-    def test_add_format(self):
+    def test_add_packer(self):
         """
-        Check if we can add a format on the fly.
+        Check if we can add a packer on the fly.
         """
-        self.serializer.add_packing_format("H_LE", "<H")  # little-endian
+        self.serializer.add_packer("H_LE", DefaultStruct("<H"))  # little-endian
 
         serialized = self.serializer.get_packer_for("H_LE").pack(1)  # Packed as 01 00
 


### PR DESCRIPTION
This PR:
* Adds the ability to register new packers with the `Serializer`.
* Adds `ListOf` that allows for almost any packer (except for `NestedPayload` and `Raw`) to be turned into a list.
 Now you can do stuff like `serializer.add_packer('infohashes', ListOf(DefaultStruct('20s')))`.
Besides its use in the `DHTCommunity`, I'd also like to use it in the `TunnelCommunity` payloads and get rid of `encode`/`decode`.
* Adds `ipv4` packer as an alternative to `4SH`. The advantage of this packer is that it deals with IP address serialization and avoids the use of `fix_` functions.
* Removes global time from DHT payloads  Since we're breaking the tunnel protocol by changing the payout mechanism in Tribler, this is a good time to update the DHT protocol.
* Removes `send_message` from the `DHTCommunity` and uses `ez_send` instead.
* Improved the way the `DHTCommunity` deals with the possibility of `RequestCache.add` returning `None`.