### PR TITLE
Fixed UDPEndpoint.send when transport is None

### DIFF
--- a/ipv8/messaging/interfaces/udp/endpoint.py
+++ b/ipv8/messaging/interfaces/udp/endpoint.py
@@ -45,7 +45,7 @@ class UDPEndpoint(Endpoint, asyncio.DatagramProtocol):
         try:
             self._transport.sendto(packet, socket_address)
             self.bytes_up += len(packet)
-        except (TypeError, ValueError) as exc:
+        except (TypeError, ValueError, AttributeError) as exc:
             self._logger.warning("Dropping packet due to message formatting error: %s", exc)
 
     def log_error(self, message, level=logging.WARNING):


### PR DESCRIPTION
Fixes https://github.com/Tribler/tribler/issues/5830

This PR fixes `AttributeError: 'NoneType' object has no attribute 'call_exception_handler'` by adding `AttributeError` to ignored exceptions.