### PR TITLE
Added IPv6 support to DHTCommunity

### DIFF
--- a/ipv8/configuration.py
+++ b/ipv8/configuration.py
@@ -98,13 +98,20 @@ default = {
         {
             'class': 'DHTDiscoveryCommunity',
             'key': "anonymous id",
-            'walkers': [{
-                'strategy': "RandomWalk",
-                'peers': 20,
-                'init': {
-                    'timeout': 3.0
+            'walkers': [
+                {
+                    'strategy': "RandomWalk",
+                    'peers': 20,
+                    'init': {
+                        'timeout': 3.0
+                    }
+                },
+                {
+                    'strategy': "PingChurn",
+                    'peers': -1,
+                    'init': {}
                 }
-            }],
+            ],
             'initialize': {},
             'on_start': []
         }
@@ -121,6 +128,7 @@ class Strategy(enum.Enum):
     RandomChurn = "RandomChurn"
     PeriodicSimilarity = "PeriodicSimilarity"
     EdgeWalk = "EdgeWalk"
+    PingChurn = "PingChurn"
 
     @classmethod
     def values(cls):

--- a/ipv8/dht/churn.py
+++ b/ipv8/dht/churn.py
@@ -13,26 +13,34 @@ class PingChurn(DiscoveryStrategy):
 
     def take_step(self):
         with self.walk_lock:
-            for node in self.overlay.routing_table.remove_bad_nodes():
-                self.overlay.network.remove_peer(node)
+            # Nothing is happening yet, skip this step
+            if not self.overlay.routing_tables:
+                return
+
+            for routing_table in self.overlay.routing_tables.values():
+                for node in routing_table.remove_bad_nodes():
+                    self.overlay.network.remove_peer(node)
 
             for peer in self.overlay.get_peers():
                 if peer.address in self.overlay.network.blacklist:
                     continue
 
                 node = Node(peer.key, peer.address)
-                if not self.overlay.routing_table.has(node.id) and not self.overlay.routing_table.add(node):
+                routing_table = self.overlay.get_routing_table(node)
+                if not routing_table.has(node.id) and not routing_table.add(node):
                     self.overlay.network.remove_peer(peer)
 
-            for bucket in self.overlay.routing_table.trie.values():
-                for node in bucket.nodes.values():
-                    if node not in self.overlay.get_peers():
-                        peer = Peer(node.key, node.address)
-                        self.overlay.network.add_verified_peer(peer)
-                        self.overlay.network.discover_services(peer, [self.overlay.community_id])
+            for routing_table in self.overlay.routing_tables.values():
+                for bucket in routing_table.trie.values():
+                    for node in bucket.nodes.values():
+                        if node not in self.overlay.get_peers():
+                            peer = Peer(node.key, node.address)
+                            self.overlay.network.add_verified_peer(peer)
+                            self.overlay.network.discover_services(peer, [self.overlay.community_id])
 
             now = time()
-            for bucket in self.overlay.routing_table.trie.values():
-                for node in bucket.nodes.values():
-                    if node.last_ping_sent + self.ping_interval <= now:
-                        self.overlay.ping(node)
+            for routing_table in self.overlay.routing_tables.values():
+                for bucket in routing_table.trie.values():
+                    for node in bucket.nodes.values():
+                        if node.last_ping_sent + self.ping_interval <= now:
+                            self.overlay.ping(node)

--- a/ipv8/dht/discovery.py
+++ b/ipv8/dht/discovery.py
@@ -16,7 +16,7 @@ class DHTDiscoveryCommunity(DHTCommunity):
     """
 
     def __init__(self, *args, **kwargs):
-        super(DHTDiscoveryCommunity, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
         self.store = defaultdict(list)
         self.store_for_me = defaultdict(list)
@@ -71,11 +71,11 @@ class DHTDiscoveryCommunity(DHTCommunity):
 
         futures = []
         for node in nodes:
-            if node in self.tokens:
+            if node.id in self.tokens:
                 cache = Request(self, 'store-peer', node, [key])
                 self.request_cache.add(cache)
                 futures.append(cache.future)
-                self.ez_send(node, StorePeerRequestPayload(cache.number, self.tokens[node][1], key))
+                self.ez_send(node, StorePeerRequestPayload(cache.number, self.tokens[node.id][1], key))
             else:
                 self.logger.debug('Not sending store-peer-request to %s (no token available)', node)
 

--- a/ipv8/messaging/anonymization/community.py
+++ b/ipv8/messaging/anonymization/community.py
@@ -505,7 +505,7 @@ class TunnelCommunity(Community):
             candidate_list_bin = self.crypto.decrypt_str(candidate_list_enc,
                                                          hop.session_keys[EXIT_NODE],
                                                          hop.session_keys[EXIT_NODE_SALT])
-            candidate_list = self.serializer.unpack('varlenH-list', candidate_list_bin)
+            candidate_list, _ = self.serializer.unpack('varlenH-list', candidate_list_bin)
 
             cache = self.request_cache.pop("retry", payload.identifier)
             self.send_extend(circuit, candidate_list, cache.max_tries if cache else 1)

--- a/ipv8/messaging/anonymization/hidden_services.py
+++ b/ipv8/messaging/anonymization/hidden_services.py
@@ -391,7 +391,7 @@ class HiddenTunnelCommunity(TunnelCommunity):
 
         rp_info_enc = payload.rp_info_enc
         rp_info_bin = self.crypto.decrypt_str(rp_info_enc, session_keys[EXIT_NODE], session_keys[EXIT_NODE_SALT])
-        rp_info = self.serializer.unpack(RendezvousInfo, rp_info_bin)
+        rp_info, _ = self.serializer.unpack(RendezvousInfo, rp_info_bin)
 
         required_exit = Peer(rp_info.key, rp_info.address)
         circuit = self.create_circuit_for_infohash(cache.info_hash, CIRCUIT_TYPE_RP_DOWNLOADER,

--- a/ipv8/messaging/anonymization/pex.py
+++ b/ipv8/messaging/anonymization/pex.py
@@ -58,7 +58,7 @@ class PexCommunity(Community):
         if not extra_bytes:
             return
 
-        for seeder_pk in self.serializer.unpack('varlenH-list', extra_bytes):
+        for seeder_pk in self.serializer.unpack('varlenH-list', extra_bytes)[0]:
             ip = IntroductionPoint(peer, seeder_pk, PEER_SOURCE_PEX)
             if ip in self.intro_points:
                 # Remove first to put introduction point at front of the deque.

--- a/ipv8/messaging/serialization.py
+++ b/ipv8/messaging/serialization.py
@@ -318,7 +318,7 @@ class Serializer(object):
         """
         return self._packers[fmt].pack(item)
 
-    def unpack(self, fmt, data):
+    def unpack(self, fmt, data, offset=0):
         """
         Unpack data without using a Serializable. Using a Serializable is the preferred method.
         :param fmt: the name of the packer to use while unpacking
@@ -328,12 +328,12 @@ class Serializer(object):
         """
         unpack_list = []
         if isinstance(fmt, str):
-            self._packers[fmt].unpack(data, 0, unpack_list)
+            offset = self._packers[fmt].unpack(data, offset, unpack_list)
         elif isinstance(fmt, list):
-            self._packers['payload-list'].unpack(data, 0, unpack_list, fmt[0])
+            offset = self._packers['payload-list'].unpack(data, offset, unpack_list, fmt[0])
         else:
-            self._packers['payload'].unpack(data, 0, unpack_list, fmt)
-        return unpack_list[0]
+            offset = self._packers['payload'].unpack(data, offset, unpack_list, fmt)
+        return unpack_list[0], offset
 
     def pack_serializable(self, serializable):
         """

--- a/ipv8/test/dht/base.py
+++ b/ipv8/test/dht/base.py
@@ -1,0 +1,13 @@
+from ..base import TestBase
+
+
+class TestDHTBase(TestBase):
+
+    def routing_table(self, i):
+        return self.nodes[i].overlay.get_routing_table(self.my_peer(i))
+
+    def storage(self, i):
+        return self.nodes[i].overlay.get_storage(self.my_peer(i))
+
+    def my_node_id(self, i):
+        return self.nodes[i].overlay.get_my_node_id(self.my_peer(i))

--- a/ipv8/test/dht/test_churn.py
+++ b/ipv8/test/dht/test_churn.py
@@ -1,11 +1,11 @@
 import time
 
-from ..base import TestBase
+from .base import TestDHTBase
 from ...dht.churn import PingChurn
 from ...dht.community import DHTCommunity
 
 
-class TestPingChurn(TestBase):
+class TestPingChurn(TestDHTBase):
 
     def setUp(self):
         super(TestPingChurn, self).setUp()
@@ -17,9 +17,9 @@ class TestPingChurn(TestBase):
 
     async def test_ping_all(self):
         await self.introduce_nodes()
-        bucket = self.overlay(0).routing_table.trie[u'']
+        bucket = self.routing_table(0).trie[u'']
 
-        node1 = bucket.get(self.overlay(1).my_node_id)
+        node1 = bucket.get(self.my_node_id(1))
         node1.failed = 1
         node1.last_response = 0
 
@@ -31,8 +31,8 @@ class TestPingChurn(TestBase):
 
     async def test_ping_all_skip(self):
         await self.introduce_nodes()
-        bucket = self.overlay(0).routing_table.trie[u'']
-        node1 = bucket.get(self.overlay(1).my_node_id)
+        bucket = self.routing_table(0).trie[u'']
+        node1 = bucket.get(self.my_node_id(1))
         node1.failed = 1
         node1.last_response = time.time() + 5
 

--- a/ipv8/test/dht/test_routing.py
+++ b/ipv8/test/dht/test_routing.py
@@ -31,7 +31,7 @@ class TestNode(TestBase):
         self.assertEqual(self.node.last_response, 0)
         self.assertEqual(self.node.last_query, 0)
         self.assertEqual(self.node.failed, 0)
-        self.assertEqual(self.node.id, unhexlify('8121e35b16b30807cdcb11f8214a5eb762c0dc19'))
+        self.assertEqual(self.node.id, unhexlify('f626d35b16b30807cdcb11f8214a5eb762c0dc19'))
 
     def test_status(self):
         self.node.last_response = time.time()

--- a/ipv8/test/test_configuration.py
+++ b/ipv8/test/test_configuration.py
@@ -299,7 +299,8 @@ class TestConfiguration(TestBase):
                                                   []) \
                                      .add_overlay("DHTDiscoveryCommunity",
                                                   "anonymous id",
-                                                  [WalkerDefinition(Strategy.RandomWalk, 20, {'timeout': 3.0})],
+                                                  [WalkerDefinition(Strategy.RandomWalk, 20, {'timeout': 3.0}),
+                                                   WalkerDefinition(Strategy.PingChurn, -1, {})],
                                                   {},
                                                   [])
 


### PR DESCRIPTION
This PR partially addresses https://github.com/Tribler/py-ipv8/issues/615 and adds IPv6 support to the `DHTCommunity`.

IPv6 support works as follows: 
All nodes in the network are identified by an ID that is partially based on the IP address that is used while sending DHT messages. Since we can now receive messages over multiple interfaces, I've added a `RoutingTable` and `Storage` object for each interface. Which of these objects is used while processing a query is decided based on the query's source address. This ensures that all nodes in the `RoutingTable` will be of the same address type, which also means that a response with nodes can only be of the same address type as was used when sending the request. When `find_values` or `find_nodes` is called, the `DHTCommunity` will perform a crawl over all available endpoints.