### PR TITLE
Fixed tracker peer for intro overwrite

### DIFF
--- a/scripts/tracker_plugin.py
+++ b/scripts/tracker_plugin.py
@@ -92,7 +92,7 @@ class EndpointServer(Community):
                                                    introduction=intro_peer, prefix=prefix)
         self.endpoint.send(peer.address, packet)
 
-    def get_peer_for_introduction(self, exclude=None):
+    def get_peer_for_introduction(self, exclude=None, new_style=False):
         """
         We explicitly provide create_introduction_response with a peer.
         If on_generic_introduction_request provides None, this method should not suggest a peer.


### PR DESCRIPTION
This PR:

 - Fixes `EndpointServer.get_peer_for_introduction` to comply with the new IPv6 interface changes.

