### PR TITLE
Automated Version Update

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -24,9 +24,9 @@ copyright = '2017-2020, Tribler'  # Do not change manually! Handled by github_in
 author = u'Tribler'
 
 # The short X.Y version
-version = '2.4'  # Do not change manually! Handled by github_increment_version.py
+version = '2.5'  # Do not change manually! Handled by github_increment_version.py
 # The full version, including alpha/beta/rc tags
-release = '2.4.0'  # Do not change manually! Handled by github_increment_version.py
+release = '2.5.0'  # Do not change manually! Handled by github_increment_version.py
 
 
 # -- General configuration ---------------------------------------------------

--- a/ipv8/REST/rest_manager.py
+++ b/ipv8/REST/rest_manager.py
@@ -84,7 +84,7 @@ class RESTManager:
         aiohttp_apispec = AiohttpApiSpec(
             app=self.root_endpoint.app,
             title="IPv8 REST API documentation",
-            version="v2.4",  # Do not change manually! Handled by github_increment_version.py
+            version="v2.5",  # Do not change manually! Handled by github_increment_version.py
             url="/docs/swagger.json",
             swagger_path="/docs",
         )

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     description='The Python implementation of the IPV8 library',
     long_description=long_description,
     long_description_content_type='text/markdown',
-    version='2.4.0',  # Do not change manually! Handled by github_increment_version.py
+    version='2.5.0',  # Do not change manually! Handled by github_increment_version.py
     url='https://github.com/Tribler/py-ipv8',
     package_data={'': ['*.*']},
     packages=find_packages(),


### PR DESCRIPTION
Suggested release message
---
Tag version: 2.5
Release title: IPv8 v2.5.1654 release
Body:
Includes the first 1654 commits (+119 since v2.4) for IPv8, containing:

 - Added 'q' format to Serializer defaults
 - Added Community base class IPv6 support
 - Added CommunityLauncher decorators
 - Added Endpoint unit tests
 - Added IPv6 support to DHTCommunity
 - Added Network.snapshot support for all addresses
 - Added Sentry support to the exit node script
 - Added TestBase shortcuts
 - Added address packer to default Serializer
 - Added cache retrieval wrapper
 - Added coverage barplot script generation
 - Added deferred bootstrap DNS resolution
 - Added documentation examples validation script
 - Added fragile packet handling mode in TestBase
 - Added hiddenimports to CommunityLauncher
 - Added identity integration test isolation
 - Added identity integration test scripts
 - Added isolation endpoint tests
 - Added overlay and walk strategy loading from a function
 - Added static typing support
 - Added tests for the REST overlays endpoint
 - Added typing for VariablePayload
 - Added unload_overlay to mock IPv8
 - Fixed Bootstrap script resolving IPv6 tuples
 - Fixed RequestCache futures not being cancelled after shutdown
 - Fixed for introducing peers to outdated addresses
 - Fixed incorrect lan_introduction_address in the IntroductionResponse
 - Fixed new style punctures sent to old style peers
 - Fixed overzealous defensive programming in create_introduction_request
 - Fixed setting anonymization and statistics for overwritten endpoints
 - Fixed tracker peer for intro overwrite
 - Fixed tracker script not being general listener
 - Removed Trustchain (moved to AnyDex)
 - Removed UDPIPv6 from default endpoints
 - Removed generate_key script
 - Removed end-of-life tracker
 - Updated "too many peers" log level to DEBUG
 - Updated CreateRequestCache to use the payload identifier
 - Updated DHTCommunity serialization
 - Updated MockIPv8.unload naming to MockIPv8.stop
 - Updated Network class polish
 - Updated NumberCache.on_timeout to no longer be abstract
 - Updated TunnelCommunity payloads and crypto
 - Updated documentation by extracting examples into Python files