### PR TITLE
Fix for introducing peers to outdated addresses

### DIFF
--- a/ipv8/peerdiscovery/network.py
+++ b/ipv8/peerdiscovery/network.py
@@ -76,7 +76,11 @@ class Network(object):
                 self.services_per_peer[peer.mid] |= set(services)
             for service in services:
                 service_cache = self.reverse_service_lookup.get(service, [])
-                self.reverse_service_lookup[service] = list(set(service_cache + [peer]))
+                # Ensure that the peer instance in the cache is the same one as in verified_peers.
+                if peer in service_cache:
+                    service_cache.remove(peer)
+                service_cache.append(self.get_verified_by_public_key_bin(peer.public_key.key_to_bin()) or peer)
+                self.reverse_service_lookup[service] = service_cache
 
     def add_verified_peer(self, peer):
         """

--- a/ipv8/test/peerdiscovery/test_network.py
+++ b/ipv8/test/peerdiscovery/test_network.py
@@ -184,6 +184,33 @@ class TestNetwork(TestBase):
         self.assertIn(self.peers[0], self.network.get_peers_for_service(service1))
         self.assertIn(self.peers[0], self.network.get_peers_for_service(service2))
 
+    def test_discover_services_address_update(self):
+        """
+        Check if an address update gets processed correctly.
+        """
+        service1 = "".join([chr(i) for i in range(20)])
+        service2 = "".join([chr(i) for i in range(20, 40)])
+
+        pk = self.peers[0].public_key
+        peer = Peer(pk, ('1.1.1.1', 1))
+        self.network.add_verified_peer(peer)
+        self.network.discover_services(peer, [service1])
+
+        peer = Peer(pk, ('1.1.1.1', 1))
+        self.network.add_verified_peer(peer)
+        self.network.discover_services(peer, [service2])
+
+        peer = Peer(pk, ('1.1.1.1', 2))
+        self.network.add_verified_peer(peer)
+        self.network.discover_services(peer, [service1])
+
+        peer = Peer(pk, ('1.1.1.1', 2))
+        self.network.add_verified_peer(peer)
+        self.network.discover_services(peer, [service2])
+
+        self.assertEqual(self.network.get_peers_for_service(service1)[0].address, peer.address)
+        self.assertEqual(self.network.get_peers_for_service(service2)[0].address, peer.address)
+
     def test_discover_services_cache(self):
         """
         Check if services cache updates properly.


### PR DESCRIPTION
This PR fixes an issue that causes trackers (and other nodes) to introduce peers to outdated addresses. This is due to outdated peer information getting stuck in the `service_cache`. It's a bit difficult to explain what happens, but it boils down to this:

* Peer A *first* sends an intro-req to Peer B for community X and *then* for community Y.
* Peer A updates its address.
* Peer A sends another intro-req to Peer B for communities X & Y.

Now in community X, peer B will use the correct addresses when sending intro-responses. However, in community Y peer B will still use the old address.

I've intentionally used the same instance in the cache as the one in `verified_peers`, to prevent future issues (like losing IPv6 addresses).