### PR TITLE
Fixed estimated WAN address being set to a LAN address

### DIFF
--- a/ipv8/community.py
+++ b/ipv8/community.py
@@ -344,7 +344,7 @@ class Community(EZPackOverlay):
 
     def on_introduction_response(self, peer, dist, payload):
         if (isinstance(payload.destination_address, UDPv4Address)
-                and not self.address_is_lan(payload.destination_address[0])):
+                and not self.address_in_lan_subnets(payload.destination_address[0])):
             self.my_estimated_wan = payload.destination_address
         self.my_peer.address = payload.destination_address
 

--- a/ipv8/messaging/interfaces/endpoint.py
+++ b/ipv8/messaging/interfaces/endpoint.py
@@ -251,15 +251,17 @@ class EndpointListener(metaclass=abc.ABCMeta):
         """
         Checks if the given ip address is either our own address or in one of the subnet defined for local network usage
         :param address: ip v4 address to be checked
-        :return: True if the adrress is a lan address, False otherwise
+        :return: True if the address is a lan address, False otherwise
         """
         if address == self.get_lan_address_without_netifaces():
             return True
-        else:
-            lan_subnets = (("192.168.0.0", 16),
-                           ("172.16.0.0", 12),
-                           ("10.0.0.0", 8))
-            return any(self._address_in_subnet(address, subnet) for subnet in lan_subnets)
+        return self.address_in_lan_subnets(address)
+
+    def address_in_lan_subnets(self, address):
+        lan_subnets = (("192.168.0.0", 16),
+                       ("172.16.0.0", 12),
+                       ("10.0.0.0", 8))
+        return any(self._address_in_subnet(address, subnet) for subnet in lan_subnets)
 
     def address_is_lan(self, address):
         if self._netifaces_failed:


### PR DESCRIPTION
Right now it's possible for any peer to overwrite the WAN address of a `Community` with a LAN address. It just needs to set the `IntroductionResponse.destination_address` to a LAN address that could be part of our LAN. (That's easy to do since we're gossiping our own LAN address.) This problem shouldn't occur when `netifaces` is not installed, as `address_is_lan` works differently without `netifaces`.

If the walker continues to walk, this problem would resolve itself right after the next introduction-response. But if the walker stops that address would remain in `my_estimated_wan`. That's the problem that I'm seeing on our exit nodes: eventually, most nodes seem to start putting LAN addresses on the DHT. Maybe some students are playing with our protocol.

Admittedly, a similar problem would arise with WAN addresses. That's why we used to have WAN voting. I think we should consider re-introducing some of this logic.