### PR TITLE
Extended simulation tutorial with bootstrap server

### DIFF
--- a/doc/simulation/simulation_tutorial.rst
+++ b/doc/simulation/simulation_tutorial.rst
@@ -8,8 +8,17 @@ All code associated with simulations are provided in the `simulation` package. I
 Code Example
 ------------
 
-Below we provide a Python snippet that runs a simple simulation. In this example, we start two IPv8 instances with a `SimulatedEndpoint` as endpoint. Like the unit tests, the LAN/WAN addresses are randomly generated. Each instance loads a single `PingPongCommunity` overlay and peers are introduced to each other after IPv8 has started. Each peer sends a ping message to the other peer every two seconds. The sending and reception of ping and pong message are printed to standard output, together with the current time of the event loop. The simulation ends after ten seconds.
+Below we provide a Python snippet that runs a simple simulation. In this example, we start two IPv8 instances with a `SimulatedEndpoint` as endpoint. Like the unit tests, the LAN/WAN addresses of peers are randomly generated and any communication to a peer that is not part of our simulation will raise an exception. Each instance loads a single `PingPongCommunity` overlay and peers are introduced to each other after IPv8 has started. Each peer sends a ping message to the other peer every two seconds. The sending and reception of ping and pong message are printed to standard output, together with the current time of the event loop. The simulation ends after ten seconds.
 
 .. literalinclude:: simulation_tutorial_1.py
 
 The endpoint used in the above code assumes that packets arrive immediately at the recipient. This is unrealistic in deployed peer-to-peer networks where link latency can be considerable, especially when considering communication between peers in different continents. Developers can simulate link latencies by modifying the `latencies` class variable, or by overriding the `get_link_latency` method. Link latencies can, for example, be set to random values or be determined by a latency matrix.
+
+Using the Bootstrap Server
+--------------------------
+
+In the example above, we explicitly introduce peers to each other by sending introduction requests between all pairs of peers. While this ensures full connectivity, it might not reflect the behaviours in deployed networks where peer discovery is a gradual and dynamic process. Peer discovery in IPv8 is assisted by bootstrap servers that maintain knowledge of the current active peers in the network and are able to introduce (a few) peers to newly joined peers to get them started.
+
+Below we show a Python snippet running a simple simulation with two simulated bootstrap servers and 20 peers. The experiments simulates a period of two minutes and every two seconds, a peer prints how many other peers it has discovered. When the simulation ends, each peer knows around ten other peers. Note that we also add a `RandomWalk` strategy to each initialized community.
+
+.. literalinclude:: simulation_tutorial_2.py

--- a/doc/simulation/simulation_tutorial_2.py
+++ b/doc/simulation/simulation_tutorial_2.py
@@ -1,0 +1,69 @@
+import os
+from asyncio import ensure_future, get_event_loop, set_event_loop, sleep
+
+from pyipv8.ipv8.community import Community
+from pyipv8.ipv8.configuration import Bootstrapper, BootstrapperDefinition, ConfigBuilder, Strategy, WalkerDefinition
+from pyipv8.ipv8_service import IPv8
+from pyipv8.scripts.tracker_service import EndpointServer
+from pyipv8.simulation.discrete_loop import DiscreteLoop
+from pyipv8.simulation.simulation_endpoint import SimulationEndpoint
+
+
+class SimpleCommunity(Community):
+    """
+    Very basic community that just prints the number of known peers every two seconds.
+    """
+    community_id = os.urandom(20)
+
+    def __init__(self, my_peer, endpoint, network, **kwargs):
+        super().__init__(my_peer, endpoint, network)
+        self.id = kwargs.pop('id')
+
+    def started(self):
+        self.register_task("print_peers", self.print_peers, interval=2.0, delay=0)
+
+    def print_peers(self):
+        self._logger.info("I am peer %d, I know %d peers...", self.id, len(self.network.verified_peers))
+
+
+async def start_communities():
+    bootstrap_ips = []
+    for i in range(2):  # We start two bootstrap nodes
+        bootstrap_endpoint = SimulationEndpoint()
+        await bootstrap_endpoint.open()
+        bootstrap_overlay = EndpointServer(bootstrap_endpoint)
+
+        # We assume all peers in our simulation have a public WAN IP (to avoid conflicts with our SimulationEndpoint)
+        bootstrap_overlay.my_estimated_lan = ("0.0.0.0", 0)
+        bootstrap_ips.append(bootstrap_endpoint.wan_address)
+
+    instances = []
+    for i in range(20):
+        builder = ConfigBuilder().clear_keys().clear_overlays()
+        builder.add_key("my peer", "medium", f"ec{i}.pem")
+        bootstrappers = [BootstrapperDefinition(Bootstrapper.DispersyBootstrapper,
+                                                {"ip_addresses": bootstrap_ips, "dns_addresses": []})]
+        walkers = [WalkerDefinition(Strategy.RandomWalk, 10, {'timeout': 3.0})]
+        builder.add_overlay("SimpleCommunity", "my peer", walkers, bootstrappers, {'id': i}, [('started',)])
+
+        endpoint = SimulationEndpoint()
+        instance = IPv8(builder.finalize(), endpoint_override=endpoint,
+                        extra_communities={'SimpleCommunity': SimpleCommunity})
+        # We assume all peers in our simulation have a public WAN IP (to avoid conflicts with our SimulationEndpoint)
+        instance.overlays[0].my_estimated_lan = ("0.0.0.0", 0)
+        await instance.start()
+        instances.append(instance)
+
+
+async def run_simulation():
+    await start_communities()
+    await sleep(120)
+    get_event_loop().stop()
+
+# We use a discrete event loop to enable quick simulations.
+loop = DiscreteLoop()
+set_event_loop(loop)
+
+ensure_future(run_simulation())
+
+loop.run_forever()


### PR DESCRIPTION
Fixes #(issue number)

This PR:

 - Extends the simulation tutorial with a simple example of how to leverage the IPv8 bootstrap server.
 
