### PR TITLE
Updated hidden services to disallow IPv8 packets over end-to-end circuits

### DIFF
--- a/ipv8/messaging/anonymization/utils.py
+++ b/ipv8/messaging/anonymization/utils.py
@@ -2,16 +2,10 @@ from asyncio import FIRST_COMPLETED, wait
 from statistics import mean, median
 from timeit import default_timer
 
-from ipv8.messaging.anonymization.tunnel import CIRCUIT_STATE_CLOSING, EXIT_NODE, ORIGINATOR
+from ipv8.messaging.anonymization.tunnel import CIRCUIT_STATE_CLOSING
 
 
-async def run_speed_test(tc, direction, circuit, window=50, size=30):
-    assert direction in [EXIT_NODE, ORIGINATOR]
-
-    request_size = 0 if direction == ORIGINATOR else 1024
-    response_size = 1024 if direction == ORIGINATOR else 0
-    # Transfer size * 1024 * 1024 = size MB (excluding protocol overhead).
-    num_packets = size * 1024
+async def run_speed_test(tc, circuit, request_size, response_size, num_requests, window=50):
     num_sent = 0
     num_ack = 0
     outstanding = set()
@@ -19,24 +13,23 @@ async def run_speed_test(tc, direction, circuit, window=50, size=30):
     rtts = []
 
     while True:
-        while num_sent < num_packets and len(outstanding) < window and circuit.state != CIRCUIT_STATE_CLOSING:
+        while num_sent < num_requests and len(outstanding) < window and circuit.state != CIRCUIT_STATE_CLOSING:
             outstanding.add(tc.send_test_request(circuit, request_size, response_size))
             num_sent += 1
         if not outstanding:
             break
-        done, outstanding = await wait(outstanding, return_when=FIRST_COMPLETED, timeout=3)
-        if not done and num_ack > 0.95 * num_packets:
-            # We have received nothing for the past 3s and did get an acknowledgement for 95%
-            # of our requests. To avoid waiting for packets that may never arrive we stop the
-            # test. Any pending messages are considered lost.
+        done, outstanding = await wait(outstanding, return_when=FIRST_COMPLETED, timeout=10)
+        if not done:
+            # We have received nothing for the past 10s.Any pending messages are considered lost.
             break
         # Make sure to only count futures that haven't been set by on_timeout.
         results = [f.result() for f in done if f.result() is not None]
         num_ack += len(results)
         rtts.extend([rtt for _, rtt in results])
 
-    return {'speed': (num_ack / 1024) / (default_timer() - start),
+    return {'speed_up': (num_ack * request_size / 1024) / (default_timer() - start),
+            'speed_down': (num_ack * response_size / 1024) / (default_timer() - start),
             'messages_sent': num_ack + len(outstanding),
             'messages_received': num_ack,
-            'rtt_mean': mean(rtts),
-            'rtt_median': median(rtts)}
+            'rtt_mean': mean(rtts) if rtts else -1,
+            'rtt_median': median(rtts) if rtts else -1}


### PR DESCRIPTION
This PR:
* Updates hidden services to no longer process incoming IPv8 packets wrapped in data cells. Once the end-to-end circuit is fully established this is no longer needed, and could lead to potential security issues.
* Updates the speed test endpoint to allow more control over the number and size of the packets.
* Fixes an issue where the byte counters of the hidden swarm would be reset after an end-to-end circuit is destroyed.

