### PR TITLE
Removed old database.py workarounds

### DIFF
--- a/ipv8/REST/attestation_endpoint.py
+++ b/ipv8/REST/attestation_endpoint.py
@@ -108,7 +108,7 @@ class AttestationEndpoint(BaseEndpoint):
         :param keys_to_keep: list of keys to not remove for
         :type keys_to_keep: [str]
         :return: the list of attestation hashes which have been removed
-        :rtype: [database_blob]
+        :rtype: [bytes]
         """
         database = self.identity_overlay.identity_manager.database
         all_identities = database.get_known_identities()
@@ -136,7 +136,7 @@ class AttestationEndpoint(BaseEndpoint):
         Remove all attestation data (claim based keys and ZKP blobs) by list of attestation hashes.
 
         :param attestation_hashes: hashes to remove
-        :type attestation_hashes: [database_blob]
+        :type attestation_hashes: [bytes]
         :returns: None
         """
         if not attestation_hashes:

--- a/ipv8/attestation/communication_manager.py
+++ b/ipv8/attestation/communication_manager.py
@@ -99,7 +99,7 @@ class CommunicationChannel(object):
         Remove all metadata from the identity community.
 
         :return: the list of attestation hashes which have been removed
-        :rtype: [database_blob]
+        :rtype: [bytes]
         """
         database = self.identity_overlay.identity_manager.database
         attestation_hashes = [t.content_hash for t in database.get_tokens_for(self.identity_overlay.my_peer.public_key)]
@@ -119,7 +119,7 @@ class CommunicationChannel(object):
         Remove all attestation data (claim based keys and ZKP blobs) by list of attestation hashes.
 
         :param attestation_hashes: hashes to remove
-        :type attestation_hashes: [database_blob]
+        :type attestation_hashes: [bytes]
         :returns: None
         """
         if not attestation_hashes:

--- a/ipv8/attestation/wallet/database.py
+++ b/ipv8/attestation/wallet/database.py
@@ -1,6 +1,6 @@
 import os
 
-from ...database import Database, database_blob
+from ...database import Database
 
 DATABASE_DIRECTORY = os.path.join(u"sqlite")
 
@@ -28,17 +28,17 @@ class AttestationsDB(Database):
         return list(self.execute(query, params, fetch_all=False))
 
     def get_attestation_by_hash(self, attestation_hash):
-        return self._get(u"SELECT blob FROM %s WHERE hash = ?" % self.db_name, (database_blob(attestation_hash),))
+        return self._get(u"SELECT blob FROM %s WHERE hash = ?" % self.db_name, (attestation_hash,))
 
     def get_all(self):
         return list(self.execute(u"SELECT * FROM %s" % self.db_name, (), fetch_all=True))
 
     def insert_attestation(self, attestation, attestation_hash, secret_key, id_format):
-        blob = database_blob(attestation.serialize_private(secret_key.public_key()))
+        blob = attestation.serialize_private(secret_key.public_key())
         self.execute(
             u"INSERT INTO %s (hash, blob, key, id_format) VALUES(?,?,?,?)" % self.db_name,
-            (database_blob(attestation_hash), blob, database_blob(secret_key.serialize()),
-             database_blob(id_format.encode('utf-8'))))
+            (attestation_hash, blob, secret_key.serialize(),
+             id_format.encode('utf-8')))
         self.commit()
 
     def get_schema(self, version):


### PR DESCRIPTION
Fixes #982

This PR:

 - Removes `database_blob`, which is just an alias for `bytes`.
 - Removes `execute_or_script`, which was only needed for MacOS <= Python 3.6.
 - Removes `import pysqlite2.dbapi2 as sqlite3`, which was only needed for MacOS <= Python 3.6.
