### PR TITLE
Added link latencies to the IPv8 simulator

### DIFF
--- a/doc/simulation/simulation_tutorial.rst
+++ b/doc/simulation/simulation_tutorial.rst
@@ -11,3 +11,5 @@ Code Example
 Below we provide a Python snippet that runs a simple simulation. In this example, we start two IPv8 instances with a `SimulatedEndpoint` as endpoint. Like the unit tests, the LAN/WAN addresses are randomly generated. Each instance loads a single `PingPongCommunity` overlay and peers are introduced to each other after IPv8 has started. Each peer sends a ping message to the other peer every two seconds. The sending and reception of ping and pong message are printed to standard output, together with the current time of the event loop. The simulation ends after ten seconds.
 
 .. literalinclude:: simulation_tutorial_1.py
+
+The endpoint used in the above code assumes that packets arrive immediately at the recipient. This is unrealistic in deployed peer-to-peer networks where link latency can be considerable, especially when considering communication between peers in different continents. Developers can simulate link latencies by modifying the `latencies` class variable, or by overriding the `get_link_latency` method. Link latencies can, for example, be set to random values or be determined by a latency matrix.

--- a/simulation/simulation_endpoint.py
+++ b/simulation/simulation_endpoint.py
@@ -1,3 +1,6 @@
+from asyncio import get_event_loop
+from collections import defaultdict
+
 from ipv8.test.mocking.endpoint import AutoMockEndpoint
 from ipv8.util import succeed
 
@@ -8,6 +11,20 @@ class SimulationEndpoint(AutoMockEndpoint):
     the IPv8 service.
     """
 
+    def __init__(self):
+        super().__init__()
+        self.latencies = defaultdict(int)
+
     async def open(self):
         self._open = True
         return succeed(None)
+
+    def get_link_latency(self, to_address):
+        """
+        Return the link latency to a particular destination address, in seconds.
+        """
+        return self.latencies[to_address]
+
+    def send(self, socket_address, packet):
+        get_event_loop().call_later(self.get_link_latency(socket_address), super().send,
+                                    socket_address, packet)


### PR DESCRIPTION
This PR:

 - Adds support for link latencies in the simulator. Specifically, we modified the `SimulationEndpoint` class to achieve this.
 