### PR TITLE
Add address packer to default Serializer

### DIFF
--- a/ipv8/messaging/anonymization/community.py
+++ b/ipv8/messaging/anonymization/community.py
@@ -155,7 +155,6 @@ class TunnelCommunity(Community):
 
     def get_serializer(self):
         serializer = super().get_serializer()
-        serializer.add_packer('address', Address())
         serializer.add_packer('flags', Flags())
         return serializer
 

--- a/ipv8/messaging/anonymization/hidden_services.py
+++ b/ipv8/messaging/anonymization/hidden_services.py
@@ -6,6 +6,7 @@ Author(s): Egbert Bouman
 import binascii
 import os
 import random
+import socket
 import struct
 from asyncio import gather, iscoroutine
 

--- a/ipv8/messaging/anonymization/payload.py
+++ b/ipv8/messaging/anonymization/payload.py
@@ -1,8 +1,6 @@
 from functools import reduce
 from struct import calcsize, pack, unpack_from
 
-from libnacl import CryptError
-
 from ...messaging.anonymization.tunnel import (CIRCUIT_TYPE_RP_DOWNLOADER, CIRCUIT_TYPE_RP_SEEDER, EXIT_NODE,
                                                EXIT_NODE_SALT, ORIGINATOR, ORIGINATOR_SALT)
 from ...messaging.anonymization.tunnelcrypto import CryptoException
@@ -229,7 +227,7 @@ class CellPayload:
                     self.message = crypto.decrypt_str(self.message,
                                                       hop.session_keys[ORIGINATOR],
                                                       hop.session_keys[ORIGINATOR_SALT])
-                except CryptError as e:
+                except ValueError as e:
                     raise CryptoException("Got exception %r when trying to remove encryption layer %s "
                                           "for message: %r received for circuit_id: %s, circuit_hops: %r" %
                                           (e, layer, self.message, self.circuit_id, circuit.hops)) from e
@@ -246,7 +244,7 @@ class CellPayload:
                 self.message = crypto.decrypt_str(self.message,
                                                   relay_session_keys[EXIT_NODE],
                                                   relay_session_keys[EXIT_NODE_SALT])
-            except CryptError as e:
+            except ValueError as e:
                 raise CryptoException("Got exception %r when trying to decrypt relay message: "
                                       "cell received for circuit_id: %s" % (e, self.circuit_id)) from e
 

--- a/ipv8/messaging/interfaces/udp/endpoint.py
+++ b/ipv8/messaging/interfaces/udp/endpoint.py
@@ -8,6 +8,7 @@ from ..endpoint import Endpoint, EndpointClosedException
 
 UDPv4Address = collections.namedtuple("UDPv4Address", ["ip", "port"])
 UDPv6Address = collections.namedtuple("UDPv6Address", ["ip", "port"])
+DomainAddress = collections.namedtuple("DomainAddress", ["host", "port"])
 
 
 class UDPEndpoint(Endpoint, asyncio.DatagramProtocol):

--- a/ipv8/test/messaging/anonymization/test_community.py
+++ b/ipv8/test/messaging/anonymization/test_community.py
@@ -10,7 +10,7 @@ from ....messaging.anonymization.community import TunnelCommunity, TunnelSetting
 from ....messaging.anonymization.endpoint import TunnelEndpoint
 from ....messaging.anonymization.tunnel import (CIRCUIT_STATE_EXTENDING, PEER_FLAG_EXIT_BT,
                                                 PEER_FLAG_EXIT_IPV8, PEER_FLAG_SPEED_TEST)
-from ....messaging.interfaces.udp.endpoint import UDPEndpoint
+from ....messaging.interfaces.udp.endpoint import DomainAddress, UDPEndpoint
 from ....util import succeed
 
 # Map of info_hash -> peer list
@@ -304,7 +304,8 @@ class TestTunnelCommunity(TestBase):
         # Tunnel the data to the endpoint
         circuit = list(self.overlay(0).circuits.values())[0]
         self.overlay(0).send_data(circuit.peer, circuit.circuit_id,
-                                  ('localhost', self.public_endpoint.get_address()[1]), ('0.0.0.0', 0), data)
+                                  DomainAddress('localhost', self.public_endpoint.get_address()[1]),
+                                  ('0.0.0.0', 0), data)
 
         future = Future()
         ep_listener.on_packet = lambda packet: ep_listener.received_packets.append(packet) or future.set_result(None)
@@ -502,7 +503,7 @@ class TestTunnelCommunity(TestBase):
         mock_exit = self.overlay(1).exit_sockets[exit_socket.circuit_id] = MockTunnelExitSocket(exit_socket)
         mock_exit.sendto = Mock()
 
-        unicode_destination = ('JP納豆.例.jp', 1234)
+        unicode_destination = DomainAddress('JP納豆.例.jp', 1234)
         self.overlay(0).send_data(circuit.peer, circuit.circuit_id, unicode_destination, ('0.0.0.0', 0), b'')
         await self.deliver_messages()
 


### PR DESCRIPTION
This PR:
* Adds the `Address` packer to the default `Serializer`. Unfortunately, to maintain compatibility with the `TunnelCommunity`, it's using a `varlenH` for domain names (wasting an extra byte).
* Updates `CellPayload` to catch the correct exception while doing crypto.
* Updates `PexCommunity` to stop using encode/decode. Now that `TrustChain` is the only community still using it, this functionality can be removed in the future (see https://github.com/Tribler/py-ipv8/issues/908).
Note that the `PexCommunity` does a +1 on the `community_id`, instead of using `version_id`. This is because the trackers aren't looking at the first 2 bytes of the prefix, which could lead to being introduced to old `PexCommunities`. This would make peer discovery take longer.