### PR TITLE
Fixed ReadTheDocs unrendered code-blocks

### DIFF
--- a/doc/basics/identity_tutorial.rst
+++ b/doc/basics/identity_tutorial.rst
@@ -30,7 +30,7 @@ In this tutorial all of the files are placed in the ``~/Documents/ipv8_tutorial`
 
 At the end of this setup step you should have the following files in your working directory:
 
-.. code-block::
+.. code-block:: console
 
    (folder) pyipv8
    (file) __init__.py
@@ -80,7 +80,7 @@ For convenience we will refer to our first peer as *Peer 1* and our second peer 
 As a last note, beware of URL encoding: when passing these identifiers they need to be properly formatted (\ ``+`` and ``=`` are illegal characters).
 In our case we need to use the following formatting of the peer identifiers in URLs (for Peer 1 and Peer 2 respectively):
 
-.. code-block::
+.. code-block:: console
 
    TGliTmFDTFBLOpyBsled71NjFOZfF3L%2Bw0sdAvcM3xI1nM%2Fik6NbRzxmwgFBJRZdQ%2Bh2CURQlwxtFxe33U7oldJtK%2BE1fTk2rOo%3D
    TGliTmFDTFBLOg%2Frrouc7qXT1ZKxHFvzxb4IVRYDPdbN4n7eFFuaT385YNW4aoh3Mruv%2BhSjbssLYmps%2Bjlh9rb250LYD7gEH20%3D

--- a/doc/basics/overlay_tutorial.rst
+++ b/doc/basics/overlay_tutorial.rst
@@ -27,7 +27,7 @@ You are free to choose whatever directory you want, to place your files in.
 
 At the end of this setup step you should have the following files in your working directory:
 
-.. code-block::
+.. code-block:: console
 
    (folder) pyipv8
    (file) __init__.py

--- a/doc/basics/testbase_tutorial.rst
+++ b/doc/basics/testbase_tutorial.rst
@@ -25,7 +25,7 @@ You are free to choose whatever directory you want, to place your files in.
 
 At the end of this setup step you should have the following files in your working directory:
 
-.. code-block::
+.. code-block:: console
 
    (folder) pyipv8
    (file) __init__.py
@@ -61,7 +61,7 @@ This also means that ``TestBase`` can be used with just about any test runner ou
 
 The way we will run our unit tests in this tutorial is with:
 
-.. code-block::
+.. code-block:: console
 
     python3 -m unittest test_community.py
 

--- a/doc/deprecated/attestation_tutorial.rst
+++ b/doc/deprecated/attestation_tutorial.rst
@@ -30,7 +30,7 @@ In this tutorial all of the files are placed in the ``~/Documents/ipv8_tutorial`
 
 At the end of this setup step you should have the following files in your working directory:
 
-.. code-block:: none
+.. code-block:: console
 
    (folder) pyipv8
    (file) __init__.py
@@ -90,7 +90,7 @@ For convenience we will refer to our first peer as *Peer 1* and our second peer 
 As a last note, beware of URL encoding: when passing these identifiers they need to be properly formatted (\ ``+`` and ``=`` are illegal characters).
 In our case we need to use the following formatting of the peer identifiers in URLs (for Peer 1 and Peer 2 respectively):
 
-.. code-block:: none
+.. code-block:: console
 
    aQVwz9aRMRypGwBkaxGRSdQs80c%3D
    bPyWPyswqXMhbW8%2B0RS6xUtNJrs%3D

--- a/doc/preliminaries/install_libsodium.rst
+++ b/doc/preliminaries/install_libsodium.rst
@@ -10,7 +10,7 @@ Windows
 
 #. Libsodium can be downloaded from https://download.libsodium.org/libsodium/releases/  
 
-   .. code-block:: none
+   .. code-block:: console
 
         For eg. https://download.libsodium.org/libsodium/releases/libsodium-1.0.17-msvc.zip
 


### PR DESCRIPTION
Fixes #1017

This PR:

 - Fixes code blocks with `none` or no language specified not rendering on ReadTheDocs.

