### PR TITLE
Renamed MockIPv8.unload to MockIPv8.stop

### DIFF
--- a/ipv8/dht/discovery.py
+++ b/ipv8/dht/discovery.py
@@ -139,7 +139,7 @@ class DHTDiscoveryCommunity(DHTCommunity):
             self.logger.debug('Storing peer %s (key %s)', node, hexlify(payload.target))
             self.store[payload.target].append(node)
 
-        self.ez_send(node, StorePeerResponsePayload(payload.indentifier))
+        self.ez_send(node, StorePeerResponsePayload(payload.identifier))
 
     @lazy_wrapper(StorePeerResponsePayload)
     def on_store_peer_response(self, peer, payload):

--- a/ipv8/test/REST/rest_base.py
+++ b/ipv8/test/REST/rest_base.py
@@ -61,7 +61,7 @@ class MockRestIPv8(object):
         await self.rest_manager.start(0)
         self.rest_port = self.rest_manager.site._server.sockets[0].getsockname()[1]
 
-    async def unload(self):
+    async def stop(self, stop_loop=True):
         await self.rest_manager.stop()
         self.endpoint.close()
         for overlay in self.overlays:

--- a/ipv8/test/base.py
+++ b/ipv8/test/base.py
@@ -51,7 +51,7 @@ class TestBase(asynctest.TestCase):
     async def tearDown(self):
         try:
             for node in self.nodes:
-                await node.unload()
+                await node.stop()
             internet.clear()
         finally:
             while self._tempdirs:

--- a/ipv8/test/dht/test_community.py
+++ b/ipv8/test/dht/test_community.py
@@ -61,7 +61,7 @@ class TestDHTCommunity(TestBase):
 
     async def test_ping_pong_fail(self):
         await self.introduce_nodes()
-        await self.nodes[1].unload()
+        await self.nodes[1].stop()
         with self.assertRaises(TimeoutError):
             await wait_for(self.nodes[0].overlay.ping(Node(self.nodes[1].my_peer.key,
                                                            self.nodes[1].my_peer.address)), 0.1)

--- a/ipv8/test/messaging/anonymization/test_hiddenservices.py
+++ b/ipv8/test/messaging/anonymization/test_hiddenservices.py
@@ -26,7 +26,7 @@ class TestHiddenServices(TestBase):
 
     async def tearDown(self):
         for node in self.private_nodes:
-            await node.unload()
+            await node.stop()
         return await super(TestHiddenServices, self).tearDown()
 
     def get_e2e_circuit_path(self):

--- a/ipv8/test/mocking/ipv8.py
+++ b/ipv8/test/mocking/ipv8.py
@@ -65,7 +65,7 @@ class MockIPv8(object):
                            if strategy.overlay != instance]
         return maybe_coroutine(instance.unload)
 
-    async def unload(self):
+    async def stop(self, stop_loop=True):
         self.endpoint.close()
         await self.overlay.unload()
         if self.trustchain:


### PR DESCRIPTION
This is consistent with the real IPv8 object, which does not have an unload but a stop method.

This PR:

 - Renames MockIPv8.unload to MockIPv8.stop
 - Fixes a typo in the DHT community
