### PR TITLE
READY: Fix pytest compatibility

### DIFF
--- a/ipv8/test/messaging/anonymization/mock.py
+++ b/ipv8/test/messaging/anonymization/mock.py
@@ -1,0 +1,21 @@
+from collections import defaultdict
+
+# Map of info_hash -> peer list
+global_dht_services = defaultdict(list)
+
+
+class MockDHTProvider:
+
+    def __init__(self, peer):
+        self.peer = peer
+        # DHTDiscoveryCommunity functionality
+        global_dht_services[peer.mid].append(peer)
+
+    async def peer_lookup(self, mid, peer=None):  # pylint: disable=W0613
+        return await self.lookup(mid)
+
+    async def lookup(self, info_hash):
+        return info_hash, global_dht_services.get(info_hash, [])
+
+    async def announce(self, info_hash, intro_point):
+        global_dht_services[info_hash].append(intro_point)

--- a/ipv8/test/messaging/anonymization/test_community.py
+++ b/ipv8/test/messaging/anonymization/test_community.py
@@ -1,7 +1,7 @@
 from asyncio import Future
-from collections import defaultdict
 from unittest.mock import Mock
 
+from .mock import MockDHTProvider
 from ...base import TestBase
 from ...mocking.endpoint import MockEndpointListener
 from ...mocking.exit_socket import MockTunnelExitSocket
@@ -12,26 +12,6 @@ from ....messaging.anonymization.tunnel import (CIRCUIT_STATE_EXTENDING, PEER_FL
                                                 PEER_FLAG_EXIT_IPV8, PEER_FLAG_SPEED_TEST)
 from ....messaging.interfaces.udp.endpoint import DomainAddress, UDPEndpoint
 from ....util import succeed
-
-# Map of info_hash -> peer list
-global_dht_services = defaultdict(list)
-
-
-class MockDHTProvider(object):
-
-    def __init__(self, peer):
-        self.peer = peer
-        # DHTDiscoveryCommunity functionality
-        global_dht_services[peer.mid].append(peer)
-
-    async def peer_lookup(self, mid, peer=None):
-        return await self.lookup(mid)
-
-    async def lookup(self, info_hash):
-        return info_hash, global_dht_services.get(info_hash, [])
-
-    async def announce(self, info_hash, intro_point):
-        global_dht_services[info_hash].append(intro_point)
 
 
 class TestTunnelCommunity(TestBase):

--- a/ipv8/test/messaging/interfaces/udp/test_endpoint.py
+++ b/ipv8/test/messaging/interfaces/udp/test_endpoint.py
@@ -61,7 +61,8 @@ class TestUDPEndpoint(TestBase):
         # range must be in [1, 51), since Asyncio transports discard empty datagrams
         for ind in range(1, 51):
             self.endpoint1.send(self.ep2_address, b'a' * ind)
-        await sleep(.05)
+        while len(self.endpoint2_listener.incoming) < 50:
+            await sleep(.02)
         self.assertEqual(len(self.endpoint2_listener.incoming), 50)
 
     async def test_send_too_big_message(self):


### PR DESCRIPTION
Related to Tribler issue https://github.com/Tribler/tribler/issues/6087

This PR:

 - Adds support for missing event loops at module load time of `TestBase`.
 - Fixes `test_send_many_messages` not finishing in time on the Windows tester.
 - Updates `MockDHTProvider` to be in its own file. This allows pytest to import it without rewriting the file.
 
Notes:
 - This is the first time I've seen our Windows PR tests fail (see test result of commit `61f6061`) on `test_send_many_messages`. The machine may be overloaded.
 - This may not fix the root issue of https://github.com/Tribler/tribler/issues/6087, but at least brings us one step closer to the source.
