### PR TITLE
Added Endpoint unit tests

### DIFF
--- a/ipv8/messaging/interfaces/statistics_endpoint.py
+++ b/ipv8/messaging/interfaces/statistics_endpoint.py
@@ -19,10 +19,9 @@ class StatisticsEndpoint(EndpointListener):
     IDS_PUNCTURE = [249, 250]
     IDS_DEPRECATED = [235, 236, 237, 238, 239, 240, 241, 242, 243, 244, 247, 248, 251, 252, 253, 254, 255]
 
-    def __init__(self, ipv8, ipv8_endpoint):
-        EndpointListener.__init__(self, ipv8_endpoint)
-        self.ipv8 = ipv8
-        self.endpoint = ipv8_endpoint
+    def __init__(self, endpoint):
+        EndpointListener.__init__(self, endpoint)
+        self.endpoint = endpoint
         self.endpoint.add_listener(self)
         self.statistics = {}
 
@@ -136,7 +135,7 @@ class StatisticsEndpoint(EndpointListener):
         if prefix in self.statistics:
             for identifier in self.statistics[prefix]:
                 if not self.is_excluded(identifier, include_introduction, include_puncture, include_deprecated):
-                    bytes_received += self.statistics[identifier].bytes_down
+                    bytes_received += self.statistics[prefix][identifier].bytes_down
         return bytes_received
 
     def is_excluded(self, identifier, include_introduction, include_puncture, include_deprecated):

--- a/ipv8/test/messaging/interfaces/test_network_stats.py
+++ b/ipv8/test/messaging/interfaces/test_network_stats.py
@@ -1,0 +1,103 @@
+from ...base import TestBase
+from ....messaging.interfaces.network_stats import NetworkStat
+
+
+class TestNetworkStat(TestBase):
+
+    async def test_initialize(self):
+        """
+        Check if the starting values of NetworkStat are sane.
+        """
+        stats = NetworkStat(1447)
+
+        self.assertEqual(1447, stats.identifier)
+        self.assertEqual(0, stats.num_up)
+        self.assertEqual(0, stats.num_down)
+        self.assertEqual(0, stats.bytes_up)
+        self.assertEqual(0, stats.bytes_down)
+        self.assertEqual(0, stats.first_measured_up)
+        self.assertEqual(0, stats.first_measured_down)
+        self.assertEqual(0, stats.last_measured_up)
+        self.assertEqual(0, stats.last_measured_down)
+
+    async def test_add_sent_stat(self):
+        """
+        Check if an added sent statistic is correctly registered.
+        """
+        stats = NetworkStat(0)
+
+        stats.add_sent_stat(1492, 1776)
+
+        self.assertEqual(1, stats.num_up)
+        self.assertEqual(1776, stats.bytes_up)
+        self.assertEqual(1492, stats.first_measured_up)
+        self.assertEqual(1492, stats.last_measured_up)
+
+    async def test_add_sent_stat_first_up(self):
+        """
+        Check if the first_measured_up is correctly registered on send.
+        """
+        stats = NetworkStat(0)
+
+        stats.add_sent_stat(1492, 1776)
+        stats.add_sent_stat(1619, 1776)
+
+        self.assertEqual(1492, stats.first_measured_up)
+
+    async def test_add_received_stat(self):
+        """
+        Check if an added received statistic is correctly registered.
+        """
+        stats = NetworkStat(0)
+
+        stats.add_received_stat(1492, 1776)
+
+        self.assertEqual(1, stats.num_down)
+        self.assertEqual(1776, stats.bytes_down)
+        self.assertEqual(1492, stats.first_measured_down)
+        self.assertEqual(1492, stats.last_measured_down)
+
+    async def test_add_received_stat_first_down(self):
+        """
+        Check if the first_measured_up is correctly registered on receive.
+        """
+        stats = NetworkStat(0)
+
+        stats.add_received_stat(1492, 1776)
+        stats.add_received_stat(1619, 1776)
+
+        self.assertEqual(1492, stats.first_measured_down)
+
+    async def test_to_dict(self):
+        """
+        Check if the dictionary form of the NetworkStat is correct.
+        """
+        stats = NetworkStat(1849)
+        stats.add_sent_stat(1492, 1776)
+        stats.add_received_stat(1619, 1787)
+        stats.add_sent_stat(1783, 1794)
+        stats.add_received_stat(1789, 1798)
+
+        self.assertDictEqual({
+            "identifier": 1849,
+            "num_up": 2,
+            "num_down": 2,
+            "bytes_up": 1776 + 1794,
+            "bytes_down": 1787 + 1798,
+            "first_measured_up": 1492,
+            "first_measured_down": 1619,
+            "last_measured_up": 1783,
+            "last_measured_down": 1789
+        }, stats.to_dict())
+
+    async def test_to_str(self):
+        """
+        Check if a NetworkStat is correctly formatted as a str.
+        """
+        stats = NetworkStat(1849)
+        stats.add_sent_stat(1492, 1776)
+        stats.add_received_stat(1619, 1787)
+        stats.add_sent_stat(1783, 1794)
+        stats.add_received_stat(1789, 1798)
+
+        self.assertEqual("NetworkStat{num_up:2, num_down:2, bytes_up:3570, bytes_down:3585, ...}", str(stats))

--- a/ipv8/test/messaging/interfaces/test_statistics_endpoint.py
+++ b/ipv8/test/messaging/interfaces/test_statistics_endpoint.py
@@ -1,0 +1,211 @@
+from ...base import TestBase
+from ...mocking.endpoint import AutoMockEndpoint
+from ....messaging.interfaces.network_stats import NetworkStat
+from ....messaging.interfaces.statistics_endpoint import StatisticsEndpoint
+
+
+class NoSendEndpoint(AutoMockEndpoint):
+
+    def send(self, socket_address, packet):
+        pass
+
+
+class TestStatisticsEndpoint(TestBase):
+
+    def setUp(self):
+        super().setUp()
+        self.raw_ep = NoSendEndpoint()
+        self.stats_ep = StatisticsEndpoint(self.raw_ep)
+
+        self.prefix = b'0' * 22
+        self.msg_id = b'\x01'
+        self.msg_num = self.msg_id[0]
+        self.fake_addr = ("0.0.0.0", 0)
+
+    async def test_getattribute(self):
+        """
+        Check if calls to the underlying Endpoint are forwarded.
+
+        Note: ``wan_address`` is specific to ``AutoMockEndpoint``.
+        """
+        self.assertEqual(self.raw_ep.wan_address, self.stats_ep.wan_address)
+
+    async def test_capture_send_enabled(self):
+        """
+        Check if send calls are registered when the prefix is enabled.
+        """
+        self.stats_ep.enable_community_statistics(self.prefix, True)
+        self.stats_ep.send(self.fake_addr, self.prefix + self.msg_id + b'Hello World!')
+
+        statistics = self.stats_ep.get_statistics(self.prefix)
+
+        self.assertIsNotNone(statistics)
+        self.assertIn(self.msg_num, statistics)
+        self.assertEqual(1, statistics[self.msg_num].num_up)
+        self.assertEqual(0, statistics[self.msg_num].num_down)
+
+    async def test_no_capture_send_disabled(self):
+        """
+        Check if send calls are not registered when the prefix is disabled.
+        """
+        self.stats_ep.enable_community_statistics(self.prefix, False)
+        self.stats_ep.send(self.fake_addr, self.prefix + self.msg_id + b'Hello World!')
+
+        statistics = self.stats_ep.get_statistics(self.prefix)
+
+        self.assertIsNotNone(statistics)
+        self.assertFalse(statistics)
+
+    async def test_capture_receive_enabled(self):
+        """
+        Check if receive calls are registered when the prefix is enabled.
+        """
+        self.stats_ep.enable_community_statistics(self.prefix, True)
+        self.stats_ep.on_packet((self.fake_addr, self.prefix + self.msg_id + b'Hello World!'))
+
+        statistics = self.stats_ep.get_statistics(self.prefix)
+
+        self.assertIsNotNone(statistics)
+        self.assertIn(self.msg_num, statistics)
+        self.assertEqual(0, statistics[self.msg_num].num_up)
+        self.assertEqual(1, statistics[self.msg_num].num_down)
+
+    async def test_no_capture_receive_disabled(self):
+        """
+        Check if receive calls are not registered when the prefix is disabled.
+        """
+        self.stats_ep.enable_community_statistics(self.prefix, False)
+        self.stats_ep.on_packet((self.fake_addr, self.prefix + self.msg_id + b'Hello World!'))
+
+        statistics = self.stats_ep.get_statistics(self.prefix)
+
+        self.assertIsNotNone(statistics)
+        self.assertFalse(statistics)
+
+    async def test_get_sent(self):
+        """
+        Check if sent messages are correctly logged for an unknown and known prefix.
+        """
+        stats = NetworkStat(self.msg_num)
+        stats.num_up = 2
+        stats.bytes_up = 42
+        self.stats_ep.statistics = {self.prefix: {self.msg_num: stats}}
+        unknown_prefix = b'some other prefix'
+
+        self.assertEqual(0, self.stats_ep.get_message_sent(unknown_prefix))
+        self.assertEqual(2, self.stats_ep.get_message_sent(self.prefix))
+        self.assertEqual(0, self.stats_ep.get_bytes_sent(unknown_prefix))
+        self.assertEqual(42, self.stats_ep.get_bytes_sent(self.prefix))
+
+    async def test_get_received(self):
+        """
+        Check if received messages are correctly logged for an unknown and known prefix.
+        """
+        stats = NetworkStat(self.msg_num)
+        stats.num_down = 2
+        stats.bytes_down = 42
+        self.stats_ep.statistics = {self.prefix: {self.msg_num: stats}}
+        unknown_prefix = b'some other prefix'
+
+        self.assertEqual(0, self.stats_ep.get_message_received(unknown_prefix))
+        self.assertEqual(2, self.stats_ep.get_message_received(self.prefix))
+        self.assertEqual(0, self.stats_ep.get_bytes_received(unknown_prefix))
+        self.assertEqual(42, self.stats_ep.get_bytes_received(self.prefix))
+
+    async def test_get_sent_excluded(self):
+        """
+        Check if excluded sent messages are not counted.
+        """
+        stats_intro, stats_puncture, stats_deprecated = NetworkStat(245), NetworkStat(249), NetworkStat(235)
+        stats_intro.num_up = stats_puncture.num_up = stats_deprecated.num_up = 1
+        self.stats_ep.statistics = {self.prefix: {245: stats_intro, 249: stats_puncture, 235: stats_deprecated}}
+
+        self.assertEqual(0, self.stats_ep.get_message_sent(self.prefix))
+        self.assertEqual(3, self.stats_ep.get_message_sent(self.prefix, True, True, True))
+        self.assertEqual(1, self.stats_ep.get_message_sent(self.prefix, include_introduction=True))
+        self.assertEqual(1, self.stats_ep.get_message_sent(self.prefix, include_puncture=True))
+        self.assertEqual(1, self.stats_ep.get_message_sent(self.prefix, include_deprecated=True))
+
+    async def test_get_received_excluded(self):
+        """
+        Check if excluded received messages are not counted.
+        """
+        stats_intro, stats_puncture, stats_deprecated = NetworkStat(245), NetworkStat(249), NetworkStat(235)
+        stats_intro.num_down = stats_puncture.num_down = stats_deprecated.num_down = 1
+        self.stats_ep.statistics = {self.prefix: {245: stats_intro, 249: stats_puncture, 235: stats_deprecated}}
+
+        self.assertEqual(0, self.stats_ep.get_message_received(self.prefix))
+        self.assertEqual(3, self.stats_ep.get_message_received(self.prefix, True, True, True))
+        self.assertEqual(1, self.stats_ep.get_message_received(self.prefix, include_introduction=True))
+        self.assertEqual(1, self.stats_ep.get_message_received(self.prefix, include_puncture=True))
+        self.assertEqual(1, self.stats_ep.get_message_received(self.prefix, include_deprecated=True))
+
+    async def test_aggregate_statistics_sum(self):
+        """
+        Check if network stats are correctly summed.
+        """
+        stat1 = NetworkStat(1)
+        stat1.num_up, stat1.num_down, stat1.bytes_up, stat1.bytes_down = 2, 3, 4, 5
+        stat2 = NetworkStat(2)
+        stat2.num_up, stat2.num_down, stat2.bytes_up, stat2.bytes_down = 6, 7, 8, 9
+        self.stats_ep.statistics = {self.prefix: {stat1.identifier: stat1, stat2.identifier: stat2}}
+
+        statistics = self.stats_ep.get_aggregate_statistics(self.prefix)
+
+        self.assertIsNotNone(statistics)
+        self.assertEqual(8, statistics['num_up'])
+        self.assertEqual(10, statistics['num_down'])
+        self.assertEqual(12, statistics['bytes_up'])
+        self.assertEqual(14, statistics['bytes_down'])
+        self.assertEqual(0, statistics['diff_time'])
+
+    async def test_aggregate_statistics_diff_one(self):
+        """
+        Check if the time diff is correctly calculated, with one positive stat.
+        """
+        stat1 = NetworkStat(1)
+        stat1.last_measured_down, stat1.last_measured_up = 0, 0
+        stat1.first_measured_down, stat1.first_measured_up = 0, 0
+        stat2 = NetworkStat(2)
+        stat2.last_measured_down, stat2.last_measured_up = 0, 5
+        stat2.first_measured_down, stat2.first_measured_up = 0, 1
+        self.stats_ep.statistics = {self.prefix: {stat1.identifier: stat1, stat2.identifier: stat2}}
+
+        statistics = self.stats_ep.get_aggregate_statistics(self.prefix)
+
+        self.assertIsNotNone(statistics)
+        self.assertEqual(4, statistics['diff_time'])
+
+    async def test_aggregate_statistics_diff_two(self):
+        """
+        Check if the time diff is correctly calculated, with two positive stats.
+        """
+        stat1 = NetworkStat(1)
+        stat1.last_measured_down, stat1.last_measured_up = 0, 6
+        stat1.first_measured_down, stat1.first_measured_up = 0, 2
+        stat2 = NetworkStat(2)
+        stat2.last_measured_down, stat2.last_measured_up = 0, 5
+        stat2.first_measured_down, stat2.first_measured_up = 0, 1
+        self.stats_ep.statistics = {self.prefix: {stat1.identifier: stat1, stat2.identifier: stat2}}
+
+        statistics = self.stats_ep.get_aggregate_statistics(self.prefix)
+
+        self.assertIsNotNone(statistics)
+        self.assertEqual(5, statistics['diff_time'])
+
+    async def test_aggregate_statistics_diff_many(self):
+        """
+        Check if the time diff is correctly calculated, with four positive stats.
+        """
+        stat1 = NetworkStat(1)
+        stat1.last_measured_down, stat1.last_measured_up = 7, 6
+        stat1.first_measured_down, stat1.first_measured_up = 3, 2
+        stat2 = NetworkStat(2)
+        stat2.last_measured_down, stat2.last_measured_up = 0, 5
+        stat2.first_measured_down, stat2.first_measured_up = 1, 2
+        self.stats_ep.statistics = {self.prefix: {stat1.identifier: stat1, stat2.identifier: stat2}}
+
+        statistics = self.stats_ep.get_aggregate_statistics(self.prefix)
+
+        self.assertIsNotNone(statistics)
+        self.assertEqual(6, statistics['diff_time'])

--- a/ipv8_service.py
+++ b/ipv8_service.py
@@ -77,7 +77,7 @@ else:
                                                    UDPIPv4={'port': configuration['port'],
                                                             'ip': configuration['address']})
                 if enable_statistics:
-                    self.endpoint = StatisticsEndpoint(self, self.endpoint)
+                    self.endpoint = StatisticsEndpoint(self.endpoint)
                 if any([overlay.get('initialize', {}).get('anonymize') for overlay in configuration['overlays']]):
                     self.endpoint = TunnelEndpoint(self.endpoint)
 


### PR DESCRIPTION
This PR:

 - Adds unit tests for the `DispatcherEndpoint`.
 - Adds unit tests for `NetworkStat`.
 - Adds unit tests for the `StatisticsEndpoint`.
 - Fixes a bug in `StatisticsEndpoint` that pulled `bytes_down` from `self.statistics[identifier].bytes_down` instead of `self.statistics[prefix][identifier].bytes_down`.
 - Removes the unused `ipv8` attribute from `StatisticsEndpoint`.
