### PR TITLE
Fixed setting anonymization and statistics for overwritten endpoints

### DIFF
--- a/ipv8_service.py
+++ b/ipv8_service.py
@@ -79,10 +79,10 @@ else:
                                                    UDPIPv6={'port': configuration['port'],
                                                             'ip': "::"}
                                                    )
-                if enable_statistics:
-                    self.endpoint = StatisticsEndpoint(self.endpoint)
-                if any([overlay.get('initialize', {}).get('anonymize') for overlay in configuration['overlays']]):
-                    self.endpoint = TunnelEndpoint(self.endpoint)
+            if enable_statistics:
+                self.endpoint = StatisticsEndpoint(self.endpoint)
+            if any([overlay.get('initialize', {}).get('anonymize') for overlay in configuration['overlays']]):
+                self.endpoint = TunnelEndpoint(self.endpoint)
 
             self.network = Network()
 


### PR DESCRIPTION
Fixes #933

This PR:

 - Updates IPv8 to allow anonymization of-and statistics for-custom endpoints (set through `endpoint_override`).