### PR TITLE
Finalized TestBase docs

### DIFF
--- a/doc/basics/testbase_tutorial.rst
+++ b/doc/basics/testbase_tutorial.rst
@@ -32,7 +32,7 @@ At the end of this setup step you should have the following files in your workin
    (file) community.py
    (file) test_community.py
 
-We will use the following ``community.py`` in this file:
+We will use the following ``community.py`` in this tutorial:
 
 .. code-block:: python
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -60,6 +60,7 @@ Table of contents
    basics/peer_discovery.rst
    basics/overlay_tutorial.rst
    basics/requestcache_tutorial.rst
+   basics/testbase_tutorial.rst
    basics/identity_tutorial.rst
 
 .. toctree::


### PR DESCRIPTION
This is the follow-up PR on #990.

The output of #990 can be found here: https://py-ipv8.readthedocs.io/en/latest/basics/testbase_tutorial/
No big surprises, everything seems ready to be exposed to the outside world.

This PR:

 - Adds the `Unit Testing Overlays` documentation to the index, exposing it.
 - Fixes `Unit Testing Overlays` documentation referring to itself as a "file".
 


