### PR TITLE
Automated Version Update

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -6,6 +6,8 @@
 # full list see the documentation:
 # http://www.sphinx-doc.org/en/master/config
 
+# pylint: disable=W0622
+
 # -- Path setup --------------------------------------------------------------
 
 # If extensions (or modules to document with autodoc) are in another directory,
@@ -20,13 +22,13 @@
 # -- Project information -----------------------------------------------------
 
 project = u'IPv8'
-copyright = '2017-2020, Tribler'  # Do not change manually! Handled by github_increment_version.py
+copyright = '2017-2021, Tribler'  # Do not change manually! Handled by github_increment_version.py
 author = u'Tribler'
 
 # The short X.Y version
-version = '2.5'  # Do not change manually! Handled by github_increment_version.py
+version = '2.6'  # Do not change manually! Handled by github_increment_version.py
 # The full version, including alpha/beta/rc tags
-release = '2.5.0'  # Do not change manually! Handled by github_increment_version.py
+release = '2.6.0'  # Do not change manually! Handled by github_increment_version.py
 
 
 # -- General configuration ---------------------------------------------------

--- a/ipv8/REST/rest_manager.py
+++ b/ipv8/REST/rest_manager.py
@@ -84,7 +84,7 @@ class RESTManager:
         aiohttp_apispec = AiohttpApiSpec(
             app=self.root_endpoint.app,
             title="IPv8 REST API documentation",
-            version="v2.5",  # Do not change manually! Handled by github_increment_version.py
+            version="v2.6",  # Do not change manually! Handled by github_increment_version.py
             url="/docs/swagger.json",
             swagger_path="/docs",
         )

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     description='The Python implementation of the IPV8 library',
     long_description=long_description,
     long_description_content_type='text/markdown',
-    version='2.5.0',  # Do not change manually! Handled by github_increment_version.py
+    version='2.6.0',  # Do not change manually! Handled by github_increment_version.py
     url='https://github.com/Tribler/py-ipv8',
     package_data={'': ['*.*']},
     packages=find_packages(),


### PR DESCRIPTION
Suggested release message
---
Tag version: 2.6
Release title: IPv8 v2.6.1699 release
Body:
Includes the first 1699 commits (+45 since v2.5) for IPv8, containing:

 - Added DiscoveryStrategies to OverlaysEndpoint
 - Added RequestCache documentation
 - Added TunnelSettings.from_dict classmethod
 - Added request cache documentation to TOC
 - Added tracker_reporter_plugin script to collect anonymized tracker statistics
 - Changed the name of CommunityLauncher
 - Fixed DHTCommunityProvider serialization
 - Fixed UDPEndpoint.send when transport is None
 - Fixed broken image in the peer discovery docs
 - Fixed issue with missing bootstrappers in PexCommunity
 - Fixed result signature for EZPackOverlay._ez_unpack_auth
 - Fixed scripts due to bootstrap refactoring
 - Modularized Community bootstrapping
 - Properly await exhaust_callbacks in TestBase
 - Updated tracker script