### PR TITLE
Initialize EndpointListener._local_interfaces

### DIFF
--- a/ipv8/messaging/interfaces/endpoint.py
+++ b/ipv8/messaging/interfaces/endpoint.py
@@ -129,6 +129,7 @@ class EndpointListener(metaclass=abc.ABCMeta):
         self.endpoint = endpoint
 
         self._netifaces_failed = netifaces is None
+        self._local_interfaces = []
         self._my_estimated_lan = None
         self.my_estimated_wan = self.my_estimated_lan
 


### PR DESCRIPTION
Fixes #997

This PR:

 - Fixes `EndpointListener._local_interfaces` not being initialized in the `__init__`.
