### PR TITLE
Fixed crashing unitialized endpoint on shutdown

### DIFF
--- a/ipv8/REST/identity_endpoint.py
+++ b/ipv8/REST/identity_endpoint.py
@@ -603,4 +603,5 @@ class IdentityEndpoint(BaseEndpoint):
         return Response({"outputs": formatted})
 
     async def on_shutdown(self, _):
-        await self.communication_manager.shutdown()
+        if self.communication_manager:
+            await self.communication_manager.shutdown()


### PR DESCRIPTION
If `IdentityEndpoint`'s  `initialize` method was not called prior to shutting down IPv8, it will crash on calling `on_shutdown` callback trying to reference `shutdown()` method of `self.communication_manager` which is `None`.

This little change fixes that, helping with IPv8 testing.
