### PR TITLE
Added request cache documentation to TOC

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -59,6 +59,7 @@ Table of contents
    
    basics/peer_discovery.rst
    basics/overlay_tutorial.rst
+   basics/requestcache_tutorial.rst
    basics/identity_tutorial.rst
 
 .. toctree::


### PR DESCRIPTION
There were no issues with the request cache documentation generation: https://py-ipv8.readthedocs.io/en/latest/basics/requestcache_tutorial/

This PR adds the tutorial to the documentation TOC so it is visible to the public.