### PR TITLE
Added deferred bootstrap DNS resolution

### DIFF
--- a/ipv8/test/peerdiscovery/test_community.py
+++ b/ipv8/test/peerdiscovery/test_community.py
@@ -1,9 +1,10 @@
+import asyncio
 import os
 from functools import reduce
 
 from ..base import TestBase
 from ..mocking.community import MockCommunity
-from ...community import _DEFAULT_ADDRESSES
+from ...community import _DEFAULT_ADDRESSES, _DNS_ADDRESSES
 from ...messaging.payload_headers import BinMemberAuthenticationPayload, GlobalTimeDistributionPayload
 from ...peerdiscovery.payload import DiscoveryIntroductionRequestPayload
 
@@ -14,6 +15,8 @@ class TestDiscoveryCommunity(TestBase):
         super(TestDiscoveryCommunity, self).setUp()
         while _DEFAULT_ADDRESSES:
             _DEFAULT_ADDRESSES.pop()
+        while _DNS_ADDRESSES:
+            _DNS_ADDRESSES.pop()
         self.tracker = MockCommunity()
         _DEFAULT_ADDRESSES.append(self.tracker.endpoint.wan_address)
 
@@ -95,3 +98,26 @@ class TestDiscoveryCommunity(TestBase):
 
         self.assertEqual(len(self.overlays[1].network.services_per_peer), 2)
         self.assertSetEqual(discovered, {MockCommunity.community_id, custom_community_id})
+
+    async def test_deferred_resolution_dns(self):
+        """
+        Check if resolution of DNS bootstrapping is atomic and deferred.
+        """
+        _DEFAULT_ADDRESSES.append(self.overlays[0].endpoint.wan_address)
+        _DNS_ADDRESSES.append(self.tracker.endpoint.wan_address)
+        _DNS_ADDRESSES.append(self.overlays[0].endpoint.wan_address)
+        _DNS_ADDRESSES.append(self.overlays[1].endpoint.wan_address)
+
+        self.assertEqual(2, len(_DEFAULT_ADDRESSES))
+
+        i = 0
+        for _ in _DEFAULT_ADDRESSES:  # Use the list iterator, don't fetch on-demand: tests thread-safety.
+            if i == 0:
+                self.overlays[0].resolve_dns_bootstrap_addresses()
+                # If the list update were not thread-safe, the next loop would cause a concurrent modification
+                # exception. The list should grow from 2 -> 3 items during the following sleep.
+                await asyncio.sleep(0.1)
+            i += 1
+
+        self.assertEqual(3, i)
+        self.assertEqual(3, len(_DEFAULT_ADDRESSES))


### PR DESCRIPTION
Fixes #903

This PR:

 - Updates `resolve_dns_bootstrap_addresses()` to run in a daemon thread.
 - Updates `resolve_dns_bootstrap_addresses()` to not add duplicates to the `_DEFAULT_ADDRESSES`.

Note (#903): this deliberately avoids `asyncio`.