### PR TITLE
Updated TunnelCommunity payloads and crypto

### DIFF
--- a/ipv8/messaging/anonymization/caches.py
+++ b/ipv8/messaging/anonymization/caches.py
@@ -11,7 +11,7 @@ class CreateRequestCache(NumberCache):
     Used to track outstanding create messages
     """
     def __init__(self, community, to_circuit_id, from_circuit_id, peer, to_peer):
-        super(CreateRequestCache, self).__init__(community.request_cache, "create", to_circuit_id)
+        super().__init__(community.request_cache, "create", to_circuit_id)
         self.community = community
         self.to_circuit_id = to_circuit_id
         self.from_circuit_id = from_circuit_id
@@ -29,7 +29,7 @@ class CreatedRequestCache(NumberCache):
     Used to track outstanding created messages
     """
     def __init__(self, community, circuit_id, candidate, candidates, timeout):
-        super(CreatedRequestCache, self).__init__(community.request_cache, "created", circuit_id)
+        super().__init__(community.request_cache, "created", circuit_id)
         self.circuit_id = circuit_id
         self.candidate = candidate
         self.candidates = candidates
@@ -43,12 +43,12 @@ class CreatedRequestCache(NumberCache):
         pass
 
 
-class RetryRequestCache(NumberCache):
+class RetryRequestCache(RandomNumberCache):
     """
     Used to track adding additional hops to the circuit.
     """
     def __init__(self, community, circuit, candidates, max_tries, retry_func, timeout):
-        super(RetryRequestCache, self).__init__(community.request_cache, "retry", circuit.circuit_id)
+        super().__init__(community.request_cache, "retry")
         self.community = community
         self.circuit = circuit
         self.candidates = candidates
@@ -80,7 +80,7 @@ class RetryRequestCache(NumberCache):
 class PingRequestCache(RandomNumberCache):
 
     def __init__(self, community, circuit):
-        super(PingRequestCache, self).__init__(community.request_cache, "ping")
+        super().__init__(community.request_cache, "ping")
 
     def on_timeout(self):
         pass
@@ -89,7 +89,7 @@ class PingRequestCache(RandomNumberCache):
 class IPRequestCache(RandomNumberCache):
 
     def __init__(self, community, circuit):
-        super(IPRequestCache, self).__init__(community.request_cache, "establish-intro")
+        super().__init__(community.request_cache, "establish-intro")
         self.logger = logging.getLogger(__name__)
         self.circuit = circuit
         self.community = community
@@ -102,7 +102,7 @@ class IPRequestCache(RandomNumberCache):
 class RPRequestCache(RandomNumberCache):
 
     def __init__(self, community, rp):
-        super(RPRequestCache, self).__init__(community.request_cache, "establish-rendezvous")
+        super().__init__(community.request_cache, "establish-rendezvous")
         self.logger = logging.getLogger(__name__)
         self.community = community
         self.rp = rp
@@ -117,7 +117,7 @@ class RPRequestCache(RandomNumberCache):
 class PeersRequestCache(RandomNumberCache):
 
     def __init__(self, community, circuit, info_hash):
-        super(PeersRequestCache, self).__init__(community.request_cache, "peers-request")
+        super().__init__(community.request_cache, "peers-request")
         self.circuit = circuit
         self.info_hash = info_hash
         self.future = Future()
@@ -129,7 +129,7 @@ class PeersRequestCache(RandomNumberCache):
 class E2ERequestCache(RandomNumberCache):
 
     def __init__(self, community, info_hash, hop, intro_point):
-        super(E2ERequestCache, self).__init__(community.request_cache, "e2e-request")
+        super().__init__(community.request_cache, "e2e-request")
         self.community = community
         self.info_hash = info_hash
         self.hop = hop
@@ -145,7 +145,7 @@ class E2ERequestCache(RandomNumberCache):
 class LinkRequestCache(RandomNumberCache):
 
     def __init__(self, community, circuit, info_hash, hs_session_keys):
-        super(LinkRequestCache, self).__init__(community.request_cache, "link-request")
+        super().__init__(community.request_cache, "link-request")
         self.circuit = circuit
         self.info_hash = info_hash
         self.hs_session_keys = hs_session_keys
@@ -157,7 +157,7 @@ class LinkRequestCache(RandomNumberCache):
 class TestRequestCache(RandomNumberCache):
 
     def __init__(self, community, circuit):
-        super(TestRequestCache, self).__init__(community.request_cache, "test-request")
+        super().__init__(community.request_cache, "test-request")
         self.circuit = circuit
         self.ts = time.time()
         self.future = Future()

--- a/ipv8/messaging/anonymization/community.py
+++ b/ipv8/messaging/anonymization/community.py
@@ -530,7 +530,7 @@ class TunnelCommunity(Community):
                     candidate_list.pop(i)
 
             extend_hop_public_bin = next(iter(candidate_list), None)
-            extend_hop_addr = None
+            extend_hop_addr = ('0.0.0.0', 0)
 
         if extend_hop_public_bin:
             extend_hop_public_key = self.crypto.key_from_public_bin(extend_hop_public_bin)
@@ -551,8 +551,8 @@ class TunnelCommunity(Community):
 
             self.send_cell(circuit.peer, ExtendPayload(circuit.circuit_id,
                                                        circuit.unverified_hop.node_public_key,
-                                                       extend_hop_addr,
-                                                       circuit.unverified_hop.dh_first_part))
+                                                       circuit.unverified_hop.dh_first_part,
+                                                       extend_hop_addr))
 
         else:
             self.remove_circuit(circuit.circuit_id, "no candidates to extend")
@@ -717,7 +717,7 @@ class TunnelCommunity(Community):
         circuit_id = payload.circuit_id
         # Leave the RequestCache in case the circuit owner wants to reuse the tunnel for a different next-hop
         request = self.request_cache.get("created", circuit_id)
-        if not (payload.node_addr or payload.node_public_key in request.candidates):
+        if payload.node_addr == ('0.0.0.0', 0) and payload.node_public_key not in request.candidates:
             self.logger.warning("Node public key not in request candidates and no ip specified")
             return
 

--- a/ipv8/messaging/anonymization/hidden_services.py
+++ b/ipv8/messaging/anonymization/hidden_services.py
@@ -293,8 +293,10 @@ class HiddenTunnelCommunity(TunnelCommunity):
             self.send_peers_response(source_address, payload, intro_points, circuit_id)
         elif circuit_id in self.exit_sockets:
             # Get peers from DHT community
-            _, intro_points = await self.dht_lookup(info_hash)
-            self.send_peers_response(source_address, payload, intro_points, circuit_id)
+            results = await self.dht_lookup(info_hash)
+            if results:
+                _, intro_points = results
+                self.send_peers_response(source_address, payload, intro_points, circuit_id)
         elif circuit_id is not None:
             self.logger.warning("Received a peers-request over circuit %d, but unable to do a DHT lookup", circuit_id)
         else:

--- a/ipv8/messaging/anonymization/payload.py
+++ b/ipv8/messaging/anonymization/payload.py
@@ -1,14 +1,13 @@
 import socket
 from functools import reduce
-from struct import pack, unpack_from
+from struct import calcsize, pack, unpack_from
 
-from cryptography.exceptions import InvalidTag
+from libnacl import CryptError
 
 from ...messaging.anonymization.tunnel import (CIRCUIT_TYPE_RP_DOWNLOADER, CIRCUIT_TYPE_RP_SEEDER, EXIT_NODE,
                                                EXIT_NODE_SALT, ORIGINATOR, ORIGINATOR_SALT)
 from ...messaging.anonymization.tunnelcrypto import CryptoException
 from ...messaging.lazy_payload import VariablePayload, vp_compile
-from ...messaging.payload import Payload
 
 ADDRESS_TYPE_IPV4 = 0x01
 ADDRESS_TYPE_DOMAIN_NAME = 0x02
@@ -16,81 +15,216 @@ ADDRESS_TYPE_DOMAIN_NAME = 0x02
 NO_CRYPTO_PACKETS = [2, 3]
 
 
-def encode_address(host, port):
-    try:
-        ip = socket.inet_aton(host)
-        is_ip = True
-    except (ValueError, OSError):
-        is_ip = False
-
-    if is_ip:
-        return pack("!B4sH", ADDRESS_TYPE_IPV4, ip, port)
-    else:
-        host_bytes = host.encode('utf-8')
-        return pack("!BH", ADDRESS_TYPE_DOMAIN_NAME, len(host_bytes)) + host_bytes + pack("!H", port)
+@vp_compile
+class ExtraIntroductionPayload(VariablePayload):
+    names = ['flags']
+    format_list = ['flags']
 
 
-def decode_address(packet):
-    addr_type, = unpack_from("!B", packet)
-
-    if addr_type == ADDRESS_TYPE_IPV4:
-        host, port = unpack_from('!4sH', packet, 1)
-        return socket.inet_ntoa(host), port
-
-    elif addr_type == ADDRESS_TYPE_DOMAIN_NAME:
-        length, = unpack_from('!H', packet, 1)
-        host = packet[3:3 + length].decode('utf-8')
-        port, = unpack_from('!H', packet, 3 + length)
-        return host, port
-
-    return None
-
-
-class ExtraIntroductionPayload(Payload):
-
-    format_list = ['H']
-
-    def __init__(self, flags):
-        super(ExtraIntroductionPayload, self).__init__()
-        self.flags = flags
-
-    def to_pack_list(self):
-        return [('H', reduce(lambda a, b: a | b, self.flags))]
-
-    @classmethod
-    def from_unpack_list(cls, flags):
-        return ExtraIntroductionPayload(list(filter(None, [flags & (2**i) for i in range(16)])))
-
-
-class DataPayload(object):
-    msg_id = 0
-
-    def __init__(self, circuit_id, dest_address, org_address, data):
-        self.circuit_id = circuit_id
-        self.dest_address = dest_address
-        self.org_address = org_address
-        self.data = data
-
-    def to_bin(self):
-        # Note that since we always wrap data packets in cells, we do not need to include prefix + message_id
-        dest = encode_address(*self.dest_address)
-        org = encode_address(*self.org_address)
-        return b''.join([pack('!H', len(dest)), dest,
-                         pack('!H', len(org)), org,
-                         self.data])
-
-    @classmethod
-    def from_bin(cls, packet):
-        circuit_id, len_dest = unpack_from('!IH', packet, 23)
-        len_org, = unpack_from('!H', packet, 29 + len_dest)
-        return cls(circuit_id,
-                   decode_address(packet[29:29 + len_dest]),
-                   decode_address(packet[31 + len_dest:31 + len_dest + len_org]),
-                   packet[31 + len_dest + len_org:])
-
-
-class CellPayload(object):
+@vp_compile
+class DataPayload(VariablePayload):
     msg_id = 1
+    names = ['circuit_id', 'dest_address', 'org_address', 'data']
+    format_list = ['I', 'address', 'address', 'raw']
+
+
+@vp_compile
+class CreatePayload(VariablePayload):
+    msg_id = 2
+    names = ['circuit_id', 'identifier', 'node_public_key', 'key']
+    format_list = ['I', 'H', 'varlenH', 'varlenH']
+
+
+@vp_compile
+class CreatedPayload(VariablePayload):
+    msg_id = 3
+    names = ['circuit_id', 'identifier', 'key', 'auth', 'candidate_list_enc']
+    format_list = ['I', 'H', 'varlenH', '32s', 'raw']
+
+
+@vp_compile
+class ExtendPayload(VariablePayload):
+    msg_id = 4
+    names = ['circuit_id', 'identifier', 'node_public_key', 'key', 'node_addr']
+    format_list = ['I', 'H', 'varlenH', 'varlenH', 'ipv4']
+
+
+@vp_compile
+class ExtendedPayload(VariablePayload):
+    msg_id = 5
+    names = ['circuit_id', 'identifier', 'key', 'auth', 'candidate_list_enc']
+    format_list = ['I', 'H', 'varlenH', '32s', 'raw']
+
+
+@vp_compile
+class PingPayload(VariablePayload):
+    msg_id = 6
+    names = ['circuit_id', 'identifier']
+    format_list = ['I', 'H']
+
+
+@vp_compile
+class PongPayload(VariablePayload):
+    msg_id = 7
+    names = ['circuit_id', 'identifier']
+    format_list = ['I', 'H']
+
+
+@vp_compile
+class DestroyPayload(VariablePayload):
+    msg_id = 8
+    names = ['circuit_id', 'reason']
+    format_list = ['I', 'H']
+
+
+@vp_compile
+class EstablishIntroPayload(VariablePayload):
+    msg_id = 9
+    names = ['circuit_id', 'identifier', 'info_hash', 'public_key']
+    format_list = ['I', 'H', '20s', 'varlenH']
+
+
+@vp_compile
+class IntroEstablishedPayload(VariablePayload):
+    msg_id = 10
+    names = ['circuit_id', 'identifier']
+    format_list = ['I', 'H']
+
+
+@vp_compile
+class EstablishRendezvousPayload(VariablePayload):
+    msg_id = 11
+    names = ['circuit_id', 'identifier', 'cookie']
+    format_list = ['I', 'H', '20s']
+
+
+@vp_compile
+class RendezvousEstablishedPayload(VariablePayload):
+    msg_id = 12
+    names = ['circuit_id', 'identifier', 'rendezvous_point_addr']
+    format_list = ['I', 'H', 'ipv4']
+
+
+@vp_compile
+class CreateE2EPayload(VariablePayload):
+    msg_id = 13
+    names = ['identifier', 'info_hash', 'node_public_key', 'key']
+    format_list = ['H', '20s', 'varlenH', 'varlenH']
+
+
+@vp_compile
+class CreatedE2EPayload(VariablePayload):
+    msg_id = 14
+    names = ['identifier', 'key', 'auth', 'rp_info_enc']
+    format_list = ['H', 'varlenH', '32s', 'raw']
+
+
+@vp_compile
+class LinkE2EPayload(VariablePayload):
+    msg_id = 15
+    names = ['circuit_id', 'identifier', 'cookie']
+    format_list = ['I', 'H', '20s']
+
+
+@vp_compile
+class LinkedE2EPayload(VariablePayload):
+    msg_id = 16
+    names = ['circuit_id', 'identifier']
+    format_list = ['I', 'H']
+
+
+@vp_compile
+class PeersRequestPayload(VariablePayload):
+    msg_id = 17
+    names = ['circuit_id', 'identifier', 'info_hash']
+    format_list = ['I', 'H', '20s']
+
+
+@vp_compile
+class IntroductionInfo(VariablePayload):
+    names = ['address', 'key', 'seeder_pk', 'source']
+    format_list = ['ipv4', 'varlenH', 'varlenH', 'B']
+
+
+@vp_compile
+class PeersResponsePayload(VariablePayload):
+    msg_id = 18
+    names = ['circuit_id', 'identifier', 'info_hash', 'peers']
+    format_list = ['I', 'H', '20s', [IntroductionInfo]]
+
+
+@vp_compile
+class RendezvousInfo(VariablePayload):
+    names = ['address', 'key', 'cookie']
+    format_list = ['ipv4', 'varlenH', '20s']
+
+
+@vp_compile
+class TestRequestPayload(VariablePayload):
+    msg_id = 19
+    names = ['circuit_id', 'identifier', 'response_size', 'data']
+    format_list = ['I', 'H', 'H', 'raw']
+
+
+@vp_compile
+class TestResponsePayload(VariablePayload):
+    msg_id = 20
+    names = ['circuit_id', 'identifier', 'data']
+    format_list = ['I', 'H', 'raw']
+
+
+class Flags:
+
+    def __init__(self, fmt='>H'):
+        self.format = fmt
+        self.size = calcsize(fmt)
+
+    def pack(self, data):
+        return pack(self.format, reduce(lambda a, b: a | b, data, 0))
+
+    def unpack(self, data, offset, unpack_list):
+        number, = unpack_from(self.format, data, offset)
+        unpack_list.append(list(filter(None, [number & (2 ** i) for i in range(self.size * 8)])))
+        return self.size
+
+
+class Address:
+
+    def pack(self, address):
+        host, port = address
+        try:
+            ip = socket.inet_aton(host)
+            is_ip = True
+        except (ValueError, OSError):
+            is_ip = False
+
+        if is_ip:
+            return pack('>B4sH', ADDRESS_TYPE_IPV4, ip, port)
+        else:
+            host_bytes = host.encode('utf-8')
+            return pack('>BH', ADDRESS_TYPE_DOMAIN_NAME, len(host_bytes)) + host_bytes + pack('>H', port)
+
+    def unpack(self, data, offset, unpack_list):
+        addr_type, = unpack_from('>B', data, offset)
+
+        if addr_type == ADDRESS_TYPE_IPV4:
+            host, port = unpack_from('>4sH', data, offset + 1)
+            address = socket.inet_ntoa(host), port
+            unpack_list.append(address)
+            return offset + 7
+
+        elif addr_type == ADDRESS_TYPE_DOMAIN_NAME:
+            length, = unpack_from('>H', data, offset + 1)
+            host = data[offset + 3:offset + 3 + length].decode('utf-8')
+            port, = unpack_from('>H', data, offset + 3 + length)
+            unpack_list.append((host, port))
+            return offset + 5 + length
+
+        raise ValueError('Cannot unpack unknown address type')
+
+
+class CellPayload:
+    msg_id = 0
 
     def __init__(self, circuit_id, message, plaintext=False, relay_early=False):
         self.circuit_id = circuit_id
@@ -131,10 +265,10 @@ class CellPayload(object):
                     self.message = crypto.decrypt_str(self.message,
                                                       hop.session_keys[ORIGINATOR],
                                                       hop.session_keys[ORIGINATOR_SALT])
-                except InvalidTag as e:
+                except CryptError as e:
                     raise CryptoException("Got exception %r when trying to remove encryption layer %s "
                                           "for message: %r received for circuit_id: %s, circuit_hops: %r" %
-                                          (e, layer, self.message, self.circuit_id, circuit.hops))
+                                          (e, layer, self.message, self.circuit_id, circuit.hops)) from e
 
             if circuit.hs_session_keys and circuit.ctype in [CIRCUIT_TYPE_RP_SEEDER, CIRCUIT_TYPE_RP_DOWNLOADER]:
                 direction = int(circuit.ctype == CIRCUIT_TYPE_RP_DOWNLOADER)
@@ -148,22 +282,9 @@ class CellPayload(object):
                 self.message = crypto.decrypt_str(self.message,
                                                   relay_session_keys[EXIT_NODE],
                                                   relay_session_keys[EXIT_NODE_SALT])
-            except InvalidTag as e:
-                # Reasons that can cause this:
-                # - The introductionpoint circuit is extended with a candidate
-                # that is already part of the circuit, causing a crypto error.
-                # Should not happen anyway, thorough analysis of the debug log
-                # may reveal why and how this candidate is discovered.
-                # - The pubkey of the introduction point changed (e.g. due to a
-                # restart), while other peers in the network are still exchanging
-                # the old key information.
-                # - A hostile peer may have forged the key of a candidate while
-                # pexing information about candidates, thus polluting the network
-                # with wrong information. I doubt this is the case but it's
-                # possible. :)
-                # (from https://github.com/Tribler/tribler/issues/1932#issuecomment-182035383)
+            except CryptError as e:
                 raise CryptoException("Got exception %r when trying to decrypt relay message: "
-                                      "cell received for circuit_id: %s" % (e, self.circuit_id))
+                                      "cell received for circuit_id: %s" % (e, self.circuit_id)) from e
 
         else:
             raise CryptoException("Error decrypting message for unknown circuit %d" % self.circuit_id)
@@ -176,174 +297,10 @@ class CellPayload(object):
 
     def to_bin(self, prefix):
         return b''.join([prefix,
-                         bytes([1]),
+                         bytes([self.msg_id]),
                          pack('!I??', self.circuit_id, self.plaintext, self.relay_early) + self.message])
 
     @classmethod
     def from_bin(cls, packet):
         circuit_id, plaintext, relay_early = unpack_from('!I??', packet, 23)
         return cls(circuit_id, packet[29:], plaintext, relay_early)
-
-
-@vp_compile
-class CreatePayload(VariablePayload):
-    msg_id = 2
-    format_list = ['I', 'H', 'varlenH', 'varlenH']
-    names = ['circuit_id', 'identifier', 'node_public_key', 'key']
-
-
-@vp_compile
-class CreatedPayload(VariablePayload):
-    msg_id = 3
-    format_list = ['I', 'H', 'varlenH', '32s', 'raw']
-    names = ['circuit_id', 'identifier', 'key', 'auth', 'candidate_list_enc']
-
-
-@vp_compile
-class ExtendPayload(VariablePayload):
-    msg_id = 4
-    format_list = ['I', 'H', 'varlenH', 'varlenH', 'ipv4']
-    names = ['circuit_id', 'identifier', 'node_public_key', 'key', 'node_addr']
-
-
-@vp_compile
-class ExtendedPayload(VariablePayload):
-    msg_id = 5
-    format_list = ['I', 'H', 'varlenH', '32s', 'raw']
-    names = ['circuit_id', 'identifier', 'key', 'auth', 'candidate_list_enc']
-
-
-@vp_compile
-class PingPayload(VariablePayload):
-    msg_id = 6
-    format_list = ['I', 'H']
-    names = ['circuit_id', 'identifier']
-
-
-@vp_compile
-class PongPayload(VariablePayload):
-    msg_id = 7
-    format_list = ['I', 'H']
-    names = ['circuit_id', 'identifier']
-
-
-@vp_compile
-class DestroyPayload(VariablePayload):
-    msg_id = 10
-    format_list = ['I', 'H']
-    names = ['circuit_id', 'reason']
-
-
-@vp_compile
-class EstablishIntroPayload(VariablePayload):
-    msg_id = 11
-    format_list = ['I', 'H', '20s', 'varlenH']
-    names = ['circuit_id', 'identifier', 'info_hash', 'public_key']
-
-
-@vp_compile
-class IntroEstablishedPayload(VariablePayload):
-    msg_id = 12
-    format_list = ['I', 'H']
-    names = ['circuit_id', 'identifier']
-
-
-@vp_compile
-class EstablishRendezvousPayload(VariablePayload):
-    msg_id = 15
-    format_list = ['I', 'H', '20s']
-    names = ['circuit_id', 'identifier', 'cookie']
-
-
-@vp_compile
-class RendezvousEstablishedPayload(VariablePayload):
-    msg_id = 16
-    format_list = ['I', 'H', 'ipv4']
-    names = ['circuit_id', 'identifier', 'rendezvous_point_addr']
-
-
-@vp_compile
-class CreateE2EPayload(VariablePayload):
-    msg_id = 17
-    format_list = ['H', '20s', 'varlenH', 'varlenH']
-    names = ['identifier', 'info_hash', 'node_public_key', 'key']
-
-
-@vp_compile
-class CreatedE2EPayload(VariablePayload):
-    msg_id = 18
-    format_list = ['H', 'varlenH', '32s', 'raw']
-    names = ['identifier', 'key', 'auth', 'rp_info_enc']
-
-
-@vp_compile
-class LinkE2EPayload(VariablePayload):
-    msg_id = 19
-    format_list = ['I', 'H', '20s']
-    names = ['circuit_id', 'identifier', 'cookie']
-
-
-@vp_compile
-class LinkedE2EPayload(VariablePayload):
-    msg_id = 20
-    format_list = ['I', 'H']
-    names = ['circuit_id', 'identifier']
-
-
-@vp_compile
-class PeersRequestPayload(VariablePayload):
-    msg_id = 21
-    format_list = ['I', 'H', '20s']
-    names = ['circuit_id', 'identifier', 'info_hash']
-
-
-@vp_compile
-class IntroductionInfo(VariablePayload):
-    format_list = ['ipv4', 'varlenH', 'varlenH', 'B']
-    names = ['address', 'key', 'seeder_pk', 'source']
-
-
-@vp_compile
-class PeersResponsePayload(VariablePayload):
-    msg_id = 22
-    format_list = ['I', 'H', '20s', [IntroductionInfo]]
-    names = ['circuit_id', 'identifier', 'info_hash', 'peers']
-
-
-@vp_compile
-class RendezvousInfo(VariablePayload):
-    format_list = ['ipv4', 'varlenH', '20s']
-    names = ['address', 'key', 'cookie']
-
-
-class TestRequestPayload:
-    msg_id = 30
-
-    def __init__(self, circuit_id, identifier, response_size, data):
-        self.circuit_id = circuit_id
-        self.identifier = identifier
-        self.response_size = response_size
-        self.data = data
-
-    def to_bin(self):
-        return pack(f'!HH{len(self.data)}s', self.identifier, self.response_size, self.data)
-
-    @classmethod
-    def from_bin(cls, packet):
-        return cls(*unpack_from('!IHH', packet, 23), packet[31:])
-
-
-class TestResponsePayload:
-    msg_id = 31
-
-    def __init__(self, circuit_id, identifier, data):
-        self.circuit_id = circuit_id
-        self.identifier = identifier
-        self.data = data
-
-    def to_bin(self):
-        return pack(f'!H{len(self.data)}s', self.identifier, self.data)
-
-    @classmethod
-    def from_bin(cls, packet):
-        return cls(*unpack_from('!IH', packet, 23), packet[29:])

--- a/ipv8/messaging/anonymization/payload.py
+++ b/ipv8/messaging/anonymization/payload.py
@@ -298,9 +298,15 @@ class PeersRequestPayload(VariablePayload):
 
 
 @vp_compile
+class IntroductionInfo(VariablePayload):
+    format_list = ['ipv4', 'varlenH', 'varlenH', 'B']
+    names = ['address', 'key', 'seeder_pk', 'source']
+
+
+@vp_compile
 class PeersResponsePayload(VariablePayload):
     msg_id = 22
-    format_list = ['I', 'H', '20s', 'raw']
+    format_list = ['I', 'H', '20s', [IntroductionInfo]]
     names = ['circuit_id', 'identifier', 'info_hash', 'peers']
 
 

--- a/ipv8/messaging/anonymization/payload.py
+++ b/ipv8/messaging/anonymization/payload.py
@@ -188,29 +188,29 @@ class CellPayload(object):
 @vp_compile
 class CreatePayload(VariablePayload):
     msg_id = 2
-    format_list = ['I', 'varlenH', 'varlenH']
-    names = ['circuit_id', 'node_public_key', 'key']
+    format_list = ['I', 'H', 'varlenH', 'varlenH']
+    names = ['circuit_id', 'identifier', 'node_public_key', 'key']
 
 
 @vp_compile
 class CreatedPayload(VariablePayload):
     msg_id = 3
-    format_list = ['I', 'varlenH', '32s', 'raw']
-    names = ['circuit_id', 'key', 'auth', 'candidate_list_enc']
+    format_list = ['I', 'H', 'varlenH', '32s', 'raw']
+    names = ['circuit_id', 'identifier', 'key', 'auth', 'candidate_list_enc']
 
 
 @vp_compile
 class ExtendPayload(VariablePayload):
     msg_id = 4
-    format_list = ['I', 'varlenH', 'varlenH', 'ipv4']
-    names = ['circuit_id', 'node_public_key', 'key', 'node_addr']
+    format_list = ['I', 'H', 'varlenH', 'varlenH', 'ipv4']
+    names = ['circuit_id', 'identifier', 'node_public_key', 'key', 'node_addr']
 
 
 @vp_compile
 class ExtendedPayload(VariablePayload):
     msg_id = 5
-    format_list = ['I', 'varlenH', '32s', 'raw']
-    names = ['circuit_id', 'key', 'auth', 'candidate_list_enc']
+    format_list = ['I', 'H', 'varlenH', '32s', 'raw']
+    names = ['circuit_id', 'identifier', 'key', 'auth', 'candidate_list_enc']
 
 
 @vp_compile

--- a/ipv8/messaging/anonymization/payload.py
+++ b/ipv8/messaging/anonymization/payload.py
@@ -92,10 +92,11 @@ class DataPayload(object):
 class CellPayload(object):
     msg_id = 1
 
-    def __init__(self, circuit_id, message="", plaintext=False):
+    def __init__(self, circuit_id, message, plaintext=False, relay_early=False):
         self.circuit_id = circuit_id
         self.message = message
         self.plaintext = plaintext
+        self.relay_early = relay_early
 
     def encrypt(self, crypto, circuit=None, relay_session_keys=None):
         if self.plaintext:
@@ -176,12 +177,12 @@ class CellPayload(object):
     def to_bin(self, prefix):
         return b''.join([prefix,
                          bytes([1]),
-                         pack('!I?', self.circuit_id, self.plaintext) + self.message])
+                         pack('!I??', self.circuit_id, self.plaintext, self.relay_early) + self.message])
 
     @classmethod
     def from_bin(cls, packet):
-        circuit_id, plaintext = unpack_from('!I?', packet, 23)
-        return cls(circuit_id, packet[28:], plaintext)
+        circuit_id, plaintext, relay_early = unpack_from('!I??', packet, 23)
+        return cls(circuit_id, packet[29:], plaintext, relay_early)
 
 
 @vp_compile

--- a/ipv8/messaging/anonymization/payload.py
+++ b/ipv8/messaging/anonymization/payload.py
@@ -198,39 +198,18 @@ class CreatedPayload(VariablePayload):
     names = ['circuit_id', 'key', 'auth', 'candidate_list_enc']
 
 
-class ExtendPayload(Payload):
+@vp_compile
+class ExtendPayload(VariablePayload):
     msg_id = 4
-    format_list = ['I', 'varlenH', 'varlenH', 'raw']
-
-    def __init__(self, circuit_id, node_public_key, node_addr, key):
-        super(ExtendPayload, self).__init__()
-        self.circuit_id = circuit_id
-        self.node_public_key = node_public_key
-        self.key = key
-        self.node_addr = node_addr
-
-    def to_pack_list(self):
-        data = [('I', self.circuit_id),
-                ('varlenH', self.node_public_key),
-                ('varlenH', self.key)]
-
-        if self.node_addr:
-            host, port = self.node_addr
-            data.append(('4SH', socket.inet_aton(host), port))
-
-        return data
-
-    @classmethod
-    def from_unpack_list(cls, circuit_id, node_public_key, key, node_addr):
-        if node_addr:
-            host, port = unpack_from('>4sH', node_addr)
-            node_addr = (socket.inet_ntoa(host), port)
-        return ExtendPayload(circuit_id, node_public_key, node_addr or None, key)
+    format_list = ['I', 'varlenH', 'varlenH', 'ipv4']
+    names = ['circuit_id', 'node_public_key', 'key', 'node_addr']
 
 
 @vp_compile
-class ExtendedPayload(CreatedPayload):
+class ExtendedPayload(VariablePayload):
     msg_id = 5
+    format_list = ['I', 'varlenH', '32s', 'raw']
+    names = ['circuit_id', 'key', 'auth', 'candidate_list_enc']
 
 
 @vp_compile
@@ -241,8 +220,10 @@ class PingPayload(VariablePayload):
 
 
 @vp_compile
-class PongPayload(PingPayload):
+class PongPayload(VariablePayload):
     msg_id = 7
+    format_list = ['I', 'H']
+    names = ['circuit_id', 'identifier']
 
 
 @vp_compile
@@ -273,27 +254,11 @@ class EstablishRendezvousPayload(VariablePayload):
     names = ['circuit_id', 'identifier', 'cookie']
 
 
-class RendezvousEstablishedPayload(Payload):
+@vp_compile
+class RendezvousEstablishedPayload(VariablePayload):
     msg_id = 16
-    format_list = ['I', 'H', '4SH']
-
-    def __init__(self, circuit_id, identifier, rendezvous_point_addr):
-        super(RendezvousEstablishedPayload, self).__init__()
-        self.circuit_id = circuit_id
-        self.identifier = identifier
-        self.rendezvous_point_addr = rendezvous_point_addr
-
-    def to_pack_list(self):
-        host, port = self.rendezvous_point_addr
-        data = [('I', self.circuit_id),
-                ('H', self.identifier),
-                ('4SH', socket.inet_aton(host), port)]
-        return data
-
-    @classmethod
-    def from_unpack_list(cls, circuit_id, identifier, address):
-        rendezvous_point_addr = (socket.inet_ntoa(address[0]), address[1])
-        return RendezvousEstablishedPayload(circuit_id, identifier, rendezvous_point_addr)
+    format_list = ['I', 'H', 'ipv4']
+    names = ['circuit_id', 'identifier', 'rendezvous_point_addr']
 
 
 @vp_compile

--- a/ipv8/messaging/anonymization/payload.py
+++ b/ipv8/messaging/anonymization/payload.py
@@ -310,6 +310,12 @@ class PeersResponsePayload(VariablePayload):
     names = ['circuit_id', 'identifier', 'info_hash', 'peers']
 
 
+@vp_compile
+class RendezvousInfo(VariablePayload):
+    format_list = ['ipv4', 'varlenH', '20s']
+    names = ['address', 'key', 'cookie']
+
+
 class TestRequestPayload:
     msg_id = 30
 

--- a/ipv8/messaging/anonymization/tunnel.py
+++ b/ipv8/messaging/anonymization/tunnel.py
@@ -346,8 +346,8 @@ class RendezvousPoint(object):
     def __init__(self, circuit, cookie):
         self.circuit = circuit
         self.cookie = cookie
+        self.address = None
         self.ready = Future()
-        self.rp_info = None
 
 
 class IntroductionPoint(object):

--- a/ipv8/messaging/anonymization/tunnel.py
+++ b/ipv8/messaging/anonymization/tunnel.py
@@ -229,6 +229,7 @@ class Circuit(Tunnel):
         self.unverified_hop = None
         self.hs_session_keys = None
         self.e2e = False
+        self.relay_early_count = 0
 
     @property
     def peer(self):
@@ -335,6 +336,9 @@ class RelayRoute(Tunnel):
         """
         super(RelayRoute, self).__init__(circuit_id, peer)
         self.rendezvous_relay = rendezvous_relay
+        # Since the creation of a RelayRoute object is triggered by an extend (which was wrapped in a cell
+        # that had the early_relay flag set) we start the count at 1.
+        self.relay_early_count = 1
 
 
 class RendezvousPoint(object):

--- a/ipv8/messaging/lazy_payload.py
+++ b/ipv8/messaging/lazy_payload.py
@@ -78,7 +78,11 @@ class VariablePayload(Payload):
 
     @staticmethod
     def _to_packlist_fmt(fmt):
-        return fmt if isinstance(fmt, str) else 'payload'
+        if isinstance(fmt, str):
+            return fmt
+        if isinstance(fmt, list):
+            return 'payload-list'
+        return 'payload'
 
     def _fix_pack(self, name):
         """
@@ -202,10 +206,12 @@ def _compile_to_pack_list(src_cls, format_list, names):
     f_code = """
 def to_pack_list(self):
     return [%s]
-        """ % ', '.join(('("%s", self.fix_pack_%s(self.%s))' % (fmt if isinstance(fmt, str) else "payload",
-                                                                names[i], names[i]))
+        """ % ', '.join(('("%s", self.fix_pack_%s(self.%s))' % (fmt if isinstance(fmt, str) else
+                                                                ("payload-list" if isinstance(fmt, list)
+                                                                 else "payload"), names[i], names[i]))
                         if hasattr(src_cls, "fix_pack_" + names[i]) else
-                        ('("%s", self.%s)' % (fmt if isinstance(fmt, str) else "payload", names[i]))
+                        ('("%s", self.%s)' % (fmt if isinstance(fmt, str) else
+                                              ("payload-list" if isinstance(fmt, list) else "payload"), names[i]))
                         for i, fmt in enumerate(format_list))
     return compile(f_code, f_code, 'exec')
 

--- a/ipv8/messaging/serialization.py
+++ b/ipv8/messaging/serialization.py
@@ -1,8 +1,12 @@
+from __future__ import annotations
+
 import abc
 import typing
 from binascii import hexlify
 from socket import inet_aton, inet_ntoa
 from struct import Struct, pack, unpack_from
+
+FormatListType = typing.Union[str, "Serializable", typing.List["FormatListType"]]  # type:ignore
 
 
 class PackError(RuntimeError):
@@ -373,7 +377,7 @@ class Serializable(metaclass=abc.ABCMeta):
     Interface for serializable objects.
     """
 
-    format_list: typing.List[str] = []
+    format_list: typing.List[FormatListType] = []
 
     @abc.abstractmethod
     def to_pack_list(self):

--- a/ipv8/messaging/serialization.py
+++ b/ipv8/messaging/serialization.py
@@ -261,6 +261,33 @@ class Serializer(object):
         """
         self._packers[name] = packer
 
+    def pack(self, fmt, item):
+        """
+        Pack data without using a Serializable. Using a Serializable is the preferred method.
+        :param fmt: the name of the packer to use while packing
+        :param item: object to pack
+        :return: the packed data
+        :rtype: bytes
+        """
+        return self._packers[fmt].pack(item)
+
+    def unpack(self, fmt, data):
+        """
+        Unpack data without using a Serializable. Using a Serializable is the preferred method.
+        :param fmt: the name of the packer to use while unpacking
+        :param data: bytes to unpack
+        :return: the unpacked object
+        :rtype: object
+        """
+        unpack_list = []
+        if isinstance(fmt, str):
+            self._packers[fmt].unpack(data, 0, unpack_list)
+        elif isinstance(fmt, list):
+            self._packers['payload-list'].unpack(data, 0, unpack_list, fmt[0])
+        else:
+            self._packers['payload'].unpack(data, 0, unpack_list, fmt)
+        return unpack_list[0]
+
     def pack_serializable(self, serializable):
         """
         Serialize a single Serializable instance.

--- a/ipv8/test/messaging/anonymization/test_community.py
+++ b/ipv8/test/messaging/anonymization/test_community.py
@@ -143,6 +143,60 @@ class TestTunnelCommunity(TestBase):
         # Node 1 should not have an exit socket open
         self.assertEqual(len(self.overlay(1).exit_sockets), 0)
 
+    async def test_create_circuit_too_many_hops(self):
+        """
+        Check if creating a circuit that is too long fails.
+        """
+        for _ in range(3):
+            self.add_node_to_experiment(self.create_node())
+        for node in self.nodes:
+            node.overlay.settings.max_relay_early = 3
+
+        self.overlay(1).settings.peer_flags.add(PEER_FLAG_EXIT_BT)
+        await self.introduce_nodes()
+        self.overlay(0).build_tunnels(5)
+
+        await self.deliver_messages()
+
+        self.assertEqual(self.overlay(0).tunnels_ready(5), 0.0)
+
+    async def test_create_circuit_relay_early_fail_hop1(self):
+        """
+        Check if extending a circuit using a cell with a bad relay_early flag fails at the first hop.
+        """
+        self.add_node_to_experiment(self.create_node())
+        for node in self.nodes:
+            node.overlay.settings.max_relay_early = 0
+
+        self.overlay(1).settings.peer_flags.add(PEER_FLAG_EXIT_BT)
+        await self.introduce_nodes()
+
+        self.overlay(0).settings.max_relay_early = 2
+        self.overlay(0).build_tunnels(2)
+
+        await self.deliver_messages()
+
+        self.assertEqual(self.overlay(0).tunnels_ready(2), 0.0)
+
+    async def test_create_circuit_relay_early_fail_hop2(self):
+        """
+        Check if extending a circuit using a cell with a bad relay_early flag fails at the second hop.
+        """
+        for _ in range(2):
+            self.add_node_to_experiment(self.create_node())
+        for node in self.nodes:
+            node.overlay.settings.max_relay_early = 1
+
+        self.overlay(1).settings.peer_flags.add(PEER_FLAG_EXIT_BT)
+        await self.introduce_nodes()
+
+        self.overlay(0).settings.max_relay_early = 2
+        self.overlay(0).build_tunnels(3)
+
+        await self.deliver_messages()
+
+        self.assertEqual(self.overlay(0).tunnels_ready(3), 0.0)
+
     async def test_create_circuit_multiple_calls(self):
         """
         Check if circuit creation is aborted when it's already building the requested circuit.

--- a/ipv8/test/messaging/anonymization/test_hiddenservices.py
+++ b/ipv8/test/messaging/anonymization/test_hiddenservices.py
@@ -8,6 +8,7 @@ from ...mocking.exit_socket import MockTunnelExitSocket
 from ...mocking.ipv8 import MockIPv8
 from ....messaging.anonymization.community import CIRCUIT_TYPE_RP_DOWNLOADER, TunnelSettings
 from ....messaging.anonymization.hidden_services import HiddenTunnelCommunity
+from ....messaging.anonymization.payload import TestRequestPayload
 from ....messaging.anonymization.tunnel import (CIRCUIT_TYPE_DATA, CIRCUIT_TYPE_IP_SEEDER, IntroductionPoint,
                                                 PEER_FLAG_EXIT_BT, PEER_FLAG_SPEED_TEST, PEER_SOURCE_DHT)
 from ....peer import Peer
@@ -312,13 +313,13 @@ class TestHiddenServices(TestBase):
         send_cell = self.overlay(0).send_cell
         self.overlay(0).send_cell = Mock(wraps=send_cell)
         on_test_request = self.overlay(2).on_test_request
-        self.overlay(2).decode_map_private[30] = Mock(wraps=on_test_request)
+        self.overlay(2).decode_map_private[TestRequestPayload.msg_id] = Mock(wraps=on_test_request)
 
         circuit, = self.overlay(0).find_circuits(ctype=CIRCUIT_TYPE_RP_DOWNLOADER)
         data, _ = await self.overlay(0).send_test_request(circuit, 3, 6)
         self.assertEqual(len(self.overlay(0).send_cell.call_args[0][1].data), 3)
         self.assertEqual(len(data), 6)
-        self.overlay(2).decode_map_private[30].assert_called_once()
+        self.overlay(2).decode_map_private[TestRequestPayload.msg_id].assert_called_once()
 
         self.overlay(0).leave_swarm(self.service)
         self.overlay(2).leave_swarm(self.service)

--- a/ipv8/test/messaging/test_lazy_payload.py
+++ b/ipv8/test/messaging/test_lazy_payload.py
@@ -100,6 +100,14 @@ class CompiledNewC(NewC):
     pass
 
 
+class E(VariablePayload):
+    """
+    A VariablePayload with a list of payloads.
+    """
+    format_list = [[A]]
+    names = ["list_of_A"]
+
+
 class TestVariablePayload(TestBase):
 
     def _pack_and_unpack(self, payload, instance):
@@ -304,3 +312,16 @@ class TestVariablePayload(TestBase):
         self.assertEqual(d.a, 0)
         self.assertEqual(deserialized.a, 0)
         self.assertEqual(serialized, b'\x00\x00\x00\x01')
+
+    def test_payload_list(self):
+        """
+        Check if unpacked payload lists works correctly.
+        """
+        e = E([A(1, 2), A(3, 4)])
+
+        deserialized = self._pack_and_unpack(E, e)
+
+        self.assertEqual(e.list_of_A[0].a, deserialized.list_of_A[0].a)
+        self.assertEqual(e.list_of_A[0].b, deserialized.list_of_A[0].b)
+        self.assertEqual(e.list_of_A[1].a, deserialized.list_of_A[1].a)
+        self.assertEqual(e.list_of_A[1].b, deserialized.list_of_A[1].b)


### PR DESCRIPTION
This PR breaks compatibility with the current version of the `TunnelCommunity` and does the following:
* Removes the nested decorator from `unpack_cell` as it's hurting performance.
* Updates the tunnel payload to use the new ipv4 packer.
* Adds the relay_early flag to `CellPayload` in order to limit the maximum length of a circuit.
* Switches to `libnacl` with AES-256-GCM for tunnel crypto, giving an increase in throughput of about 25%.
* Adds an identifier field to create(d)/extend(ed).
* Adds functions for manual (un)packing to the `Serializer`.
* Removes the use of `encode`/`decode` throughout the `TunnelCommunity`.
* Updates `DataPayload` to use the IPv8 `Serializer`. With the recent changes to the `Serializer`, it's fast enough to use for tunnel data. I measured a small decrease in throughput of 1-2% (which could just as easily be attributed to random variance).
* Adds list support to `NestedPayload`, so we can have payloads like:

```python
@vp_compile
class IntroductionInfo(VariablePayload):
    names = ['address', 'key', 'seeder_pk', 'source']
    format_list = ['ipv4', 'varlenH', 'varlenH', 'B']

@vp_compile
class PeersResponsePayload(VariablePayload):
    msg_id = 22
    names = ['circuit_id', 'identifier', 'info_hash', 'peers']
    format_list = ['I', 'H', '20s', [IntroductionInfo]]
```
