### PR TITLE
Changed the name of CommunityLauncher

### DIFF
--- a/ipv8/loader.py
+++ b/ipv8/loader.py
@@ -343,7 +343,7 @@ class CommunityLauncher:
 
         :rtype: str
         """
-        return self.get_overlay_class().__name__
+        return self.__class__.__name__
 
     def not_before(self):
         """

--- a/ipv8/test/test_loader.py
+++ b/ipv8/test/test_loader.py
@@ -333,7 +333,7 @@ class TestCommunityLauncher(TestBase):
         class DecoratedCommunityLauncher(CommunityLauncher):
             pass
 
-        self.assertEqual('MockCommunity', DecoratedCommunityLauncher().get_name())
+        self.assertEqual('DecoratedCommunityLauncher', DecoratedCommunityLauncher().get_name())
 
 
 class TestCommunityLoader(TestBase):


### PR DESCRIPTION
Right now when calling `CommunityLoader.set_launcher` IPv8 imports the community (which happens when calling `CommunityLauncher.get_name`). However, since the `precondition` can fail, this import may be unneeded. This requires us to have the dependencies of the community installed, even if it's disabled.

As a workaround, I suggest changing `CommunityLauncher.get_name` to simply return the name of the launcher itself, rather than that of the community.
