### PR TITLE
Community base class IPv6 support

### DIFF
--- a/ipv8/attestation/trustchain/community.py
+++ b/ipv8/attestation/trustchain/community.py
@@ -657,16 +657,17 @@ class TrustChainCommunity(Community):
         return 0 if not latest_block else latest_block.sequence_number
 
     @synchronized
-    def create_introduction_request(self, socket_address, extra_bytes=b''):
+    def create_introduction_request(self, socket_address, extra_bytes=b'', new_style=False):
         extra_bytes = struct.pack('>l', self.get_chain_length())
-        return super(TrustChainCommunity, self).create_introduction_request(socket_address, extra_bytes)
+        return super().create_introduction_request(socket_address, extra_bytes, new_style)
 
     @synchronized
     def create_introduction_response(self, lan_socket_address, socket_address, identifier,
-                                     introduction=None, extra_bytes=b''):
+                                     introduction=None, extra_bytes=b'', prefix=None, new_style=False):
         extra_bytes = struct.pack('>l', self.get_chain_length())
         return super(TrustChainCommunity, self).create_introduction_response(lan_socket_address, socket_address,
-                                                                             identifier, introduction, extra_bytes)
+                                                                             identifier, introduction, extra_bytes,
+                                                                             prefix, new_style)
 
     @synchronized
     def introduction_response_callback(self, peer, dist, payload):

--- a/ipv8/messaging/anonymization/community.py
+++ b/ipv8/messaging/anonymization/community.py
@@ -579,17 +579,18 @@ class TunnelCommunity(Community):
     def introduction_response_callback(self, peer, dist, payload):
         self.candidates[peer] = self.extract_peer_flags(payload.extra_bytes)
 
-    def create_introduction_request(self, socket_address, extra_bytes=b''):
+    def create_introduction_request(self, socket_address, extra_bytes=b'', new_style=False):
         extra_payload = ExtraIntroductionPayload(self.settings.peer_flags)
         extra_bytes = self.serializer.pack_serializable(extra_payload)
-        return super(TunnelCommunity, self).create_introduction_request(socket_address, extra_bytes)
+        return super().create_introduction_request(socket_address, extra_bytes, new_style)
 
     def create_introduction_response(self, lan_socket_address, socket_address, identifier,
-                                     introduction=None, extra_bytes=b''):
+                                     introduction=None, extra_bytes=b'', prefix=None, new_style=False):
         extra_payload = ExtraIntroductionPayload(self.settings.peer_flags)
         extra_bytes = self.serializer.pack_serializable(extra_payload)
         return super(TunnelCommunity, self).create_introduction_response(lan_socket_address, socket_address,
-                                                                         identifier, introduction, extra_bytes)
+                                                                         identifier, introduction, extra_bytes,
+                                                                         prefix, new_style)
 
     def on_cell(self, source_address, data):
         cell = CellPayload.from_bin(data)

--- a/ipv8/messaging/anonymization/pex.py
+++ b/ipv8/messaging/anonymization/pex.py
@@ -72,13 +72,13 @@ class PexCommunity(Community):
     def introduction_response_callback(self, peer, dist, payload):
         self.process_extra_bytes(peer, payload.extra_bytes)
 
-    def create_introduction_request(self, socket_address, extra_bytes=b''):
-        return super().create_introduction_request(socket_address, self.get_seeder_pks())
+    def create_introduction_request(self, socket_address, extra_bytes=b'', new_style=False):
+        return super().create_introduction_request(socket_address, self.get_seeder_pks(), new_style)
 
     def create_introduction_response(self, lan_socket_address, socket_address, identifier,
-                                     introduction=None, extra_bytes=b''):
-        return super().create_introduction_response(lan_socket_address, socket_address,
-                                                    identifier, introduction, self.get_seeder_pks())
+                                     introduction=None, extra_bytes=b'', prefix=None, new_style=False):
+        return super().create_introduction_response(lan_socket_address, socket_address, identifier, introduction,
+                                                    self.get_seeder_pks(), new_style=new_style)
 
     def get_seeder_pks(self):
         pks = random.sample(self.intro_points_for, min(len(self.intro_points_for), 10))

--- a/ipv8/messaging/interfaces/udp/endpoint.py
+++ b/ipv8/messaging/interfaces/udp/endpoint.py
@@ -134,4 +134,4 @@ class UDPv6Endpoint(UDPEndpoint):
         # If the endpoint is still running, accept incoming requests, otherwise drop them
         if self._running:
             self.bytes_down += len(datagram)
-            self.notify_listeners((UDPv6Address(*addr), datagram))
+            self.notify_listeners((UDPv6Address(*addr[:2]), datagram))

--- a/ipv8/messaging/payload.py
+++ b/ipv8/messaging/payload.py
@@ -1,6 +1,6 @@
 from socket import inet_aton, inet_ntoa
 
-from ..messaging.serialization import Serializable
+from ..messaging.serialization import Payload
 
 
 def encode_connection_type(type):
@@ -19,17 +19,6 @@ def decode_connection_type(bit_0, bit_1):
         return u"public"
     if bits == (1, 1):
         return u"symmetric-NAT"
-
-
-class Payload(Serializable):
-
-    def __str__(self):
-        out = self.__class__.__name__
-        for attribute in dir(self):
-            if not (attribute.startswith('_') or callable(getattr(self, attribute))) \
-                    and attribute not in ['format_list', 'names']:
-                out += '\n| %s: %s' % (attribute, repr(getattr(self, attribute)))
-        return out
 
 
 class IntroductionRequestPayload(Payload):

--- a/ipv8/messaging/payload.py
+++ b/ipv8/messaging/payload.py
@@ -1,5 +1,4 @@
-from socket import inet_aton, inet_ntoa
-
+from ..messaging.lazy_payload import VariablePayload, vp_compile
 from ..messaging.serialization import Payload
 
 
@@ -24,10 +23,10 @@ def decode_connection_type(bit_0, bit_1):
 class IntroductionRequestPayload(Payload):
 
     msg_id = 246
-    format_list = ['4SH', '4SH', '4SH', 'bits', 'H', 'raw']
+    format_list = ['ipv4', 'ipv4', 'ipv4', 'bits', 'H', 'raw']
 
     def __init__(self, destination_address, source_lan_address, source_wan_address, advice, connection_type,
-                 identifier, extra_bytes):
+                 identifier, extra_bytes, supports_new_style=True):
         """
         Create the payload for an introduction-request message.
 
@@ -58,42 +57,55 @@ class IntroductionRequestPayload(Payload):
         self.source_lan_address = source_lan_address
         self.source_wan_address = source_wan_address
         self.advice = advice
+        self.supports_new_style = supports_new_style
         self.connection_type = connection_type
         self.identifier = identifier % 65536
         self.extra_bytes = extra_bytes
 
     def to_pack_list(self):
         encoded_connection_type = encode_connection_type(self.connection_type)
-        data = [('4SH', inet_aton(self.destination_address[0]), self.destination_address[1]),
-                ('4SH', inet_aton(self.source_lan_address[0]), self.source_lan_address[1]),
-                ('4SH', inet_aton(self.source_wan_address[0]), self.source_wan_address[1]),
-                ('bits', encoded_connection_type[0], encoded_connection_type[1], 0, 0, 0, 0, 0, self.advice),
+        data = [('ipv4', self.destination_address),
+                ('ipv4', self.source_lan_address),
+                ('ipv4', self.source_wan_address),
+                ('bits', encoded_connection_type[0], encoded_connection_type[1], self.supports_new_style, 0, 0, 0, 0,
+                 self.advice),
                 ('H', self.identifier),
                 ('raw', self.extra_bytes)]
         return data
 
     @classmethod
     def from_unpack_list(cls, destination_address, source_lan_address, source_wan_address,
-                         connection_type_0, connection_type_1, dflag0, dflag1, dflag2, tunnel, sync, advice,
+                         connection_type_0, connection_type_1, supports_new_style, dflag1, dflag2, tunnel, sync, advice,
                          identifier, extra_bytes):
-        args = [(inet_ntoa(destination_address[0]), destination_address[1]),
-                (inet_ntoa(source_lan_address[0]), source_lan_address[1]),
-                (inet_ntoa(source_wan_address[0]), source_wan_address[1]),
+        args = [destination_address,
+                source_lan_address[1],
+                source_wan_address[1],
                 [True, False][advice],
                 decode_connection_type(connection_type_0, connection_type_1),
                 identifier,
-                extra_bytes]
+                extra_bytes,
+                supports_new_style]
 
         return IntroductionRequestPayload(*args)
+
+
+@vp_compile
+class NewIntroductionRequestPayload(VariablePayload):
+
+    msg_id = 234
+    format_list = ['ip_address', 'ip_address', 'ip_address', 'H', 'bits', 'raw']
+    names = ["destination_address", "source_lan_address", "source_wan_address", "identifier", "flag0", "flag1",
+             "flag2", "flag3", "flag4", "flag5", "flag6", "flag7", "extra_bytes"]
 
 
 class IntroductionResponsePayload(Payload):
 
     msg_id = 245
-    format_list = ['4SH', '4SH', '4SH', '4SH', '4SH', 'bits', 'H', 'raw']
+    format_list = ['ipv4', 'ipv4', 'ipv4', 'ipv4', 'ipv4', 'bits', 'H', 'raw']
 
     def __init__(self, destination_address, source_lan_address, source_wan_address, lan_introduction_address,
-                 wan_introduction_address, connection_type, tunnel, identifier, extra_bytes):
+                 wan_introduction_address, connection_type, tunnel, identifier, extra_bytes, supports_new_style=True,
+                 intro_supports_new_style=False):
         """
         Create the payload for an introduction-response message.
 
@@ -139,17 +151,20 @@ class IntroductionResponsePayload(Payload):
         self.wan_introduction_address = wan_introduction_address
         self.connection_type = connection_type
         self.tunnel = tunnel
+        self.supports_new_style = supports_new_style
+        self.intro_supports_new_style = intro_supports_new_style
         self.identifier = identifier % 65536
         self.extra_bytes = extra_bytes
 
     def to_pack_list(self):
         encoded_connection_type = encode_connection_type(self.connection_type)
-        data = [('4SH', inet_aton(self.destination_address[0]), self.destination_address[1]),
-                ('4SH', inet_aton(self.source_lan_address[0]), self.source_lan_address[1]),
-                ('4SH', inet_aton(self.source_wan_address[0]), self.source_wan_address[1]),
-                ('4SH', inet_aton(self.lan_introduction_address[0]), self.lan_introduction_address[1]),
-                ('4SH', inet_aton(self.wan_introduction_address[0]), self.wan_introduction_address[1]),
-                ('bits', encoded_connection_type[0], encoded_connection_type[1], 0, 0, 0, 0, 0, 0),
+        data = [('ipv4', self.destination_address),
+                ('ipv4', self.source_lan_address),
+                ('ipv4', self.source_wan_address),
+                ('ipv4', self.lan_introduction_address),
+                ('ipv4', self.wan_introduction_address),
+                ('bits', encoded_connection_type[0], encoded_connection_type[1], 0, self.supports_new_style,
+                 self.intro_supports_new_style, 0, 0, 0),
                 ('H', self.identifier),
                 ('raw', self.extra_bytes)]
         return data
@@ -157,25 +172,37 @@ class IntroductionResponsePayload(Payload):
     @classmethod
     def from_unpack_list(cls, destination_address, source_lan_address, source_wan_address,
                          introduction_lan_address, introduction_wan_address,
-                         connection_type_0, connection_type_1, dflag0, dflag1, dflag2, dflag3, dflag4, dflag5,
-                         identifier, extra_bytes):
-        args = [(inet_ntoa(destination_address[0]), destination_address[1]),
-                (inet_ntoa(source_lan_address[0]), source_lan_address[1]),
-                (inet_ntoa(source_wan_address[0]), source_wan_address[1]),
-                (inet_ntoa(introduction_lan_address[0]), introduction_lan_address[1]),
-                (inet_ntoa(introduction_wan_address[0]), introduction_wan_address[1]),
+                         connection_type_0, connection_type_1, dflag0, supports_new_style, intro_supports_new_style,
+                         dflag3, dflag4, dflag5, identifier, extra_bytes):
+        args = [destination_address,
+                source_lan_address,
+                source_wan_address,
+                introduction_lan_address,
+                introduction_wan_address,
                 decode_connection_type(connection_type_0, connection_type_1),
                 False,
                 identifier,
-                extra_bytes]
+                extra_bytes,
+                supports_new_style,
+                intro_supports_new_style]
 
         return IntroductionResponsePayload(*args)
+
+
+@vp_compile
+class NewIntroductionResponsePayload(VariablePayload):
+
+    msg_id = 233
+    format_list = ['ip_address', 'ip_address', 'ip_address', 'ip_address', 'ip_address', 'H', 'bits', 'raw']
+    names = ["destination_address", "source_lan_address", "source_wan_address", "lan_introduction_address",
+             "wan_introduction_address", "identifier", "intro_supports_new_style", "flag1", "flag2", "flag3",
+             "flag4", "flag5", "flag6", "flag7", "extra_bytes"]
 
 
 class PunctureRequestPayload(Payload):
 
     msg_id = 250
-    format_list = ['4SH', '4SH', 'H']
+    format_list = ['ipv4', 'ipv4', 'H']
 
     def __init__(self, lan_walker_address, wan_walker_address, identifier):
         """
@@ -201,25 +228,33 @@ class PunctureRequestPayload(Payload):
         self.identifier = identifier % 65536
 
     def to_pack_list(self):
-        data = [('4SH', inet_aton(self.lan_walker_address[0]), self.lan_walker_address[1]),
-                ('4SH', inet_aton(self.wan_walker_address[0]), self.wan_walker_address[1]),
+        data = [('ipv4', self.lan_walker_address),
+                ('ipv4', self.wan_walker_address),
                 ('H', self.identifier)]
 
         return data
 
     @classmethod
     def from_unpack_list(cls, lan_walker_address, wan_walker_address, identifier):
-        args = [(inet_ntoa(lan_walker_address[0]), lan_walker_address[1]),
-                (inet_ntoa(wan_walker_address[0]), wan_walker_address[1]),
+        args = [lan_walker_address,
+                wan_walker_address,
                 identifier]
 
         return PunctureRequestPayload(*args)
 
 
+@vp_compile
+class NewPunctureRequestPayload(VariablePayload):
+
+    msg_id = 232
+    format_list = ['ip_address', 'ip_address', 'H']
+    names = ["lan_walker_address", "wan_walker_address", "identifier"]
+
+
 class PuncturePayload(Payload):
 
     msg_id = 249
-    format_list = ['4SH', '4SH', 'H']
+    format_list = ['ipv4', 'ipv4', 'H']
 
     def __init__(self, source_lan_address, source_wan_address, identifier):
         """
@@ -240,16 +275,24 @@ class PuncturePayload(Payload):
         self.identifier = identifier % 65536
 
     def to_pack_list(self):
-        data = [('4SH', inet_aton(self.source_lan_address[0]), self.source_lan_address[1]),
-                ('4SH', inet_aton(self.source_wan_address[0]), self.source_wan_address[1]),
+        data = [('ipv4', self.source_lan_address),
+                ('ipv4', self.source_wan_address),
                 ('H', self.identifier)]
 
         return data
 
     @classmethod
     def from_unpack_list(cls, lan_walker_address, wan_walker_address, identifier):
-        args = [(inet_ntoa(lan_walker_address[0]), lan_walker_address[1]),
-                (inet_ntoa(wan_walker_address[0]), wan_walker_address[1]),
+        args = [lan_walker_address,
+                wan_walker_address,
                 identifier]
 
         return PuncturePayload(*args)
+
+
+@vp_compile
+class NewPuncturePayload(VariablePayload):
+
+    msg_id = 231
+    format_list = ['ip_address', 'ip_address', 'H']
+    names = ["source_lan_address", "source_wan_address", "identifier"]

--- a/ipv8/messaging/serialization.py
+++ b/ipv8/messaging/serialization.py
@@ -98,14 +98,14 @@ class Bits(object):
         :type *data: list of 8 True or False values (or anything that maps to it in an if-statement)
         """
         byte = 0
-        byte |= 0x80 if data[7] else 0x00
-        byte |= 0x40 if data[6] else 0x00
-        byte |= 0x20 if data[5] else 0x00
-        byte |= 0x10 if data[4] else 0x00
-        byte |= 0x08 if data[3] else 0x00
-        byte |= 0x04 if data[2] else 0x00
-        byte |= 0x02 if data[1] else 0x00
-        byte |= 0x01 if data[0] else 0x00
+        byte |= 0x80 if data[0] else 0x00
+        byte |= 0x40 if data[1] else 0x00
+        byte |= 0x20 if data[2] else 0x00
+        byte |= 0x10 if data[3] else 0x00
+        byte |= 0x08 if data[4] else 0x00
+        byte |= 0x04 if data[5] else 0x00
+        byte |= 0x02 if data[6] else 0x00
+        byte |= 0x01 if data[7] else 0x00
         return pack('>B', byte)
 
     def unpack(self, data, offset, unpack_list):
@@ -438,6 +438,17 @@ class Serializable(metaclass=abc.ABCMeta):
         Create a new Serializable object from a list of unpacked variables.
         """
         pass
+
+
+class Payload(Serializable, abc.ABC):
+
+    def __str__(self):
+        out = self.__class__.__name__
+        for attribute in dir(self):
+            if not (attribute.startswith('_') or callable(getattr(self, attribute))) \
+                    and attribute not in ['format_list', 'names']:
+                out += '\n| %s: %s' % (attribute, repr(getattr(self, attribute)))
+        return out
 
 
 # Serializers should be stateless.

--- a/ipv8/messaging/serialization.py
+++ b/ipv8/messaging/serialization.py
@@ -169,7 +169,7 @@ class IPv4:
 
     def unpack(self, data, offset, unpack_list):
         host_bytes, port = unpack_from('>4sH', data, offset)
-        unpack_list.append((socket.inet_ntoa(host_bytes), port))
+        unpack_list.append(UDPv4Address(socket.inet_ntoa(host_bytes), port))
         return offset + 6
 
 

--- a/ipv8/peer.py
+++ b/ipv8/peer.py
@@ -43,7 +43,7 @@ class DirtyDict(dict):
 
 class Peer(object):
 
-    INTERFACE_ORDER = [UDPv4Address, UDPv6Address, tuple]
+    INTERFACE_ORDER = [UDPv6Address, UDPv4Address, tuple]
 
     def __init__(self, key: Key, address: Optional[Address] = None, intro: bool = True) -> None:
         """
@@ -66,6 +66,7 @@ class Peer(object):
         self.last_response = 0 if intro else time()
         self._lamport_timestamp = 0
         self.pings: deque = deque(maxlen=5)
+        self.new_style_intro = False
 
     @property
     def addresses(self) -> Dict[Type[Address], Address]:

--- a/ipv8/peerdiscovery/community.py
+++ b/ipv8/peerdiscovery/community.py
@@ -70,7 +70,7 @@ class DiscoveryCommunity(Community):
         await self.request_cache.shutdown()
         await super(DiscoveryCommunity, self).unload()
 
-    def on_introduction_request(self, source_address, data):
+    def on_old_introduction_request(self, source_address, data):
         if self.max_peers >= 0 and len(self.get_peers()) > self.max_peers:
             self.logger.debug("Dropping introduction request from (%s, %d): too many peers!",
                               source_address[0], source_address[1])
@@ -92,7 +92,7 @@ class DiscoveryCommunity(Community):
             matches = [p for p in peers if p.mid == introduce_to]
             introduction = matches[0] if matches else None
         packet = self.create_introduction_response(payload.destination_address, source_address, payload.identifier,
-                                                   introduction=introduction)
+                                                   introduction=introduction, new_style=False)
         self.endpoint.send(source_address, packet)
 
     def introduction_response_callback(self, peer, dist, payload):

--- a/ipv8/peerdiscovery/discovery.py
+++ b/ipv8/peerdiscovery/discovery.py
@@ -124,7 +124,7 @@ class EdgeWalk(DiscoveryStrategy):
                 if waiting_root:
                     self.under_construction[waiting_root] = [waiting_root]
                     self.last_edge_responses[waiting_root] = time()
-                    self.overlay.get_new_introduction(waiting_root.address)
+                    self.overlay.get_new_introduction(waiting_root)
                 else:
                     # Check if our introduced peer has answered yet
                     completed = []

--- a/ipv8/test/messaging/test_lazy_payload.py
+++ b/ipv8/test/messaging/test_lazy_payload.py
@@ -17,6 +17,19 @@ class CompiledA(A):
     pass
 
 
+class BitsPayload(VariablePayload):
+    """
+    An unbalanced VariablePayload.
+    """
+    format_list = ['bits']
+    names = ['flag0', 'flag1', 'flag2', 'flag3', 'flag4', 'flag5', 'flag6', 'flag7']
+
+
+@vp_compile
+class CompiledBitsPayload(BitsPayload):
+    pass
+
+
 class B(VariablePayload):
     """
     A VariablePayload with a nested Payload.
@@ -174,6 +187,40 @@ class TestVariablePayload(TestBase):
         self.assertEqual(a.b, 1337)
         self.assertEqual(deserialized.a, 42)
         self.assertEqual(deserialized.b, 1337)
+
+    def test_bits_payload(self):
+        """
+        Check if unpacked BitPayload works correctly.
+        """
+        bpl = BitsPayload(False, True, False, True, False, True, False, True)
+
+        deserialized = self._pack_and_unpack(BitsPayload, bpl)
+
+        self.assertEqual(deserialized.flag0, False)
+        self.assertEqual(deserialized.flag1, True)
+        self.assertEqual(deserialized.flag2, False)
+        self.assertEqual(deserialized.flag3, True)
+        self.assertEqual(deserialized.flag4, False)
+        self.assertEqual(deserialized.flag5, True)
+        self.assertEqual(deserialized.flag6, False)
+        self.assertEqual(deserialized.flag7, True)
+
+    def test_bits_payload_compiled(self):
+        """
+        Check if unpacked compiled BitPayload works correctly.
+        """
+        bpl = CompiledBitsPayload(False, True, False, True, False, True, False, True)
+
+        deserialized = self._pack_and_unpack(BitsPayload, bpl)
+
+        self.assertEqual(deserialized.flag0, False)
+        self.assertEqual(deserialized.flag1, True)
+        self.assertEqual(deserialized.flag2, False)
+        self.assertEqual(deserialized.flag3, True)
+        self.assertEqual(deserialized.flag4, False)
+        self.assertEqual(deserialized.flag5, True)
+        self.assertEqual(deserialized.flag6, False)
+        self.assertEqual(deserialized.flag7, True)
 
     def test_inheritance(self):
         """

--- a/ipv8/test/peerdiscovery/test_community.py
+++ b/ipv8/test/peerdiscovery/test_community.py
@@ -48,7 +48,7 @@ class TestDiscoveryCommunity(TestBase):
         dist = GlobalTimeDistributionPayload(global_time)
 
         packet = self.overlays[0]._ez_pack(self.overlays[0]._prefix, 246, [auth, dist, payload])
-        self.overlays[1].on_introduction_request(self.overlays[0].endpoint.wan_address, packet)
+        self.overlays[1].on_old_introduction_request(self.overlays[0].endpoint.wan_address, packet)
 
         await self.deliver_messages()
 

--- a/ipv8/test/test_peer.py
+++ b/ipv8/test/test_peer.py
@@ -155,27 +155,27 @@ class TestPeer(TestBase):
 
     def test_address_order1(self):
         """
-        Check if IPv4 is preferred over IPv6 (append in-order).
+        Check if IPv6 is preferred over IPv4 (append out-of-order).
         """
         address1 = UDPv4Address("1.2.3.4", 5)
         address2 = UDPv6Address("1:2:3:4:5:6", 7)
         peer = Peer(TestPeer.test_key)
-        peer.add_address(address1)
         peer.add_address(address2)
+        peer.add_address(address1)
 
-        self.assertEqual(peer.address, address1)
+        self.assertEqual(peer.address, address2)
 
     def test_address_order2(self):
         """
-        Check if IPv4 is preferred over IPv6 (append out-of-order).
+        Check if IPv6 is preferred over IPv4 (append in-order).
         """
         address1 = UDPv4Address("1.2.3.4", 5)
         address2 = UDPv6Address("1:2:3:4:5:6", 7)
         peer = Peer(TestPeer.test_key)
-        peer.add_address(address2)
         peer.add_address(address1)
+        peer.add_address(address2)
 
-        self.assertEqual(peer.address, address1)
+        self.assertEqual(peer.address, address2)
 
     def test_default_address(self):
         """
@@ -197,11 +197,11 @@ class TestPeer(TestBase):
         """
         Check if manual updates to the addresses dictionary are caught (double update, out-of-order).
         """
-        address1 = UDPv4Address("1.2.3.4", 5)
-        address2 = UDPv6Address("1:2:3:4:5:6", 7)
+        address1 = UDPv6Address("1:2:3:4:5:6", 7)
+        address2 = UDPv4Address("1.2.3.4", 5)
         peer = Peer(TestPeer.test_key)
-        peer.addresses.update({UDPv6Address: address2})
-        peer.addresses.update({UDPv4Address: address1})
+        peer.addresses.update({UDPv4Address: address2})
+        peer.addresses.update({UDPv6Address: address1})
 
         self.assertEqual(peer.address, address1)
 

--- a/ipv8_service.py
+++ b/ipv8_service.py
@@ -73,9 +73,12 @@ else:
             if endpoint_override:
                 self.endpoint = endpoint_override
             else:
-                self.endpoint = DispatcherEndpoint(["UDPIPv4"],
+                self.endpoint = DispatcherEndpoint(["UDPIPv6", "UDPIPv4"],
                                                    UDPIPv4={'port': configuration['port'],
-                                                            'ip': configuration['address']})
+                                                            'ip': configuration['address']},
+                                                   UDPIPv6={'port': configuration['port'],
+                                                            'ip': "::"}
+                                                   )
                 if enable_statistics:
                     self.endpoint = StatisticsEndpoint(self.endpoint)
                 if any([overlay.get('initialize', {}).get('anonymize') for overlay in configuration['overlays']]):

--- a/stresstest/peer_discovery.py
+++ b/stresstest/peer_discovery.py
@@ -43,12 +43,13 @@ class MyCommunity(Community):
                     LOW_EDGE_PEER = self.my_peer
         self.register_task("check_peers", check_peers, interval=0.1, delay=0)
 
-    def create_introduction_response(self, lan_socket_address, socket_address, identifier, introduction=None):
+    def create_introduction_response(self, lan_socket_address, socket_address, identifier, introduction=None,
+                                     extra_bytes=b'', prefix=None, new_style=False):
         return super(MyCommunity, self).create_introduction_response(lan_socket_address, socket_address,
-                                                                     identifier, introduction, b'1')
+                                                                     identifier, introduction, b'1', prefix, new_style)
 
-    def create_introduction_request(self, socket_address):
-        return super(MyCommunity, self).create_introduction_request(socket_address, b'2')
+    def create_introduction_request(self, socket_address, extra_bytes=b'', new_style=False):
+        return super().create_introduction_request(socket_address, b'2', new_style)
 
 
 _COMMUNITIES['MyCommunity'] = MyCommunity


### PR DESCRIPTION
Fixes #912 
Related to #615 

This PR:
 - Adds `get_ipv6_address` to intially guess the IPv6 address.
 - Adds support for IPv6 addresses in `Community`.
 - Adds hand-off from the current address to the preferred address (using `my_preferred_address()`) in `Community` (practically usually IPv4 bootstrap into IPv6).
 - Adds `AutoMockEndpoint.ADDRESS_TYPE` to switch between `"UDPv4Address"` and `"UDPv6Address"` during unit tests.
 - Fixes `'bits'` serialization:
   - Fixes `'bits'` being unpacked in reverse order.
   - Fixes `VariablePayload` not working with the `'bits'` packer.
 - Updates `Peer` to prefer `IPv6` over `IPv4`.
 - Updates `IPv8` to load the `UDPIPv6` interface.
 - Updates `Payload`'s location to `serialization.py` instead of `payload.py`, so classes in `payload.py` can use `VariablePayload`.
 - Updates classes in `payload.py` to use `ipv4` instead of `4SH`.

**Future Work (NOT in this PR!)**
 - Add a configuration option for binding the IPv6 address.
 - Update the `DHTCommunity` and `TunnelCommunity` to work with IPv6.
 - Update the `AutoMockEndpoint` to use a mix of IPv4 and IPv6 addresses during testing.