### PR TITLE
Network class polishing

### DIFF
--- a/ipv8/lazy_community.py
+++ b/ipv8/lazy_community.py
@@ -83,7 +83,9 @@ def lazy_wrapper(*payloads: Type[Payload]):
                 raise PacketDecodingError("Incoming packet %s has an invalid signature" %
                                           str([payload_class.__name__ for payload_class in payloads]))
             # PRODUCE
-            return func(self, Peer(auth.public_key_bin, source_address), *unpacked)
+            peer = (self.network.verified_by_public_key_bin.get(auth.public_key_bin)
+                    or Peer(auth.public_key_bin, source_address))
+            return func(self, peer, *unpacked)
         return wrapper
     return decorator
 
@@ -117,7 +119,9 @@ def lazy_wrapper_wd(*payloads: Type[Payload]):
                                           str([payload_class.__name__ for payload_class in payloads]))
             # PRODUCE
             output = unpacked + [data]
-            return func(self, Peer(auth.public_key_bin, source_address), *output)
+            peer = (self.network.verified_by_public_key_bin.get(auth.public_key_bin)
+                    or Peer(auth.public_key_bin, source_address))
+            return func(self, peer, *output)
         return wrapper
     return decorator
 

--- a/ipv8/peerdiscovery/network.py
+++ b/ipv8/peerdiscovery/network.py
@@ -1,52 +1,83 @@
 import logging
-from collections import OrderedDict
+from collections import OrderedDict, namedtuple
 from threading import RLock
+from typing import Dict, Iterable, List, Optional, Set
 
 from ..messaging.serialization import default_serializer
+from ..types import Address, Overlay, Peer
+
+
+MID = bytes
+PublicKeyMat = bytes
+Service = bytes
+ServiceSet = Set[Service]
+WalkableAddress = namedtuple('WalkableAddress', ['introduced_by', 'services', 'new_style'])
 
 
 class Network(object):
 
     def __init__(self):
-        # All known IP:port addresses, mapped to (introduction peer, services, new_style)
-        self._all_addresses = {}
-        # All verified Peer objects (Peer.address must be in _all_addresses)
-        self.verified_peers = set()
+        self._all_addresses: Dict[Address, WalkableAddress] = {}
+        '''All known IP:port addresses, mapped to (introduction peer, services, new_style).'''
+
+        self.verified_peers: Set[Peer] = set()
+        '''All verified Peer objects (Peer.address must be in _all_addresses).'''
+
+        self.verified_by_public_key_bin: Dict[PublicKeyMat, Peer] = {}
+        '''Map of known public keys to Peer objects.'''
+
         self.graph_lock = RLock()
-        # Peers we should not add to the network
-        # For example, bootstrap peers
-        self.blacklist = []
-        # Excluded mids
-        self.blacklist_mids = []
+        '''Lock for all updates of the peer pool.'''
 
-        # Map of advertised services (set) per peer
-        self.services_per_peer = {}
-        # Map of service identifiers to local overlays
-        self.service_overlays = {}
+        self.blacklist: List[Address] = []
+        '''Peers we should not add to the network (e.g., bootstrap peers), by address.'''
 
-        # Cache of IP:port -> Peer
-        self.reverse_ip_lookup = OrderedDict()
+        self.blacklist_mids: List[MID] = []
+        '''Peers we should not add to the network (e.g., bootstrap peers), by mid.'''
+
+        self.services_per_peer: Dict[PublicKeyMat, ServiceSet] = {}
+        '''Map of advertised services (set) per peer.'''
+
+        self.service_overlays: Dict[Service, Overlay] = {}
+        '''Map of service identifiers to local overlays.'''
+
         self.reverse_ip_cache_size = 500
+        self.reverse_ip_lookup = OrderedDict()
+        '''Cache of IP:port -> Peer. This is a cache rather than a normal dictionary (the addresses of a peer are
+        temporal and can grow infinitely): we rotate out old information to avoid a memory leak.'''
 
-        # Cache of Peer -> [IP:port]
-        self.reverse_intro_lookup = OrderedDict()
         self.reverse_intro_cache_size = 500
+        self.reverse_intro_lookup = OrderedDict()
+        '''Map of Peer -> [IP:port], reversing the information from _all_addresses. This is a cache rather than a
+        normal dictionary (the addresses of a peer are temporal and can grow infinitely): we rotate out old
+        information to avoid a memory leak.'''
 
-        # Cache of service_id -> [Peer]
-        self.reverse_service_lookup = OrderedDict()
         self.reverse_service_cache_size = 500
+        self.reverse_service_lookup = OrderedDict()
+        '''Cache of service_id -> [Peer]. This is a cache rather than a normal dictionary (the services of a peer may
+        be temporal and can grow infinitely): we rotate out old information to avoid a memory leak.'''
 
-    def is_new_style(self, address):
-        return self._all_addresses.get(address, ('', None, False))[2]
+    def is_new_style(self, address: Address) -> bool:
+        """
+        Check if an address supports new-style introduction requests and responses.
 
-    def discover_address(self, peer, address, service=None, new_style=False):
+        :param address: the address to check for.
+        :returns: True iff the address is both known and known to support new-style introductions.
+        """
+        return (self._all_addresses.get(address) or WalkableAddress(b'', None, False)).new_style
+
+    def discover_address(self,
+                         peer: Peer,
+                         address: Address,
+                         service: Optional[Service] = None,
+                         new_style: bool = False) -> None:
         """
         A peer has introduced us to another IP address.
 
-        :param peer: the peer that performed the introduction
-        :param address: the introduced address
-        :param service: the service through which we discovered the peer
-        :param new_style: the introduced address uses new introduction logic
+        :param peer: the peer that performed the introduction.
+        :param address: the introduced address.
+        :param service: the service through which we discovered the peer.
+        :param new_style: the introduced address uses new introduction logic.
         """
         if address in self.blacklist:
             self.add_verified_peer(peer)
@@ -54,88 +85,94 @@ class Network(object):
 
         with self.graph_lock:
             if ((address not in self._all_addresses)
-                    or (self._all_addresses[address][0] not in [p.mid for p in self.verified_peers])):
+                    or (self._all_addresses[address].introduced_by not in self.verified_by_public_key_bin)):
                 # This is a new address, or our previous parent has been removed
-                self._all_addresses[address] = (peer.mid, service, new_style)
+                self._all_addresses[address] = WalkableAddress(peer.public_key.key_to_bin(), service, new_style)
                 intro_cache = self.reverse_intro_lookup.get(peer, None)
                 if intro_cache:
                     intro_cache.append(address)
+                else:
+                    self.reverse_intro_lookup[peer] = [address]
 
             self.add_verified_peer(peer)
 
-    def discover_services(self, peer, services):
+    def discover_services(self, peer: Peer, services: Iterable) -> None:
         """
         A peer has advertised some services he can use.
 
-        :param peer: the peer to update the services for
-        :param services: the list of services to register
+        :param peer: the peer to update the services for.
+        :param services: the list of services to register.
         """
         with self.graph_lock:
-            if peer.mid not in self.services_per_peer:
-                self.services_per_peer[peer.mid] = set(services)
+            key_material = peer.public_key.key_to_bin()
+            if key_material not in self.services_per_peer:
+                self.services_per_peer[key_material] = set(services)
             else:
-                self.services_per_peer[peer.mid] |= set(services)
+                self.services_per_peer[key_material] |= set(services)
             for service in services:
                 service_cache = self.reverse_service_lookup.get(service, [])
                 # Ensure that the peer instance in the cache is the same one as in verified_peers.
                 if peer in service_cache:
                     service_cache.remove(peer)
-                service_cache.append(self.get_verified_by_public_key_bin(peer.public_key.key_to_bin()) or peer)
+                service_cache.append(self.verified_by_public_key_bin.get(key_material, peer))
                 self.reverse_service_lookup[service] = service_cache
 
-    def add_verified_peer(self, peer):
+    def add_verified_peer(self, peer: Peer) -> None:
         """
         The holepunching layer has a new peer for us.
 
-        :param peer: the new peer
+        :param peer: the new peer.
         """
         if peer.mid in self.blacklist_mids:
             return
         with self.graph_lock:
             # This may just be an address update
-            for known in self.verified_peers:
-                if known.mid == peer.mid:
-                    known.addresses.update(peer.addresses)
-                    return
+            known = self.verified_by_public_key_bin.get(peer.public_key.key_to_bin(), None)
+            if known:
+                known.addresses.update(peer.addresses)
+                return
             if any(address in self._all_addresses for address in peer.addresses.values()):
                 if peer not in self.verified_peers:
                     # This should always happen, unless someone edits the verified_peers dict directly.
                     # This would be a programmer 'error', but we will allow it.
                     self.verified_peers.add(peer)
+                    self.verified_by_public_key_bin[peer.public_key.key_to_bin()] = peer
             elif all(address not in self.blacklist for address in peer.addresses.values()):
                 for address in peer.addresses.values():
                     if address not in self._all_addresses:
-                        self._all_addresses[address] = ('', None, False)
+                        self._all_addresses[address] = WalkableAddress(b'', None, False)
                 if peer not in self.verified_peers:
                     self.verified_peers.add(peer)
+                    self.verified_by_public_key_bin[peer.public_key.key_to_bin()] = peer
 
-    def register_service_provider(self, service_id, overlay):
+    def register_service_provider(self, service_id: Service, overlay: Overlay) -> None:
         """
         Register an overlay to provide a certain service id.
 
-        :param service_id: the name/id of the service
-        :param overlay: the actual service
+        :param service_id: the name/id of the service.
+        :param overlay: the actual service.
         """
         with self.graph_lock:
             self.service_overlays[service_id] = overlay
 
-    def get_peers_for_service(self, service_id):
+    def get_peers_for_service(self, service_id: Service) -> List[Peer]:
         """
         Get peers which support a certain service.
 
-        :param service_id: the service name/id to fetch peers for
+        :param service_id: the service name/id to fetch peers for.
         """
         out = []
         service_cache = self.reverse_service_lookup.pop(service_id, None)
         if service_cache is None:
             with self.graph_lock:
                 for peer in self.verified_peers:
-                    if peer.mid in self.services_per_peer:
-                        if service_id in self.services_per_peer[peer.mid]:
-                            out.append(peer)
+                    key_material = peer.public_key.key_to_bin()
+                    if service_id in self.services_per_peer.get(key_material, []):
+                        out.append(peer)
         else:
             out = [peer for peer in service_cache if
-                   peer in self.verified_peers and service_id in self.services_per_peer.get(peer.mid, [])]
+                   peer in self.verified_peers
+                   and service_id in self.services_per_peer.get(peer.public_key.key_to_bin(), [])]
         self.reverse_service_lookup[service_id] = out
         if len(self.reverse_service_lookup) > self.reverse_service_cache_size:
             self.reverse_service_lookup.popitem(False)  # Pop the oldest cache entry
@@ -145,20 +182,23 @@ class Network(object):
         """
         Get the known services supported by a peer.
 
-        :param peer: the peer to check services for
+        :param peer: the peer to check services for.
         """
         with self.graph_lock:
-            return self.services_per_peer.get(peer.mid, set())
+            return self.services_per_peer.get(peer.public_key.key_to_bin(), set())
 
-    def get_walkable_addresses(self, service_id=None, old_style=False):
+    def get_walkable_addresses(self,
+                               service_id: Optional[Service] = None,
+                               old_style: bool = False) -> List[Address]:
         """
         Get all addresses ready to be walked to.
 
-        :param service_id: the service_id to filter on
+        :param service_id: the service_id to filter on.
+        :param old_style: only return addresses that are not new-style.
         """
         with self.graph_lock:
             known = self.get_peers_for_service(service_id) if service_id else self.verified_peers
-            verified = []
+            verified: List[Address] = []
             for peer in known:
                 verified.extend(peer.addresses.values())
             out = list(set(self._all_addresses.keys()) - set(verified))
@@ -176,7 +216,7 @@ class Network(object):
                 out = new_out
             return out
 
-    def get_verified_by_address(self, address):
+    def get_verified_by_address(self, address: Address) -> Peer:
         """
         Get a verified Peer by its IP address.
 
@@ -200,19 +240,15 @@ class Network(object):
                 self.reverse_ip_lookup[address] = peer
         return peer
 
-    def get_verified_by_public_key_bin(self, public_key_bin):
+    def get_verified_by_public_key_bin(self, public_key_bin: PublicKeyMat) -> Optional[Peer]:
         """
         Get a verified Peer by its public key bin.
-
         :param public_key_bin: the string representation of the public key
         :return: the Peer object for this public_key_bin or None
         """
-        with self.graph_lock:
-            for p in self.verified_peers:
-                if p.public_key.key_to_bin() == public_key_bin:
-                    return p
+        return self.verified_by_public_key_bin.get(public_key_bin)
 
-    def get_introductions_from(self, peer):
+    def get_introductions_from(self, peer: Peer) -> List[Address]:
         """
         Get the addresses introduced to us by a certain peer.
 
@@ -222,13 +258,14 @@ class Network(object):
         introductions = self.reverse_intro_lookup.get(peer, None)
         if introductions is None:
             with self.graph_lock:
-                introductions = [k for k, v in self._all_addresses.items() if v[0] == peer.mid]
+                introductions = [k for k, v in self._all_addresses.items()
+                                 if v.introduced_by == peer.public_key.key_to_bin()]
                 self.reverse_intro_lookup[peer] = introductions
                 if len(self.reverse_intro_lookup) > self.reverse_intro_cache_size:
                     self.reverse_intro_lookup.popitem(False)  # Pop the oldest cache entry
         return introductions
 
-    def remove_by_address(self, address):
+    def remove_by_address(self, address: Address) -> None:
         """
         Remove all walkable addresses and verified peers using a certain IP address.
 
@@ -240,9 +277,9 @@ class Network(object):
             # the services_per_peer mapping if they are no longer included. This is fast.
             self.verified_peers = {peer for peer in self.verified_peers
                                    if address not in peer.addresses.values()
-                                   or self.services_per_peer.pop(peer.mid, None) == 0}
+                                   or self.services_per_peer.pop(peer.public_key.key_to_bin(), None) == 0}
 
-    def remove_peer(self, peer):
+    def remove_peer(self, peer: Peer) -> None:
         """
         Remove a verified peer.
 
@@ -253,7 +290,8 @@ class Network(object):
                 self._all_addresses.pop(address, None)
             if peer in self.verified_peers:
                 self.verified_peers.remove(peer)
-            self.services_per_peer.pop(peer.mid, None)
+            self.verified_by_public_key_bin.pop(peer.public_key.key_to_bin(), None)
+            self.services_per_peer.pop(peer.public_key.key_to_bin(), None)
 
     def snapshot(self) -> bytes:
         """
@@ -283,7 +321,7 @@ class Network(object):
                 previous_offset = offset
                 try:
                     address, offset = default_serializer.unpack('address', snapshot, offset)
-                    self._all_addresses[address] = ('', None, False)
+                    self._all_addresses[address] = WalkableAddress(b'', None, False)
                 except Exception:  # pylint: disable=W0703
                     if offset <= previous_offset:
                         # We got stuck, or even went back in time.

--- a/ipv8/test/peerdiscovery/test_network.py
+++ b/ipv8/test/peerdiscovery/test_network.py
@@ -138,7 +138,7 @@ class TestNetwork(TestBase):
         """
         Check if services are properly registered for a peer.
         """
-        service = "".join([chr(i) for i in range(20)])
+        service = bytes(range(20))
         self.network.discover_services(self.peers[0], [service])
         self.network.add_verified_peer(self.peers[0])
 
@@ -149,7 +149,7 @@ class TestNetwork(TestBase):
         """
         Check if services are properly registered for an unverified peer.
         """
-        service = "".join([chr(i) for i in range(20)])
+        service = bytes(range(20))
         self.network.discover_services(self.peers[0], [service])
 
         self.assertIn(service, self.network.get_services_for_peer(self.peers[0]))
@@ -159,8 +159,8 @@ class TestNetwork(TestBase):
         """
         Check if services are properly combined for a peer.
         """
-        service1 = "".join([chr(i) for i in range(20)])
-        service2 = "".join([chr(i) for i in range(20, 40)])
+        service1 = bytes(range(20))
+        service2 = bytes(range(20, 40))
         self.network.discover_services(self.peers[0], [service1])
         self.network.discover_services(self.peers[0], [service2])
         self.network.add_verified_peer(self.peers[0])
@@ -174,8 +174,8 @@ class TestNetwork(TestBase):
         """
         Check if services are properly combined when discovered services overlap.
         """
-        service1 = "".join([chr(i) for i in range(20)])
-        service2 = "".join([chr(i) for i in range(20, 40)])
+        service1 = bytes(range(20))
+        service2 = bytes(range(20, 40))
         self.network.discover_services(self.peers[0], [service1])
         self.network.discover_services(self.peers[0], [service1, service2])
         self.network.add_verified_peer(self.peers[0])
@@ -189,8 +189,8 @@ class TestNetwork(TestBase):
         """
         Check if an address update gets processed correctly.
         """
-        service1 = "".join([chr(i) for i in range(20)])
-        service2 = "".join([chr(i) for i in range(20, 40)])
+        service1 = bytes(range(20))
+        service2 = bytes(range(20, 40))
 
         pk = self.peers[0].public_key
         peer = Peer(pk, ('1.1.1.1', 1))
@@ -216,8 +216,8 @@ class TestNetwork(TestBase):
         """
         Check if services cache updates properly.
         """
-        service1 = "".join([chr(i) for i in range(20)])
-        service2 = "".join([chr(i) for i in range(20, 40)])
+        service1 = bytes(range(20))
+        service2 = bytes(range(20, 40))
         self.network.reverse_service_cache_size = 1
         self.network.discover_services(self.peers[0], [service1])
         self.network.add_verified_peer(self.peers[0])
@@ -402,7 +402,7 @@ class TestNetwork(TestBase):
         """
         Check if we can retrieve walkable addresses by parent service id.
         """
-        service = "".join([chr(i) for i in range(20)])
+        service = bytes(range(20))
         self.network.discover_address(self.peers[2], self.peers[3].address)
         self.network.discover_address(self.peers[0], self.peers[1].address)
         self.network.discover_services(self.peers[0], [service])
@@ -435,7 +435,7 @@ class TestNetwork(TestBase):
         """
         self.network.blacklist_mids.append(self.peers[0].mid)
         for peer in self.peers[1:]:
-            self.network.discover_address(self.peers[0], peer)
+            self.network.discover_address(self.peers[0], peer.address)
         snapshot = self.network.snapshot()
 
         self.assertEqual(len(snapshot), 0)

--- a/ipv8/types.py
+++ b/ipv8/types.py
@@ -18,6 +18,7 @@ if typing.TYPE_CHECKING:
     from ipv8.keyvault.keys import Key, PrivateKey, PublicKey
     from ipv8.messaging.interfaces.endpoint import Endpoint
     from ipv8.messaging.serialization import Payload
+    from ipv8.overlay import Overlay
     from ipv8.peer import Peer
     from ipv8.requestcache import NumberCache
     from ipv8_service import IPv8
@@ -37,6 +38,7 @@ else:
     Key = 'ipv8.keyvault.keys.Key'
     Metadata = 'ipv8.attestation.identity.metadata.Metadata'
     NumberCache = 'ipv8.requestcache.NumberCache'
+    Overlay = 'ipv8.overlay.Overlay'
     Payload = 'ipv8.messaging.serialization.Payload'
     Peer = 'ipv8.peer.Peer'
     PrivateKey = 'ipv8.keyvault.keys.PrivateKey'


### PR DESCRIPTION
Fixes #935

This PR:

 - Adds automatic resolution of known peers in `lazy_community.py` `lazy_wrapper*` decorators.
 - Adds typing information to `Network`.
 - Adds `verified_by_public_key_bin` to `Network` for quicker lookups per public key.
 - Updates `Network` attribute comments to be attribute docstrings (you can now press `Ctrl+Q` on them 😃).
 - Updates `Network.services_per_peer` to use the full public key material instead of an mid.
 - Updates `TestNetwork` to use `bytes` as overlay ids.

Notable deviation from proposed fix in #935: decided not to go with best performance, but simple one line lookups (thanks @kozlovsky). This class is cryptic and fagile enough, we don't need even more mystical constructs.
