### PR TITLE
Remove UDPIPv6 from default endpoints

### DIFF
--- a/ipv8_service.py
+++ b/ipv8_service.py
@@ -69,12 +69,9 @@ else:
             if endpoint_override:
                 self.endpoint = endpoint_override
             else:
-                self.endpoint = DispatcherEndpoint(["UDPIPv6", "UDPIPv4"],
+                self.endpoint = DispatcherEndpoint(["UDPIPv4"],
                                                    UDPIPv4={'port': configuration['port'],
-                                                            'ip': configuration['address']},
-                                                   UDPIPv6={'port': configuration['port'],
-                                                            'ip': "::"}
-                                                   )
+                                                            'ip': configuration['address']})
             if enable_statistics:
                 self.endpoint = StatisticsEndpoint(self.endpoint)
             if any([overlay.get('initialize', {}).get('anonymize') for overlay in configuration['overlays']]):


### PR DESCRIPTION
Fixes #943

This PR:

 - Removes `UDPIPv6` from the default endpoints loaded by `IPv8`.

