### PR TITLE
Fixed scripts due to bootstrap refactoring

### DIFF
--- a/doc/basics/overlay_tutorial_3.py
+++ b/doc/basics/overlay_tutorial_3.py
@@ -2,7 +2,7 @@ import os
 from asyncio import ensure_future, get_event_loop
 
 from pyipv8.ipv8.community import Community
-from pyipv8.ipv8.configuration import ConfigBuilder, Strategy, WalkerDefinition
+from pyipv8.ipv8.configuration import ConfigBuilder, Strategy, WalkerDefinition, default_bootstrap_defs
 from pyipv8.ipv8_service import IPv8
 
 
@@ -27,8 +27,8 @@ async def start_communities():
         # RandomWalk strategy, until we find 10 peers.
         # We do not provide additional startup arguments or a function to run
         # once the overlay has been initialized.
-        builder.add_overlay("MyCommunity", "my peer", [WalkerDefinition(Strategy.RandomWalk, 10, {'timeout': 3.0})], {},
-                            [])
+        builder.add_overlay("MyCommunity", "my peer", [WalkerDefinition(Strategy.RandomWalk, 10, {'timeout': 3.0})],
+                            default_bootstrap_defs, {}, [])
         ipv8 = IPv8(builder.finalize(), extra_communities={'MyCommunity': MyCommunity})
         await ipv8.start()
 

--- a/doc/basics/overlay_tutorial_4.py
+++ b/doc/basics/overlay_tutorial_4.py
@@ -2,7 +2,7 @@ import os
 from asyncio import ensure_future, get_event_loop
 
 from pyipv8.ipv8.community import Community
-from pyipv8.ipv8.configuration import ConfigBuilder, Strategy, WalkerDefinition
+from pyipv8.ipv8.configuration import ConfigBuilder, Strategy, WalkerDefinition, default_bootstrap_defs
 from pyipv8.ipv8_service import IPv8
 
 
@@ -26,8 +26,8 @@ async def start_communities():
         # We provide the 'started' function to the 'on_start'.
         # We will call the overlay's 'started' function without any
         # arguments once IPv8 is initialized.
-        builder.add_overlay("MyCommunity", "my peer", [WalkerDefinition(Strategy.RandomWalk, 10, {'timeout': 3.0})], {},
-                            [('started',)])
+        builder.add_overlay("MyCommunity", "my peer", [WalkerDefinition(Strategy.RandomWalk, 10, {'timeout': 3.0})],
+                            default_bootstrap_defs, {}, [('started',)])
         await IPv8(builder.finalize(), extra_communities={'MyCommunity': MyCommunity}).start()
 
 

--- a/doc/basics/overlay_tutorial_5.py
+++ b/doc/basics/overlay_tutorial_5.py
@@ -2,7 +2,7 @@ import os
 from asyncio import ensure_future, get_event_loop
 
 from pyipv8.ipv8.community import Community
-from pyipv8.ipv8.configuration import ConfigBuilder, Strategy, WalkerDefinition
+from pyipv8.ipv8.configuration import ConfigBuilder, Strategy, WalkerDefinition, default_bootstrap_defs
 from pyipv8.ipv8.lazy_community import lazy_wrapper
 from pyipv8.ipv8.messaging.lazy_payload import VariablePayload, vp_compile
 from pyipv8.ipv8_service import IPv8
@@ -51,8 +51,8 @@ async def start_communities():
     for i in [1, 2, 3]:
         builder = ConfigBuilder().clear_keys().clear_overlays()
         builder.add_key("my peer", "medium", f"ec{i}.pem")
-        builder.add_overlay("MyCommunity", "my peer", [WalkerDefinition(Strategy.RandomWalk, 10, {'timeout': 3.0})], {},
-                            [('started',)])
+        builder.add_overlay("MyCommunity", "my peer", [WalkerDefinition(Strategy.RandomWalk, 10, {'timeout': 3.0})],
+                            default_bootstrap_defs, {}, [('started',)])
         await IPv8(builder.finalize(), extra_communities={'MyCommunity': MyCommunity}).start()
 
 

--- a/doc/deprecated/attestation_tutorial_integration/main.py
+++ b/doc/deprecated/attestation_tutorial_integration/main.py
@@ -6,7 +6,7 @@ from sys import argv
 from ipv8.REST.rest_manager import RESTManager
 from ipv8.attestation.identity.community import IdentityCommunity
 from ipv8.attestation.wallet.community import AttestationCommunity
-from ipv8.configuration import get_default_configuration
+from ipv8.configuration import DISPERSY_BOOTSTRAPPER, get_default_configuration
 from ipv8.peerdiscovery.community import DiscoveryCommunity
 
 from ipv8_service import IPv8
@@ -66,10 +66,9 @@ async def start_communities():
                     'init': {}
                 }
             ],
+            'bootstrappers': [DISPERSY_BOOTSTRAPPER],
             'initialize': {},
-            'on_start': [
-                ('resolve_dns_bootstrap_addresses',)
-            ]
+            'on_start': []
         },
             {
                 'class': 'IsolatedAttestationCommunity',
@@ -81,6 +80,7 @@ async def start_communities():
                         'timeout': 3.0
                     }
                 }],
+                'bootstrappers': [DISPERSY_BOOTSTRAPPER],
                 'initialize': {'working_directory': 'state_%d' % i},
                 'on_start': []
             },
@@ -94,6 +94,7 @@ async def start_communities():
                         'timeout': 3.0
                     }
                 }],
+                'bootstrappers': [DISPERSY_BOOTSTRAPPER],
                 'initialize': {'working_directory': 'state_%d' % i},
                 'on_start': []
             }]

--- a/ipv8/attestation/identity/community.py
+++ b/ipv8/attestation/identity/community.py
@@ -7,7 +7,9 @@ from time import time
 from .attestation import Attestation
 from .manager import IdentityManager
 from .payload import AttestPayload, DiclosePayload, MissingResponsePayload, RequestMissingPayload
+from ...bootstrapping.dispersy.bootstrapper import DispersyBootstrapper
 from ...community import Community, DEFAULT_MAX_PEERS
+from ...configuration import DISPERSY_BOOTSTRAPPER
 from ...lazy_community import lazy_wrapper
 from ...peer import Peer
 from ...peerdiscovery.discovery import RandomWalk
@@ -300,5 +302,6 @@ async def create_community(private_key: PrivateKey, ipv8, identity_manager: Iden
         })
     community = overlay_cls(my_peer, endpoint, identity_manager=identity_manager,
                             working_directory=working_directory_str, anonymize=anonymize)
+    community.bootstrappers = [DispersyBootstrapper(**DISPERSY_BOOTSTRAPPER['init'])]
     ipv8.add_strategy(community, RandomWalk(community), -1)
     return community

--- a/ipv8/configuration.py
+++ b/ipv8/configuration.py
@@ -4,8 +4,9 @@ import copy
 import enum
 import socket
 import typing
+from typing import Any, Dict
 
-DISPERSY_BOOTSTRAPPER = {
+DISPERSY_BOOTSTRAPPER: Dict[Any, Any] = {
     'class': "DispersyBootstrapper",
     'init': {
         'ip_addresses': [
@@ -174,6 +175,9 @@ class Bootstrapper(enum.Enum):
 class BootstrapperDefinition(typing.NamedTuple):
     bootstrapper: Bootstrapper
     init: dict
+
+
+default_bootstrap_defs = [BootstrapperDefinition(Bootstrapper.DispersyBootstrapper, DISPERSY_BOOTSTRAPPER['init'])]
 
 
 class ConfigBuilder(object):
@@ -372,4 +376,4 @@ class ConfigBuilder(object):
 
 
 __all__ = ['Bootstrapper', 'BootstrapperDefinition', 'ConfigBuilder', 'DISPERSY_BOOTSTRAPPER', 'Strategy',
-           'WalkerDefinition', 'get_default_configuration']
+           'WalkerDefinition', 'default_bootstrap_defs', 'get_default_configuration']

--- a/stresstest/peer_discovery.py
+++ b/stresstest/peer_discovery.py
@@ -12,7 +12,7 @@ except ImportError:
     import __scriptpath__  # noqa: F401
 
 from ipv8.community import Community
-from ipv8.configuration import get_default_configuration
+from ipv8.configuration import DISPERSY_BOOTSTRAPPER, get_default_configuration
 
 from ipv8_service import IPv8, _COMMUNITIES
 
@@ -74,6 +74,7 @@ async def start_communities():
                     'timeout': 3.0
                 }
             }],
+            'bootstrappers': [DISPERSY_BOOTSTRAPPER],
             'initialize': {},
             'on_start': [('started', )]
         }]


### PR DESCRIPTION
Fixes #956
Fixes #958

This PR:

 - Fixes validation tests not using new bootstrapping logic.
 - Fixes identity community not spawning with a bootstrapper.
 - Fixes `peer_discovery.py` stresstest not using new bootstrapping logic.

