### PR TITLE
Added Payload match support

### DIFF
--- a/ipv8/messaging/lazy_payload.py
+++ b/ipv8/messaging/lazy_payload.py
@@ -65,6 +65,7 @@ class VariablePayload(Payload):
             raise KeyError("%s missing %d arguments!" % (self.__class__.__name__, len(args) - index))
         if kwargs:
             raise KeyError("%s has leftover keyword arguments: %s!" % (self.__class__.__name__, str(kwargs)))
+        self.__class__.__match_args__ = tuple(self.names)
 
     @classmethod
     def from_unpack_list(cls, *args) -> VariablePayload:
@@ -229,6 +230,7 @@ def vp_compile(vp_definition: typing.Type[VariablePayload]) -> typing.Type[Varia
     # Rewrite the class methods from the locally loaded overwrites.
     # from_unpack_list is a classmethod, so we need to scope it properly.
     setattr(vp_definition, '__init__', locals()['__init__'])
+    setattr(vp_definition, '__match_args__', tuple(vp_definition.names))
     setattr(vp_definition, 'from_unpack_list', types.MethodType(locals()['from_unpack_list'], vp_definition))
     setattr(vp_definition, 'to_pack_list', locals()['to_pack_list'])
     return vp_definition

--- a/ipv8/test/base.py
+++ b/ipv8/test/base.py
@@ -114,7 +114,10 @@ class TestBase(asynctest.TestCase):
             while self._tempdirs:
                 shutil.rmtree(self._tempdirs.pop(), ignore_errors=True)
         # Now that everyone has calmed down, sweep up the remaining callbacks and check if they failed.
-        await asynctest.helpers.exhaust_callbacks(self.loop)
+        # [port] ``asynctest.helpers.exhaust_callbacks`` no longer works in Python 3.10
+        while self.loop._ready:  # pylint: disable=W0212
+            await sleep(0)
+        # [end of ``asynctest.helpers.exhaust_callbacks`` port]
         if self._uncaught_async_failure is not None:
             raise self._uncaught_async_failure["exception"]
         self.loop.set_exception_handler(None)  # None is equivalent to the default handler

--- a/ipv8/test/messaging/test_lazy_payload.py
+++ b/ipv8/test/messaging/test_lazy_payload.py
@@ -1,7 +1,14 @@
+from sys import version_info
+from unittest import skipIf
+
 from ..base import TestBase
 from ...messaging.lazy_payload import VariablePayload, vp_compile
 from ...messaging.payload import Payload
 from ...messaging.serialization import default_serializer
+
+
+skipUnlessPython310 = skipIf(version_info[0] < 4 and not (version_info[0] == 3 and version_info[1] >= 10),
+                             reason="Test only available for Python 3.10 and later.")
 
 
 class A(VariablePayload):
@@ -372,3 +379,85 @@ class TestVariablePayload(TestBase):
         self.assertEqual(e.list_of_A[0].b, deserialized.list_of_A[0].b)
         self.assertEqual(e.list_of_A[1].a, deserialized.list_of_A[1].a)
         self.assertEqual(e.list_of_A[1].b, deserialized.list_of_A[1].b)
+
+    @skipUnlessPython310
+    def test_plain_mismatch_list(self):
+        """
+        Check if a VariablePayload instance does not match anything but its own pattern.
+
+        We intentionally check here for a list of values equal to the __init__ arguments, which is the default.
+        If this test fails, you probably screwed up the class-level sub-pattern.
+        """
+        # pylint: disable=W0122, W0641
+        payload = BitsPayload(False, True, False, True, False, True, False, True)
+
+        # The following will crash all interpreters < 3.10 if not contained in a string.
+        exec(compile('''
+match payload:
+    case [False, True, False, True, False, True, False, True]:
+        matched = True
+    case _:
+        matched = False
+''', '<string>', 'exec'), globals(), locals())
+
+        self.assertFalse(locals()["matched"])
+
+    @skipUnlessPython310
+    def test_compiled_mismatch_list(self):
+        """
+        Check if a compiled VariablePayload instance does not match anything but its own pattern.
+
+        We intentionally check here for a list of values equal to the __init__ arguments, which is the default.
+        If this test fails, you probably screwed up the class-level sub-pattern.
+        """
+        # pylint: disable=W0122, W0641
+        payload = CompiledBitsPayload(False, True, False, True, False, True, False, True)
+
+        # The following will crash all interpreters < 3.10 if not contained in a string.
+        exec(compile('''
+match payload:
+    case [False, True, False, True, False, True, False, True]:
+        matched = True
+    case _:
+        matched = False
+''', '<string>', 'exec'), globals(), locals())
+
+        self.assertFalse(locals()["matched"])
+
+    @skipUnlessPython310
+    def test_plain_match_pattern(self):
+        """
+        Check if a VariablePayload instance matches its own pattern.
+        """
+        # pylint: disable=W0122, W0641
+        payload = BitsPayload(False, True, False, True, False, True, False, True)
+
+        # The following will crash all interpreters < 3.10 if not contained in a string.
+        exec(compile('''
+match payload:
+    case BitsPayload(False, True, False, True, False, True, False, True):
+        matched = True
+    case _:
+        matched = False
+''', '<string>', 'exec'), globals(), locals())
+
+        self.assertTrue(locals()["matched"])
+
+    @skipUnlessPython310
+    def test_compiled_match_pattern(self):
+        """
+        Check if a compiled VariablePayload instance matches its own pattern.
+        """
+        # pylint: disable=W0122, W0641
+        payload = CompiledBitsPayload(False, True, False, True, False, True, False, True)
+
+        # The following will crash all interpreters < 3.10 if not contained in a string.
+        exec(compile('''
+match payload:
+    case CompiledBitsPayload(False, True, False, True, False, True, False, True):
+        matched = True
+    case _:
+        matched = False
+''', '<string>', 'exec'), globals(), locals())
+
+        self.assertTrue(locals()["matched"])


### PR DESCRIPTION
Fixes #989

This PR:

 - Adds `__match_args__` to `VariablePayload` to allow for Python 3.10 structural pattern matching.
 - Fixes `asynctest.helpers.exhaust_callbacks` no longer working in Python 3.10.

Notes:
 - The `exec(compile(...))` construction in `test_lazy_payload.py` exists because Python crashes when importing files with syntax errors. This means that everyone running the tests with a Python version lower than 3.10 would crash when importing this file. As an aside: Python 3.9 has soft keywords for this, but we have to deal with Python 3.7 and Python 3.8 as well.
 - This makes IPv8 Python 3.10 compatible.
