### PR TITLE
Decoding prefix before printing

### DIFF
--- a/ipv8/community.py
+++ b/ipv8/community.py
@@ -43,7 +43,7 @@ class Community(EZPackOverlay):
         self._prefix = b'\x00' + self.version + self.community_id
         self.endpoint.remove_listener(self)
         self.endpoint.add_prefix_listener(self, self._prefix)
-        self.logger.debug("Launching %s with prefix %s.", self.__class__.__name__, hexlify(self._prefix))
+        self.logger.debug("Launching %s with prefix %s.", self.__class__.__name__, hexlify(self._prefix).decode())
 
         self.max_peers = max_peers
         self.anonymize = anonymize


### PR DESCRIPTION
This PR:

 - When creating a new community, there is a log entry that prints the community name and the prefix. The prefix is hexlified but not decoded, leading to b'' in the log entry. This commit changes this behaviour so that the prefix is decoded after hexlification.
 
