### PR TITLE
Added static typing support

### DIFF
--- a/ipv8/REST/base_endpoint.py
+++ b/ipv8/REST/base_endpoint.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import typing
 
 from aiohttp import web
 
@@ -10,7 +11,7 @@ HTTP_CONFLICT = 409
 HTTP_PRECONDITION_FAILED = 412
 HTTP_INTERNAL_SERVER_ERROR = 500
 
-DEFAULT_HEADERS = {}
+DEFAULT_HEADERS: typing.Dict[str, str] = {}
 
 
 class BaseEndpoint:

--- a/ipv8/attestation/identity/attestation.py
+++ b/ipv8/attestation/identity/attestation.py
@@ -1,13 +1,11 @@
+from __future__ import annotations
+
 import binascii
 import struct
 import typing
 
-from .metadata import Metadata
 from ..signed_object import AbstractSignedObject
-from ...keyvault.keys import PrivateKey
-
-
-AttestationType = typing.TypeVar('AttestationType', bound='Attestation')
+from ...types import Metadata, PrivateKey, PublicKey
 
 
 class Attestation(AbstractSignedObject):
@@ -29,13 +27,13 @@ class Attestation(AbstractSignedObject):
         return self.metadata_pointer
 
     @classmethod
-    def unserialize(cls, data, public_key, offset=0) -> AttestationType:
+    def unserialize(cls, data: bytes, public_key: PublicKey, offset: int = 0) -> Attestation:
         sig_len = public_key.get_signature_length()
         metadata_pointer, signature = struct.unpack_from(f">32s{sig_len}s", data, offset=offset)
         return Attestation(metadata_pointer, signature=signature)
 
     @classmethod
-    def create(cls, metadata: Metadata, private_key: PrivateKey) -> AttestationType:
+    def create(cls, metadata: Metadata, private_key: PrivateKey) -> Attestation:
         return Attestation(metadata.get_hash(), private_key=private_key)
 
     def to_database_tuple(self) -> typing.Tuple[bytes, bytes]:
@@ -49,7 +47,7 @@ class Attestation(AbstractSignedObject):
     @classmethod
     def from_database_tuple(cls,
                             metadata_pointer: bytes,
-                            signature: bytes) -> AttestationType:
+                            signature: bytes) -> Attestation:
         """
         Create a Token from a two-byte-string representation (metadata hash and signature).
 

--- a/ipv8/attestation/identity/community.py
+++ b/ipv8/attestation/identity/community.py
@@ -5,18 +5,14 @@ from binascii import hexlify, unhexlify
 from time import time
 
 from .attestation import Attestation
-from .database import Credential
-from .manager import IdentityManager, PseudonymManager
-from .metadata import Metadata
+from .manager import IdentityManager
 from .payload import AttestPayload, DiclosePayload, MissingResponsePayload, RequestMissingPayload
 from ...community import Community, DEFAULT_MAX_PEERS
-from ...keyvault.keys import PrivateKey, PublicKey
 from ...lazy_community import lazy_wrapper
-from ...messaging.interfaces.endpoint import Endpoint
 from ...peer import Peer
 from ...peerdiscovery.discovery import RandomWalk
 from ...peerdiscovery.network import Network
-
+from ...types import Credential, Endpoint, Metadata, PrivateKey, PseudonymManager, PublicKey
 
 SAFE_UDP_PACKET_LENGTH = 1296
 
@@ -25,8 +21,8 @@ class IdentityCommunity(Community):
 
     community_id = unhexlify('d5889074c1e4c50423cdb6e9307ee0ca5695ead7')
 
-    def __init__(self, my_peer, endpoint, network=None, max_peers=DEFAULT_MAX_PEERS,
-                 anonymize=True, identity_manager=None, working_directory="."):
+    def __init__(self, my_peer: Peer, endpoint: Endpoint, network: Network = None, max_peers: int = DEFAULT_MAX_PEERS,
+                 anonymize: bool = True, identity_manager: IdentityManager = None, working_directory: str = "."):
         if network is None:
             network = Network()
         super(IdentityCommunity, self).__init__(my_peer, endpoint, network, max_peers, anonymize)
@@ -66,7 +62,7 @@ class IdentityCommunity(Community):
         self.add_message_handler(RequestMissingPayload, self.on_request_missing)
         self.add_message_handler(MissingResponsePayload, self.on_missing_response)
 
-    def pad_hash(self, attribute_hash):
+    def pad_hash(self, attribute_hash: bytes) -> bytes:
         """
         Pad an old-style SHA-1 hash into the new 32 byte SHA3-256 space.
         """
@@ -187,7 +183,7 @@ class IdentityCommunity(Community):
                                           attribute_hash: bytes,
                                           name: str,
                                           block_type: str = "id_metadata",
-                                          metadata: typing.Optional[dict] = None):
+                                          metadata: typing.Optional[dict] = None) -> None:
         """
         Request a peer to sign for our attestation advertisement.
         :param peer: the attestor of our block

--- a/ipv8/attestation/identity/database.py
+++ b/ipv8/attestation/identity/database.py
@@ -187,12 +187,12 @@ class IdentityDatabase(Database):
     def check_database(self, database_version: str) -> int:
         assert database_version.isdigit()
         assert int(database_version) >= 0
-        database_version = int(database_version) or self.LATEST_DB_VERSION
+        database_version_num = int(database_version) or self.LATEST_DB_VERSION
 
         # This is where an existing schema would be upgraded.
         # As no changes have been made, there is nothing to upgrade.
 
-        self.executescript(self.get_schema(database_version))
+        self.executescript(self.get_schema(database_version_num))
         self.commit()
 
         return self.LATEST_DB_VERSION

--- a/ipv8/attestation/identity/database.py
+++ b/ipv8/attestation/identity/database.py
@@ -4,7 +4,7 @@ from .attestation import Attestation
 from .metadata import Metadata
 from ..tokentree.token import Token
 from ...database import Database
-from ...keyvault.keys import PublicKey
+from ...types import PublicKey
 
 
 class Credential(object):

--- a/ipv8/attestation/identity/manager.py
+++ b/ipv8/attestation/identity/manager.py
@@ -7,10 +7,10 @@ import typing
 from .attestation import Attestation
 from .database import Credential, IdentityDatabase
 from .metadata import Metadata
-from ..tokentree.token import Token
 from ..tokentree.tree import TokenTree
 from ...keyvault.crypto import ECCrypto
-from ...keyvault.keys import PrivateKey, PublicKey
+from ...keyvault.keys import PrivateKey
+from ...types import PublicKey, Token
 
 
 class PseudonymManager(object):

--- a/ipv8/attestation/identity/manager.py
+++ b/ipv8/attestation/identity/manager.py
@@ -63,6 +63,7 @@ class PseudonymManager(object):
                 out = Credential(metadata, valid_attestations)
                 self.credentials.append(out)
                 return out
+        return None
 
     def add_attestation(self, public_key: PublicKey, attestation: Attestation) -> bool:
         """
@@ -104,7 +105,7 @@ class PseudonymManager(object):
         preceding = None if after is None else self.tree.elements.get(after.token_pointer, None)
         token = self.tree.add_by_hash(attestation_hash, preceding)
         metadata = Metadata(token.get_hash(), json.dumps(metadata_json).encode(), self.tree.private_key)
-        return self.add_credential(token, metadata, set())
+        return self.add_credential(token, metadata, set())  # type:ignore
 
     def get_credential(self, metadata: Metadata) -> Credential:
         """

--- a/ipv8/attestation/identity/metadata.py
+++ b/ipv8/attestation/identity/metadata.py
@@ -1,13 +1,11 @@
+from __future__ import annotations
+
 import binascii
 import json
 import typing
 
 from ..signed_object import AbstractSignedObject
-from ..tokentree.token import Token
-from ...keyvault.keys import PrivateKey
-
-
-MetadataType = typing.TypeVar('MetadataType', bound='Metadata')
+from ...types import PrivateKey, Token
 
 
 class Metadata(AbstractSignedObject):
@@ -47,14 +45,14 @@ class Metadata(AbstractSignedObject):
         return self.token_pointer + self.serialized_json_dict
 
     @classmethod
-    def unserialize(cls, data, public_key, offset=0) -> MetadataType:
+    def unserialize(cls, data, public_key, offset=0) -> Metadata:
         if offset != 0:
             raise RuntimeError("Offset is not supported for Metadata!")
         sig_len = public_key.get_signature_length()
         return Metadata(data[:32], data[32:-sig_len], signature=data[-sig_len:])
 
     @classmethod
-    def create(cls, token: Token, json_dict: dict, private_key: PrivateKey) -> MetadataType:
+    def create(cls, token: Token, json_dict: dict, private_key: PrivateKey) -> Metadata:
         return Metadata(token.get_hash(), json.dumps(json_dict).encode(), private_key=private_key)
 
     def to_database_tuple(self) -> typing.Tuple[bytes, bytes, bytes]:
@@ -69,7 +67,7 @@ class Metadata(AbstractSignedObject):
     def from_database_tuple(cls,
                             token_pointer: bytes,
                             signature: bytes,
-                            serialized_json_dict: bytes) -> MetadataType:
+                            serialized_json_dict: bytes) -> Metadata:
         """
         Create a Token from a three-byte-string representation (token hash, signature and json dictionary).
 

--- a/ipv8/attestation/identity/payload.py
+++ b/ipv8/attestation/identity/payload.py
@@ -7,12 +7,19 @@ class DiclosePayload(VariablePayload):
     format_list = ['varlenH', 'varlenH', 'varlenH', 'varlenH']
     names = ['metadata', 'tokens', 'attestations', 'authorities']
 
+    metadata: bytes
+    tokens: bytes
+    attestations: bytes
+    authorities: bytes
+
 
 @vp_compile
 class AttestPayload(VariablePayload):
     msg_id = 2
     format_list = ['varlenH']
     names = ['attestation']
+
+    attestation: bytes
 
 
 @vp_compile
@@ -21,9 +28,13 @@ class RequestMissingPayload(VariablePayload):
     format_list = ['I']
     names = ['known']
 
+    known: int
+
 
 @vp_compile
 class MissingResponsePayload(VariablePayload):
     msg_id = 4
     format_list = ['raw']
     names = ['tokens']
+
+    tokens: bytes

--- a/ipv8/attestation/schema/manager.py
+++ b/ipv8/attestation/schema/manager.py
@@ -1,3 +1,5 @@
+import typing
+
 from ...types import IdentityAlgorithmClass
 
 
@@ -12,8 +14,8 @@ class SchemaManager(object):
         """
         super(SchemaManager, self).__init__()
 
-        self.formats = dict()
-        self.algorithms = dict()
+        self.formats: typing.Dict[str, typing.Dict[str, typing.Any]] = dict()
+        self.algorithms: typing.Dict[str, IdentityAlgorithmClass] = dict()
 
     def get_algorithm_class(self, algorithm_name: str) -> IdentityAlgorithmClass:
         """
@@ -31,7 +33,7 @@ class SchemaManager(object):
         # Lazy load
         if algorithm_name == "bonehexact":
             from ..wallet.bonehexact.algorithm import BonehExactAlgorithm
-            algorithm = BonehExactAlgorithm
+            algorithm: IdentityAlgorithmClass = BonehExactAlgorithm
         elif algorithm_name == "pengbaorange":
             from ..wallet.pengbaorange.algorithm import PengBaoRangeAlgorithm
             algorithm = PengBaoRangeAlgorithm
@@ -72,7 +74,7 @@ class SchemaManager(object):
         """
         from ..default_identity_formats import FORMATS
         for schema in FORMATS:
-            self.register_schema(schema, FORMATS[schema]["algorithm"], FORMATS[schema])
+            self.register_schema(schema, FORMATS[schema]["algorithm"], FORMATS[schema])  # type:ignore
 
     def get_algorithm_instance(self, schema_name: str):
         """

--- a/ipv8/attestation/schema/manager.py
+++ b/ipv8/attestation/schema/manager.py
@@ -1,6 +1,4 @@
-from typing import Type
-
-from ..identity_formats import IdentityAlgorithm
+from ...types import IdentityAlgorithmClass
 
 
 class SchemaManager(object):
@@ -17,7 +15,7 @@ class SchemaManager(object):
         self.formats = dict()
         self.algorithms = dict()
 
-    def get_algorithm_class(self, algorithm_name: str) -> Type[IdentityAlgorithm]:
+    def get_algorithm_class(self, algorithm_name: str) -> IdentityAlgorithmClass:
         """
         Get the implementation belonging to a certain algorithm name.
         These are bound to either:

--- a/ipv8/attestation/signed_object.py
+++ b/ipv8/attestation/signed_object.py
@@ -4,7 +4,7 @@ import struct
 import typing
 
 from ..keyvault.crypto import ECCrypto
-from ..keyvault.keys import PrivateKey, PublicKey
+from ..types import PrivateKey, PublicKey
 
 T = typing.TypeVar('T')
 

--- a/ipv8/attestation/tokentree/token.py
+++ b/ipv8/attestation/tokentree/token.py
@@ -38,7 +38,7 @@ class Token(AbstractSignedObject):
         :param signature: the signature for this Token.
         """
         if content is not None and content_hash is None:
-            self.content = content
+            self.content: typing.Optional[bytes] = content
             self.content_hash = hashlib.sha3_256(content).digest()
         elif content is None and content_hash is not None:
             self.content = None
@@ -79,7 +79,7 @@ class Token(AbstractSignedObject):
     def create(cls, previous_token: Token, content: bytes, private_key: PrivateKey) -> Token:
         return Token(previous_token.get_hash(), content, private_key=private_key)
 
-    def to_database_tuple(self) -> typing.Tuple[bytes, bytes, bytes, bytes]:
+    def to_database_tuple(self) -> typing.Tuple[bytes, bytes, bytes, typing.Optional[bytes]]:
         """
         Get a representation of this Token as four byte strings (previous hash, signature, content hash and content).
 

--- a/ipv8/attestation/tokentree/token.py
+++ b/ipv8/attestation/tokentree/token.py
@@ -1,13 +1,12 @@
+from __future__ import annotations
+
 import binascii
 import hashlib
 import struct
 import typing
 
 from ..signed_object import AbstractSignedObject
-from ...keyvault.keys import PrivateKey
-
-
-TokenType = typing.TypeVar('TokenType', bound='Token')
+from ...types import PrivateKey
 
 
 class Token(AbstractSignedObject):
@@ -58,7 +57,7 @@ class Token(AbstractSignedObject):
         return self.previous_token_hash + self.content_hash
 
     @classmethod
-    def unserialize(cls, data, public_key, offset=0) -> TokenType:
+    def unserialize(cls, data, public_key, offset=0) -> Token:
         sig_len = public_key.get_signature_length()
         previous_token_hash, content_hash, signature = struct.unpack_from(f">32s32s{sig_len}s", data, offset=offset)
         return Token(previous_token_hash, content_hash=content_hash, signature=signature)
@@ -77,7 +76,7 @@ class Token(AbstractSignedObject):
         return False
 
     @classmethod
-    def create(cls, previous_token: TokenType, content: bytes, private_key: PrivateKey) -> TokenType:
+    def create(cls, previous_token: Token, content: bytes, private_key: PrivateKey) -> Token:
         return Token(previous_token.get_hash(), content, private_key=private_key)
 
     def to_database_tuple(self) -> typing.Tuple[bytes, bytes, bytes, bytes]:
@@ -93,7 +92,7 @@ class Token(AbstractSignedObject):
                             previous_token_hash: bytes,
                             signature: bytes,
                             content_hash: bytes,
-                            content: typing.Optional[bytes]) -> TokenType:
+                            content: typing.Optional[bytes]) -> Token:
         """
         Create a Token from a four-byte-string representation (previous hash, signature, content hash and content).
 

--- a/ipv8/attestation/tokentree/tree.py
+++ b/ipv8/attestation/tokentree/tree.py
@@ -1,7 +1,7 @@
 import logging
 from collections import OrderedDict
 from hashlib import sha3_256
-from typing import List, Optional, Set
+from typing import Dict, List, Optional, Set
 
 from .token import Token
 from ...types import PrivateKey, PublicKey
@@ -32,8 +32,8 @@ class TokenTree(object):
         super(TokenTree, self).__init__()
         self._logger = logging.getLogger(self.__class__.__name__)
 
-        self.elements = {}
-        self.unchained = OrderedDict()
+        self.elements: Dict[bytes, Token] = {}
+        self.unchained: OrderedDict = OrderedDict()
         self.unchained_max_size = 100
 
         if public_key is not None and private_key is None:

--- a/ipv8/attestation/tokentree/tree.py
+++ b/ipv8/attestation/tokentree/tree.py
@@ -1,13 +1,10 @@
 import logging
 from collections import OrderedDict
 from hashlib import sha3_256
-from typing import List, Optional, Set, TypeVar
+from typing import List, Optional, Set
 
 from .token import Token
-from ...keyvault.keys import PrivateKey, PublicKey
-
-
-TokenTreeType = TypeVar('TokenTreeType', bound='TokenTree')
+from ...types import PrivateKey, PublicKey
 
 
 class TokenTree(object):

--- a/ipv8/attestation/wallet/irmaexact/gabi/builder.py
+++ b/ipv8/attestation/wallet/irmaexact/gabi/builder.py
@@ -7,7 +7,7 @@ The authors of this file are not -in any way- affiliated with the original autho
 """
 from random import randint
 
-from cryptography.hazmat.primitives.asymmetric.rsa import _modinv
+from cryptography.hazmat.primitives.asymmetric.rsa import _modinv  # type:ignore
 
 from .credential import Credential
 from .keys import CLSignature, DefaultSystemParameters, signMessageBlockAndCommitment

--- a/ipv8/attestation/wallet/irmaexact/gabi/keys.py
+++ b/ipv8/attestation/wallet/irmaexact/gabi/keys.py
@@ -9,7 +9,7 @@ The authors of this file are not -in any way- affiliated with the original autho
 from binascii import hexlify
 from os import urandom
 
-from cryptography.hazmat.primitives.asymmetric.rsa import _modinv
+from cryptography.hazmat.primitives.asymmetric.rsa import _modinv  # type:ignore
 
 from .. import secure_randint
 from ...primitives.attestation import sha256_as_int

--- a/ipv8/attestation/wallet/irmaexact/gabi/proofs.py
+++ b/ipv8/attestation/wallet/irmaexact/gabi/proofs.py
@@ -5,7 +5,7 @@ All rights reserved.
 This source code has been ported from https://github.com/privacybydesign/gabi
 The authors of this file are not -in any way- affiliated with the original authors or organizations.
 """
-from cryptography.hazmat.primitives.asymmetric.rsa import _modinv
+from cryptography.hazmat.primitives.asymmetric.rsa import _modinv  # type:ignore
 
 from pyasn1.codec.ber.encoder import encode
 from pyasn1.type import univ

--- a/ipv8/attestation/wallet/primitives/value.py
+++ b/ipv8/attestation/wallet/primitives/value.py
@@ -1,4 +1,4 @@
-from cryptography.hazmat.primitives.asymmetric.rsa import _modinv
+from cryptography.hazmat.primitives.asymmetric.rsa import _modinv  # type:ignore
 
 
 def format_polynomial(a, b, c):

--- a/ipv8/configuration.py
+++ b/ipv8/configuration.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import copy
 import enum
 import socket
@@ -131,9 +133,6 @@ class WalkerDefinition(typing.NamedTuple):
     init: dict
 
 
-ConfigBuilderType = typing.TypeVar('ConfigBuilderType', bound='ConfigBuilder')
-
-
 class ConfigBuilder(object):
 
     def __init__(self, clean: bool = False):
@@ -184,21 +183,21 @@ class ConfigBuilder(object):
 
         return self.config
 
-    def clear_keys(self) -> ConfigBuilderType:
+    def clear_keys(self) -> ConfigBuilder:
         """
         Remove all keys in the current configuration.
         """
         self.config['keys'] = []
         return self
 
-    def clear_overlays(self) -> ConfigBuilderType:
+    def clear_overlays(self) -> ConfigBuilder:
         """
         Remove all overlays in the current configuration.
         """
         self.config['overlays'] = []
         return self
 
-    def set_address(self, address: str) -> ConfigBuilderType:
+    def set_address(self, address: str) -> ConfigBuilder:
         """
         Set the address IPv8 is to try and bind to.
 
@@ -209,7 +208,7 @@ class ConfigBuilder(object):
         self.config['address'] = address
         return self
 
-    def set_port(self, port: int) -> ConfigBuilderType:
+    def set_port(self, port: int) -> ConfigBuilder:
         """
         Set the port that IPv8 should TRY to bind to.
         If your port is not available, IPv8 will try and find another one.
@@ -217,7 +216,7 @@ class ConfigBuilder(object):
         self.config['port'] = port
         return self
 
-    def set_log_level(self, log_level: str) -> ConfigBuilderType:
+    def set_log_level(self, log_level: str) -> ConfigBuilder:
         """
         Set the log level for all of IPv8's loggers.
         Choose from 'CRITICAL', 'ERROR', 'WARNING', 'INFO', 'DEBUG' or 'NOTSET'.
@@ -226,7 +225,7 @@ class ConfigBuilder(object):
         self.config['logger'] = {'level': log_level}
         return self
 
-    def set_working_directory(self, folder_path: str) -> ConfigBuilderType:
+    def set_working_directory(self, folder_path: str) -> ConfigBuilder:
         """
         Set the common working directory for overlays.
 
@@ -235,7 +234,7 @@ class ConfigBuilder(object):
         self.config['working_directory'] = folder_path
         return self
 
-    def set_walker_interval(self, interval: float) -> ConfigBuilderType:
+    def set_walker_interval(self, interval: float) -> ConfigBuilder:
         """
         Set the interval, in seconds, at which IPv8 schedules its strategies.
 
@@ -246,7 +245,7 @@ class ConfigBuilder(object):
         self.config['walker_interval'] = interval
         return self
 
-    def add_key(self, alias: str, generation: str, file_path: str) -> ConfigBuilderType:
+    def add_key(self, alias: str, generation: str, file_path: str) -> ConfigBuilder:
         """
         Add a key by alias and mode of generation, to be stored at a certain file path.
 
@@ -270,7 +269,7 @@ class ConfigBuilder(object):
                     walkers: typing.List[WalkerDefinition],
                     initialize: typing.Dict[str, typing.Any],
                     on_start: typing.List[tuple],
-                    allow_duplicate: bool = False) -> ConfigBuilderType:
+                    allow_duplicate: bool = False) -> ConfigBuilder:
         """
         Add an overlay by its class name. You can choose from the default communities or register your own (see IPv8's
         ``extra_communities`` for the latter). Whatever key alias you choose for this overlay should be registered

--- a/ipv8/database.py
+++ b/ipv8/database.py
@@ -8,6 +8,7 @@ This module provides basic database functionalty and simple version control.
 import logging
 import os
 import sys
+import typing
 from abc import ABCMeta, abstractmethod
 from collections import defaultdict
 from threading import RLock
@@ -35,13 +36,8 @@ def execute_or_script(cursor, statement):
 
 
 # In Python 3 sqlite expects bytes instead of buffer objects.
-try:
-    database_blob = buffer
-except NameError:
-    database_blob = bytes
-
-
-db_locks = defaultdict(RLock)
+database_blob = bytes
+db_locks: typing.Dict[str, RLock] = defaultdict(RLock)
 
 
 def db_call(f):

--- a/ipv8/messaging/interfaces/dispatcher/endpoint.py
+++ b/ipv8/messaging/interfaces/dispatcher/endpoint.py
@@ -122,6 +122,7 @@ class DispatcherEndpoint(Endpoint):
             return self.interfaces[interface].get_address()
         elif self._preferred_interface:
             return self._preferred_interface.get_address()
+        return None
 
     def send(self, socket_address, packet, interface=None) -> None:
         if interface is not None:

--- a/ipv8/messaging/lazy_payload.py
+++ b/ipv8/messaging/lazy_payload.py
@@ -1,5 +1,6 @@
 import inspect
 import types
+import typing
 
 from .payload import Payload
 
@@ -25,7 +26,7 @@ class VariablePayload(Payload):
     want to apply when actually sending over the wire.
     """
 
-    names = []
+    names: typing.List[str] = []
 
     def __init__(self, *args, **kwargs):
         """

--- a/ipv8/messaging/serialization.py
+++ b/ipv8/messaging/serialization.py
@@ -1,4 +1,5 @@
 import abc
+import typing
 from binascii import hexlify
 from socket import inet_aton, inet_ntoa
 from struct import Struct, pack, unpack_from
@@ -340,7 +341,7 @@ class Serializable(metaclass=abc.ABCMeta):
     Interface for serializable objects.
     """
 
-    format_list = []
+    format_list: typing.List[str] = []
 
     @abc.abstractmethod
     def to_pack_list(self):

--- a/ipv8/peer.py
+++ b/ipv8/peer.py
@@ -54,9 +54,9 @@ class Peer(object):
         :param intro: is this peer suggested to us (otherwise it contacted us)
         """
         if not isinstance(key, Key):
-            self.key = default_eccrypto.key_from_public_bin(key)
+            self.key: Key = default_eccrypto.key_from_public_bin(key)
         else:
-            self.key = key
+            self.key = key  # type:ignore
         self.mid = self.key.key_to_hash()
         self.public_key = self.key.pub()
         self._addresses = DirtyDict()
@@ -65,7 +65,7 @@ class Peer(object):
         self._address = address
         self.last_response = 0 if intro else time()
         self._lamport_timestamp = 0
-        self.pings = deque(maxlen=5)
+        self.pings: deque = deque(maxlen=5)
 
     @property
     def addresses(self) -> Dict[Type[Address], Address]:

--- a/ipv8/types.py
+++ b/ipv8/types.py
@@ -1,0 +1,39 @@
+import typing
+
+Address = typing.Tuple[str, int]
+
+# pylint: disable=unused-import
+
+if typing.TYPE_CHECKING:
+    from ipv8.attestation.identity.attestation import Attestation
+    from ipv8.attestation.identity.database import Credential
+    from ipv8.attestation.identity.manager import PseudonymManager
+    from ipv8.attestation.identity.metadata import Metadata
+    from ipv8.attestation.identity_formats import IdentityAlgorithm
+    from ipv8.attestation.tokentree.token import Token
+    from ipv8.attestation.wallet.community import AttestationCommunity
+    from ipv8.configuration import ConfigBuilder
+    from ipv8.database import Database
+    from ipv8.keyvault.keys import Key, PrivateKey, PublicKey
+    from ipv8.messaging.interfaces.endpoint import Endpoint
+    from ipv8.peer import Peer
+    from ipv8_service import IPv8
+
+    IdentityAlgorithmClass = typing.Type[IdentityAlgorithm]
+else:
+    Attestation = 'ipv8.attestation.identity.attestation.Attestation'
+    AttestationCommunity = 'ipv8.attestation.wallet.community.AttestationCommunity'
+    ConfigBuilder = 'ipv8.configuration.ConfigBuilder'
+    Credential = 'ipv8.attestation.identity.database.Credential'
+    Database = 'ipv8.database.Database'
+    Endpoint = 'ipv8.messaging.interfaces.endpoint.Endpoint'
+    IdentityAlgorithm = 'ipv8.attestation.identity_formats.IdentityAlgorithm'
+    IdentityAlgorithmClass = 'ipv8.attestation.identity_formats.IdentityAlgorithm.__class__'
+    IPv8 = 'ipv8_service.IPv8'
+    Key = 'ipv8.keyvault.keys.Key'
+    Metadata = 'ipv8.attestation.identity.metadata.Metadata'
+    Peer = 'ipv8.peer.Peer'
+    PrivateKey = 'ipv8.keyvault.keys.PrivateKey'
+    PseudonymManager = 'ipv8.attestation.identity.manager.PseudonymManager'
+    PublicKey = 'ipv8.keyvault.keys.PublicKey'
+    Token = 'ipv8.attestation.tokentree.token.Token'

--- a/mypy.ini
+++ b/mypy.ini
@@ -3,3 +3,9 @@ ignore_missing_imports = True
 
 [mypy-ipv8_service]
 follow_imports = skip
+
+[mypy-ipv8.attestation.wallet.irmaexact.enroll_script]
+ignore_errors = True
+
+[mypy-ipv8.test.*]
+ignore_errors = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,5 @@
+[mypy]
+ignore_missing_imports = True
+
+[mypy-ipv8_service]
+follow_imports = skip


### PR DESCRIPTION
Fixes #879

This PR:

 - Adds a top-level file for typing, reducing the amount of imports only used for typing (possibly creating circular dependencies).
 - Adds support for running Mypy on the codebase (using `mypy ipv8` from the root folder).
 - Fixes Mypy errors (fixing errors includes adding missing types in some cases).

Note that this PR **does not** add typing to the entire codebase: it only fixes what was already there.

## Lessons learned (and applied)

 - Use PEP 563 for class and static methods. For example:

```python
from __future__ import annotations  # Included PEP 563 in Python 3.7

class A:
    @classmethod
    def create(cls) -> A:  # This wont work without the future import, A is not defined/loaded yet
        return cls
```

 - Use PEP 484 and PEP 563 to avoid circular imports and unnecessary/typing-only imports:

```python
# Top-level definitions in types.py
if typing.TYPE_CHECKING:  # PEP 563
    # This may be a circular import, but Mypy doesn't care for its static analysis
    from ipv8.database import Database
else:
    # This is what is actually used at running time
    Database = 'ipv8.database.Database'  # PEP 484
```

 - Mypy gets confused sometimes. Our Pylint configuration doesn't like specific Mypy ignores though, use this instead:

```python
a = 1
a_str = str(a)  # Preferred solution

# The following is a type conflict, sometimes this cannot be avoided
# NOTE: Don't use specific ignores like "type:ignore[override]", it throws off Pylint.
a = str(a)  # type:ignore
```

 - Subtypes are automatically inferred and may need adjustment in the function body:

```python
class A:
    pass
class B1(A):
    pass
class B2(A):
    pass
a: A = B1()  # Need type hint here, otherwise type will be inferred as B1, causing a conflict on the next line
a = B2()  # No type hint needed here as "a" was already introduced
```

 - Mypy and `OrderedDict` don't get along, use `OrderedDict` without subscript.

 - Mypy needs static type definitions. To play nicely with VariablePayloads, you can define valueless class attributes with types:

```python
@vp_compile
class MyPayload(VariablePayload):
    msg_id = 1
    format_list = ['I', 'H', 'varlenH', 'bits']
    names = ['a', 'b', 'c', 'd']

    a: int
    b: int
    c: bytes
    d: typing.List[bool]
```
