### PR TITLE
Update CreateRequestCache to use the payload identifier

### DIFF
--- a/ipv8/messaging/anonymization/caches.py
+++ b/ipv8/messaging/anonymization/caches.py
@@ -10,8 +10,8 @@ class CreateRequestCache(NumberCache):
     """
     Used to track outstanding create messages
     """
-    def __init__(self, community, to_circuit_id, from_circuit_id, peer, to_peer):
-        super().__init__(community.request_cache, "create", to_circuit_id)
+    def __init__(self, community, identifier, to_circuit_id, from_circuit_id, peer, to_peer):
+        super().__init__(community.request_cache, "create", identifier)
         self.community = community
         self.to_circuit_id = to_circuit_id
         self.from_circuit_id = from_circuit_id

--- a/ipv8/messaging/anonymization/community.py
+++ b/ipv8/messaging/anonymization/community.py
@@ -116,7 +116,6 @@ class TunnelCommunity(Community):
         self.add_cell_handler(TestRequestPayload, self.on_test_request)
         self.add_cell_handler(TestResponsePayload, self.on_test_response)
 
-        self.select_index = -1
         self.circuits = {}
         self.directions = {}
         self.relay_from_to = {}
@@ -239,14 +238,6 @@ class TunnelCommunity(Community):
                 and (ctype is None or c.ctype == ctype)
                 and (exit_flags is None or set(exit_flags) <= set(c.exit_flags))
                 and (hops is None or hops == c.goal_hops)]
-
-    def select_circuit(self, destination, hops):
-        circuits = sorted(self.find_circuits(hops=hops), key=lambda c: c.circuit_id)
-        if not circuits:
-            return None
-
-        self.select_index = (self.select_index + 1) % len(circuits)
-        return circuits[self.select_index]
 
     def create_circuit(self, goal_hops, ctype=CIRCUIT_TYPE_DATA, exit_flags=None, required_exit=None, info_hash=None):
         self.logger.info("Creating a new circuit of length %d (type: %s)", goal_hops, ctype)

--- a/ipv8/messaging/anonymization/hidden_services.py
+++ b/ipv8/messaging/anonymization/hidden_services.py
@@ -260,7 +260,9 @@ class HiddenTunnelCommunity(TunnelCommunity):
             if circuit and circuit.state == CIRCUIT_STATE_READY and \
                circuit.ctype == CIRCUIT_TYPE_RP_DOWNLOADER:
                 return circuit
-        return super(HiddenTunnelCommunity, self).select_circuit(destination, hops)
+
+        circuits = self.find_circuits(hops=hops)
+        return random.choice(circuits) if circuits else None
 
     def send_peers_request(self, info_hash, target, hops):
         circuit = self.select_circuit(None, hops)


### PR DESCRIPTION
This PR:
* Updates `CreateRequestCache` to use the payload identifier.
* Removes `select_circuit` from `TunnelCommunity` as this functionality has moved to `Dispatcher`.