### PR TITLE
Updated NumberCache.on_timeout to no longer be abstract

### DIFF
--- a/ipv8/requestcache.py
+++ b/ipv8/requestcache.py
@@ -54,7 +54,7 @@ class NumberCache(object):
         return 10.0
 
     def on_timeout(self):
-        raise NotImplementedError()
+        pass
 
     def __str__(self):
         return "<%s %s-%d>" % (self.__class__.__name__, self.prefix, self.number)


### PR DESCRIPTION
Fixes #917

This PR:

 - Updates `NumberCache.on_timeout()` to no longer `raise NotImplementedError` if not overwritten in a subclass.

