### PR TITLE
Updated "too many peers" log level to DEBUG

### DIFF
--- a/ipv8/community.py
+++ b/ipv8/community.py
@@ -286,8 +286,8 @@ class Community(EZPackOverlay):
     @lazy_wrapper(GlobalTimeDistributionPayload, IntroductionRequestPayload)
     def on_introduction_request(self, peer, dist, payload):
         if self.max_peers >= 0 and len(self.get_peers()) > self.max_peers:
-            self.logger.info("Dropping introduction request from (%s, %d): too many peers!",
-                             peer.address[0], peer.address[1])
+            self.logger.debug("Dropping introduction request from (%s, %d): too many peers!",
+                              peer.address[0], peer.address[1])
             return
 
         self.network.add_verified_peer(peer)

--- a/ipv8/peerdiscovery/community.py
+++ b/ipv8/peerdiscovery/community.py
@@ -72,8 +72,8 @@ class DiscoveryCommunity(Community):
 
     def on_introduction_request(self, source_address, data):
         if self.max_peers >= 0 and len(self.get_peers()) > self.max_peers:
-            self.logger.info("Dropping introduction request from (%s, %d): too many peers!",
-                             source_address[0], source_address[1])
+            self.logger.debug("Dropping introduction request from (%s, %d): too many peers!",
+                              source_address[0], source_address[1])
             return
 
         try:
@@ -116,8 +116,8 @@ class DiscoveryCommunity(Community):
     @lazy_wrapper(GlobalTimeDistributionPayload, SimilarityResponsePayload)
     def on_similarity_response(self, node, dist, payload):
         if self.max_peers >= 0 and len(self.get_peers()) > self.max_peers and node not in self.network.verified_peers:
-            self.logger.info("Dropping similarity response from (%s, %d): too many peers!",
-                             node.address[0], node.address[1])
+            self.logger.debug("Dropping similarity response from (%s, %d): too many peers!",
+                              node.address[0], node.address[1])
             return
 
         self.network.add_verified_peer(node)


### PR DESCRIPTION
Fixes #905

This PR:

 - Updates the logging level for too many peers to `DEBUG`.

