### PR TITLE
Automated Version Update

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -26,9 +26,9 @@ copyright = '2017-2021, Tribler'  # Do not change manually! Handled by github_in
 author = u'Tribler'
 
 # The short X.Y version
-version = '2.6'  # Do not change manually! Handled by github_increment_version.py
+version = '2.7'  # Do not change manually! Handled by github_increment_version.py
 # The full version, including alpha/beta/rc tags
-release = '2.6.0'  # Do not change manually! Handled by github_increment_version.py
+release = '2.7.0'  # Do not change manually! Handled by github_increment_version.py
 
 
 # -- General configuration ---------------------------------------------------

--- a/ipv8/REST/rest_manager.py
+++ b/ipv8/REST/rest_manager.py
@@ -84,7 +84,7 @@ class RESTManager:
         aiohttp_apispec = AiohttpApiSpec(
             app=self.root_endpoint.app,
             title="IPv8 REST API documentation",
-            version="v2.6",  # Do not change manually! Handled by github_increment_version.py
+            version="v2.7",  # Do not change manually! Handled by github_increment_version.py
             url="/docs/swagger.json",
             swagger_path="/docs",
         )

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     description='The Python implementation of the IPV8 library',
     long_description=long_description,
     long_description_content_type='text/markdown',
-    version='2.6.0',  # Do not change manually! Handled by github_increment_version.py
+    version='2.7.0',  # Do not change manually! Handled by github_increment_version.py
     url='https://github.com/Tribler/py-ipv8',
     package_data={'': ['*.*']},
     packages=find_packages(),


### PR DESCRIPTION
Suggested release message
---
Tag version: 2.7
Release title: IPv8 v2.7.1757 release
Body:
Includes the first 1757 commits (+58 since v2.6) for IPv8, containing:

 - Added RequestCache.passthrough()
 - Added TestBase tutorial
 - Added UDP broadcast bootstrapper
 - Added basic simulation capabilities to IPv8
 - Added link latencies to the IPv8 simulator
 - Decoding prefix before printing
 - Extended simulation tutorial with bootstrap server
 - Finalized TestBase docs
 - Fixed CONTRIBUTING.md grammar
 - Fixed compatibility with Python 3.8
 - Fixed estimated WAN address being set to a LAN address
 - Fixed for getting exits from TunnelEndpoint
 - Fixed pytest compatibility
 - Initialize EndpointListener._local_interfaces
 - The key when creating a Peer can also be bytes
 - Updated IRMA enroll script
 - Updated hidden services peer discovery
 - Updated hidden services to disallow IPv8 packets over end-to-end circuits
 - Use a unique identifier while sending CreatePayloads