### PR TITLE
Added UDP broadcast bootstrapper

### DIFF
--- a/ipv8/bootstrapping/bootstrapper_interface.py
+++ b/ipv8/bootstrapping/bootstrapper_interface.py
@@ -53,3 +53,9 @@ class Bootstrapper(ABC):
         """
         Returns the blacklisted addresses for this Bootstrapper.
         """
+
+    @abstractmethod
+    def unload(self) -> None:
+        """
+        Stop and unload all the resources used by this Bootstrapper.
+        """

--- a/ipv8/bootstrapping/dispersy/bootstrapper.py
+++ b/ipv8/bootstrapping/dispersy/bootstrapper.py
@@ -67,3 +67,6 @@ class DispersyBootstrapper(Bootstrapper):
 
     def blacklist(self) -> Iterable[Address]:
         return self.ip_addresses
+
+    def unload(self) -> None:
+        pass

--- a/ipv8/bootstrapping/udpbroadcast/bootstrapper.py
+++ b/ipv8/bootstrapping/udpbroadcast/bootstrapper.py
@@ -1,8 +1,8 @@
 import logging
+from asyncio import BaseTransport, DatagramProtocol, get_event_loop
 from asyncio.futures import Future
 from binascii import hexlify
 from socket import AF_INET, SOCK_DGRAM, SOL_SOCKET, SO_BROADCAST, SO_REUSEADDR, socket
-from threading import Thread
 from typing import Coroutine, Iterable, Optional, Union
 
 from ..bootstrapper_interface import Bootstrapper
@@ -16,41 +16,69 @@ MAGIC = b'\x49\x50\x76\x38'
 HDR_ANNOUNCE = PROTOCOL_VERSION + MAGIC + b'\x00'
 
 
+class BroadcastBootstrapEndpoint(DatagramProtocol):
+
+    def __init__(self, overlay: Community):
+        super().__init__()
+
+        self._socket: Optional[socket] = None
+        self._transport: Optional[BaseTransport] = None
+        self.overlay = overlay
+        self.logger = logging.getLogger(self.__class__.__name__)
+
+    async def open(self) -> bool:
+        loop = get_event_loop()
+
+        try:
+            self._socket = socket(AF_INET, SOCK_DGRAM)
+            self._socket.setsockopt(SOL_SOCKET, SO_REUSEADDR, 1)
+            self._socket.setsockopt(SOL_SOCKET, SO_BROADCAST, 1)
+            self._socket.bind(('', 0))
+            self._transport, _ = await loop.create_datagram_endpoint(lambda: self, sock=self._socket)
+        except (OSError, ValueError):
+            return False
+
+        return True
+
+    def send(self, socket_address, data: bytes):
+        try:
+            if self._socket is not None:
+                self._socket.sendto(data, socket_address)
+        except (TypeError, ValueError, AttributeError, OSError):
+            pass  # Windows doesn't really care, Ubuntu throws an exception on "illegal" ports
+
+    def datagram_received(self, data: bytes, addr) -> None:
+        if data.startswith(HDR_ANNOUNCE):
+            if self.overlay.get_prefix() == data[len(HDR_ANNOUNCE):]:
+                self.logger.debug("Received data from beacon %s: attempting walk!", repr(addr))
+                self.overlay.walk_to(addr)
+            # Otherwise: valid, but not for our overlay
+        elif data.startswith(self.overlay.get_prefix()):
+            self.logger.debug("Walk success by %s: attempting handoff!", repr(addr))
+            self.overlay.on_packet((addr, data))
+        else:
+            self.logger.debug("Dropping garbage packet from %s: %s", repr(addr), hexlify(data))
+
+    def close(self) -> None:
+        if self._transport is not None and not self._transport.is_closing():
+            self._transport.close()
+
+
 class UDPBroadcastBootstrapper(Bootstrapper):
 
     def __init__(self):
-        self.socket: Optional[socket] = None
-        self.receive_thread = None
+        self.endpoint = None
         self.overlay = None
-        self.logger = logging.getLogger(self.__class__.__name__)
 
-    def receive(self):
-        while True:
-            data, address = self.socket.recvfrom(1024)
-
-            if data.startswith(HDR_ANNOUNCE):
-                if self.overlay.get_prefix() == data[len(HDR_ANNOUNCE):]:
-                    self.logger.debug("Received data from beacon %s: attempting walk!", repr(address))
-                    self.overlay.walk_to(address)
-                # Otherwise: valid, but not for our overlay
-            elif data.startswith(self.overlay.get_prefix()):
-                self.logger.debug("Walk success by %s: attempting handoff!", repr(address))
-                self.overlay.on_packet((address, data))
-            else:
-                self.logger.debug("Dropping garbage packet from %s: %s", repr(address), hexlify(data))
-
-    def initialize(self, overlay: Community) -> Union[Future, Coroutine]:
+    async def initialize(self, overlay: Community) -> Union[Future, Coroutine]:  # pylint: disable=W0236
         self.overlay = overlay
 
         # Open the socket
-        self.socket = socket(AF_INET, SOCK_DGRAM)
-        self.socket.setsockopt(SOL_SOCKET, SO_REUSEADDR, 1)
-        self.socket.setsockopt(SOL_SOCKET, SO_BROADCAST, 1)
-        self.socket.bind(('', 0))
-
-        # Start listening
-        self.receive_thread = Thread(target=self.receive, daemon=True)
-        self.receive_thread.start()
+        endpoint = BroadcastBootstrapEndpoint(overlay)
+        success = await endpoint.open()
+        if not success:
+            return succeed(False)
+        self.endpoint = endpoint
 
         # Start sending
         self.beacon(overlay.get_prefix())
@@ -61,12 +89,9 @@ class UDPBroadcastBootstrapper(Bootstrapper):
         """
         Try to find a listener (fire and forget).
         """
-        if self.socket is not None:
+        if self.endpoint is not None:
             for p in range(65535):
-                try:
-                    self.socket.sendto(HDR_ANNOUNCE + service_prefix, ('255.255.255.255', p))
-                except OSError:
-                    pass  # Windows doesn't really care, Ubuntu throws an exception on "illegal" ports
+                self.endpoint.send(('255.255.255.255', p), HDR_ANNOUNCE + service_prefix)
 
     async def get_addresses(self, overlay: Community, timeout: float) -> Iterable[Address]:
         self.beacon(overlay.get_prefix())
@@ -77,3 +102,7 @@ class UDPBroadcastBootstrapper(Bootstrapper):
 
     def blacklist(self) -> Iterable[Address]:
         return []
+
+    def unload(self) -> None:
+        if self.endpoint:
+            self.endpoint.close()

--- a/ipv8/bootstrapping/udpbroadcast/bootstrapper.py
+++ b/ipv8/bootstrapping/udpbroadcast/bootstrapper.py
@@ -1,0 +1,79 @@
+import logging
+from asyncio.futures import Future
+from binascii import hexlify
+from socket import AF_INET, SOCK_DGRAM, SOL_SOCKET, SO_BROADCAST, SO_REUSEADDR, socket
+from threading import Thread
+from typing import Coroutine, Iterable, Optional, Union
+
+from ..bootstrapper_interface import Bootstrapper
+from ...types import Address, Community
+from ...util import succeed
+
+
+PROTOCOL_VERSION = b'\x00\x00'
+MAGIC = b'\x49\x50\x76\x38'
+
+HDR_ANNOUNCE = PROTOCOL_VERSION + MAGIC + b'\x00'
+
+
+class UDPBroadcastBootstrapper(Bootstrapper):
+
+    def __init__(self):
+        self.socket: Optional[socket] = None
+        self.receive_thread = None
+        self.overlay = None
+        self.logger = logging.getLogger(self.__class__.__name__)
+
+    def receive(self):
+        while True:
+            data, address = self.socket.recvfrom(1024)
+
+            if data.startswith(HDR_ANNOUNCE):
+                if self.overlay.get_prefix() == data[len(HDR_ANNOUNCE):]:
+                    self.logger.debug("Received data from beacon %s: attempting walk!", repr(address))
+                    self.overlay.walk_to(address)
+                # Otherwise: valid, but not for our overlay
+            elif data.startswith(self.overlay.get_prefix()):
+                self.logger.debug("Walk success by %s: attempting handoff!", repr(address))
+                self.overlay.on_packet((address, data))
+            else:
+                self.logger.debug("Dropping garbage packet from %s: %s", repr(address), hexlify(data))
+
+    def initialize(self, overlay: Community) -> Union[Future, Coroutine]:
+        self.overlay = overlay
+
+        # Open the socket
+        self.socket = socket(AF_INET, SOCK_DGRAM)
+        self.socket.setsockopt(SOL_SOCKET, SO_REUSEADDR, 1)
+        self.socket.setsockopt(SOL_SOCKET, SO_BROADCAST, 1)
+        self.socket.bind(('', 0))
+
+        # Start listening
+        self.receive_thread = Thread(target=self.receive, daemon=True)
+        self.receive_thread.start()
+
+        # Start sending
+        self.beacon(overlay.get_prefix())
+
+        return succeed(True)
+
+    def beacon(self, service_prefix: bytes) -> None:
+        """
+        Try to find a listener (fire and forget).
+        """
+        if self.socket is not None:
+            for p in range(65535):
+                try:
+                    self.socket.sendto(HDR_ANNOUNCE + service_prefix, ('255.255.255.255', p))
+                except OSError:
+                    pass  # Windows doesn't really care, Ubuntu throws an exception on "illegal" ports
+
+    async def get_addresses(self, overlay: Community, timeout: float) -> Iterable[Address]:
+        self.beacon(overlay.get_prefix())
+        return []
+
+    def keep_alive(self, overlay: Community) -> None:
+        self.beacon(overlay.get_prefix())
+
+    def blacklist(self) -> Iterable[Address]:
+        return []

--- a/ipv8/community.py
+++ b/ipv8/community.py
@@ -112,6 +112,12 @@ class Community(EZPackOverlay):
     def get_prefix(self):
         return self._prefix
 
+    async def unload(self):
+        while self.bootstrappers:
+            bootstrapper = self.bootstrappers.pop()
+            bootstrapper.unload()
+        await super().unload()
+
     def add_message_handler(self, msg_num, callback):
         """
         Add a handler for a message identifier. Any messages coming in with this identifier will be delivered to

--- a/ipv8/configuration.py
+++ b/ipv8/configuration.py
@@ -166,6 +166,7 @@ class WalkerDefinition(typing.NamedTuple):
 
 class Bootstrapper(enum.Enum):
     DispersyBootstrapper = "DispersyBootstrapper"
+    UDPBroadcastBootstrapper = "UDPBroadcastBootstrapper"
 
     @classmethod
     def values(cls):

--- a/ipv8_service.py
+++ b/ipv8_service.py
@@ -16,6 +16,7 @@ else:
         from ipv8.attestation.identity.community import IdentityCommunity
         from ipv8.attestation.wallet.community import AttestationCommunity
         from ipv8.bootstrapping.dispersy.bootstrapper import DispersyBootstrapper
+        from ipv8.bootstrapping.udpbroadcast.bootstrapper import UDPBroadcastBootstrapper
         from ipv8.keyvault.crypto import default_eccrypto
         from ipv8.keyvault.private.m2crypto import M2CryptoSK
         from ipv8.messaging.anonymization.community import TunnelCommunity
@@ -34,6 +35,7 @@ else:
         from .ipv8.attestation.identity.community import IdentityCommunity
         from .ipv8.attestation.wallet.community import AttestationCommunity
         from .ipv8.bootstrapping.dispersy.bootstrapper import DispersyBootstrapper
+        from .ipv8.bootstrapping.udpbroadcast.bootstrapper import UDPBroadcastBootstrapper
         from .ipv8.keyvault.crypto import default_eccrypto
         from .ipv8.keyvault.private.m2crypto import M2CryptoSK
         from .ipv8.messaging.anonymization.community import TunnelCommunity
@@ -63,7 +65,8 @@ else:
     }
 
     _BOOTSTRAPPERS = {
-        'DispersyBootstrapper': DispersyBootstrapper
+        'DispersyBootstrapper': DispersyBootstrapper,
+        'UDPBroadcastBootstrapper': UDPBroadcastBootstrapper
     }
 
     class IPv8(object):


### PR DESCRIPTION
Fixes #972 (this PR follows the approach presented in this issue)

This PR:

 - Adds a bootstrapper based on UDP broadcasts.
 - Adds `unload()` to bootstrapper interface.

This is my test script (which I run on separate machines):

```python
import os
from asyncio import ensure_future, get_event_loop

from pyipv8.ipv8.community import Community
from pyipv8.ipv8.configuration import Bootstrapper, BootstrapperDefinition, ConfigBuilder, Strategy, WalkerDefinition
from pyipv8.ipv8_service import IPv8


class MyCommunity(Community):
    community_id = b'testudpbroadcast\x00\x00\x00\x00'

    def started(self):
        async def print_peers():
            print("I am:", self.my_peer, "\nI know:", [str(p) for p in self.get_peers()])

        self.register_task("print_peers", print_peers, interval=5.0, delay=0)


async def start_communities():
    for i in [1]:
        builder = ConfigBuilder().clear_keys().clear_overlays()
        builder.add_key("my peer", "medium", f"ec{i}.pem")
        builder.add_overlay("MyCommunity",
                            "my peer",
                            [WalkerDefinition(Strategy.RandomWalk, 10, {'timeout': 3.0})],
                            [BootstrapperDefinition(Bootstrapper.UDPBroadcastBootstrapper, {})],
                            {},
                            [('started',)])
        await IPv8(builder.finalize(), extra_communities={'MyCommunity': MyCommunity}).start()


ensure_future(start_communities())
get_event_loop().run_forever()
```