### PR TITLE
Added RequestCache.passthrough()

### DIFF
--- a/ipv8/test/test_requestcache.py
+++ b/ipv8/test/test_requestcache.py
@@ -1,7 +1,7 @@
-from asyncio import Future, all_tasks
+from asyncio import Future, all_tasks, sleep
 
 from .base import TestBase
-from ..requestcache import RandomNumberCache, RequestCache
+from ..requestcache import NumberCache, RandomNumberCache, RequestCache
 
 CACHE_TIMEOUT = 0.01
 
@@ -35,14 +35,32 @@ class MockRegisteredCache(RandomNumberCache):
         pass
 
 
+class MockInfiniteCache(RandomNumberCache):
+
+    def __init__(self, request_cache):
+        super().__init__(request_cache, u"mock")
+        self.timed_out = False
+
+    @property
+    def timeout_delay(self):
+        return 8589934592
+
+    def on_timeout(self):
+        self.timed_out = True
+
+
 class TestRequestCache(TestBase):
+
+    def setUp(self):
+        super().setUp()
+        self.request_cache = RequestCache()
 
     async def test_shutdown(self):
         """
         Test if RequestCache does not allow new Caches after shutdown().
         """
         num_tasks = len(all_tasks())
-        request_cache = RequestCache()
+        request_cache = RequestCache()  # This adds a task, don't use ``self.request_cache`` here!
         request_cache.add(MockCache(request_cache))
         self.assertEqual(len(all_tasks()), num_tasks + 2)
         await request_cache.shutdown()
@@ -54,76 +72,153 @@ class TestRequestCache(TestBase):
         """
         Test if the cache.on_timeout() is called after the cache.timeout_delay.
         """
-        request_cache = RequestCache()
-        cache = MockCache(request_cache)
-        request_cache.add(cache)
+        cache = MockCache(self.request_cache)
+        self.request_cache.add(cache)
         await cache.timed_out
 
     async def test_add_duplicate(self):
         """
         Test if adding a cache twice returns None as the newly added cache.
         """
-        request_cache = RequestCache()
-        cache = MockCache(request_cache)
-        request_cache.add(cache)
+        cache = MockCache(self.request_cache)
+        self.request_cache.add(cache)
 
-        self.assertIsNone(request_cache.add(cache))
+        self.assertIsNone(self.request_cache.add(cache))
 
-        await request_cache.shutdown()
+        await self.request_cache.shutdown()
 
     async def test_timeout_future_default_value(self):
         """
         Test if a registered future gets set to None on timeout.
         """
-        request_cache = RequestCache()
-        cache = MockRegisteredCache(request_cache)
-        request_cache.add(cache)
+        cache = MockRegisteredCache(self.request_cache)
+        self.request_cache.add(cache)
         self.assertEqual(None, (await cache.timed_out))
-        await request_cache.shutdown()
+        await self.request_cache.shutdown()
 
     async def test_timeout_future_custom_value(self):
         """
         Test if a registered future gets set to a value on timeout.
         """
-        request_cache = RequestCache()
-        cache = MockRegisteredCache(request_cache)
-        request_cache.add(cache)
+        cache = MockRegisteredCache(self.request_cache)
+        self.request_cache.add(cache)
 
         cache.managed_futures[0] = (cache.managed_futures[0][0], 123)
         self.assertEqual(123, (await cache.timed_out))
 
-        await request_cache.shutdown()
+        await self.request_cache.shutdown()
 
     async def test_timeout_future_exception(self):
         """
         Test if a registered future raises an exception on timeout.
         """
-        request_cache = RequestCache()
-        cache = MockRegisteredCache(request_cache)
-        request_cache.add(cache)
+        cache = MockRegisteredCache(self.request_cache)
+        self.request_cache.add(cache)
 
         cache.managed_futures[0] = (cache.managed_futures[0][0], RuntimeError())
         with self.assertRaises(RuntimeError):
             await cache.timed_out
 
-        await request_cache.shutdown()
+        await self.request_cache.shutdown()
 
     async def test_cancel_future_after_shutdown(self):
         """
         Test if a registered future is cancelled when the RequestCache has shutdown.
         """
-        request_cache = RequestCache()
-        await request_cache.shutdown()
-        cache = MockRegisteredCache(request_cache)
-        request_cache.add(cache)
+        await self.request_cache.shutdown()
+        cache = MockRegisteredCache(self.request_cache)
+        self.request_cache.add(cache)
         assert cache.managed_futures[0][0].done()
 
     async def test_cancel_future(self):
         """
         Test if a registered future gets canceled at shutdown.
         """
-        request_cache = RequestCache()
-        cache = MockRegisteredCache(request_cache)
-        request_cache.add(cache)
-        await request_cache.shutdown()
+        cache = MockRegisteredCache(self.request_cache)
+        self.request_cache.add(cache)
+        await self.request_cache.shutdown()
         self.assertTrue(cache.timed_out.cancelled())
+
+    async def test_passthrough_noargs(self):
+        """
+        Test if passthrough without arguments immediately times a cache out.
+        """
+        cache = MockInfiniteCache(self.request_cache)
+
+        with self.request_cache.passthrough():
+            self.request_cache.add(cache)
+            await sleep(0.0)
+
+        self.assertTrue(cache.timed_out)
+
+    async def test_passthrough_timeout(self):
+        """
+        Test if passthrough respects the timeout value.
+        """
+        cache = MockInfiniteCache(self.request_cache)
+
+        with self.request_cache.passthrough(timeout=10.0):
+            self.request_cache.add(cache)
+            await sleep(0.0)
+
+        self.assertFalse(cache.timed_out)
+
+    async def test_passthrough_filter_one_match(self):
+        """
+        Test if passthrough filters correctly with one filter, that matches
+        """
+        cache = MockInfiniteCache(self.request_cache)
+
+        with self.request_cache.passthrough(MockInfiniteCache):
+            self.request_cache.add(cache)
+            await sleep(0.0)
+
+        self.assertTrue(cache.timed_out)
+
+    async def test_passthrough_filter_one_mismatch(self):
+        """
+        Test if passthrough filters correctly with one filter, that doesn't match
+        """
+        cache = MockInfiniteCache(self.request_cache)
+
+        with self.request_cache.passthrough(MockRegisteredCache):
+            self.request_cache.add(cache)
+            await sleep(0.0)
+
+        self.assertFalse(cache.timed_out)
+
+    async def test_passthrough_filter_many_match(self):
+        """
+        Test if passthrough filters correctly with many filters, that all match
+        """
+        cache = MockInfiniteCache(self.request_cache)
+
+        with self.request_cache.passthrough(MockInfiniteCache, RandomNumberCache, NumberCache):
+            self.request_cache.add(cache)
+            await sleep(0.0)
+
+        self.assertTrue(cache.timed_out)
+
+    async def test_passthrough_filter_some_match(self):
+        """
+        Test if passthrough filters correctly with many filters, for which some match
+        """
+        cache = MockInfiniteCache(self.request_cache)
+
+        with self.request_cache.passthrough(MockRegisteredCache, MockCache, RandomNumberCache):
+            self.request_cache.add(cache)
+            await sleep(0.0)
+
+        self.assertTrue(cache.timed_out)
+
+    async def test_passthrough_filter_no_match(self):
+        """
+        Test if passthrough filters correctly with many filters, for which none match
+        """
+        cache = MockInfiniteCache(self.request_cache)
+
+        with self.request_cache.passthrough(MockRegisteredCache, MockCache):
+            self.request_cache.add(cache)
+            await sleep(0.0)
+
+        self.assertFalse(cache.timed_out)


### PR DESCRIPTION
Fixes #987

This PR:

 - Adds the `RequestCache.passthrough()`, as described in #987.
 - Updates `TestRequestCache` to use a common `self.request_cache` to reduce code duplication.

Note that the `passthrough()` does not allow nesting.