### PR TITLE
Added bootstrapping documentation

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -68,6 +68,7 @@ Table of contents
    :caption: References:
 
    reference/configuration.rst
+   reference/bootstrapping.rst
    reference/keys.rst
    reference/serialization.rst
 

--- a/doc/reference/bootstrapping.rst
+++ b/doc/reference/bootstrapping.rst
@@ -1,0 +1,109 @@
+IPv8 bootstrapping
+==================
+
+Peers discover each other through other Peers, as specified in the `the Peer discovery basics <../../basics/peer_discovery>`_.
+We call this type of Peer discovery *introduction*.
+However, you cannot be introduced to a new Peer if you don't know anyone to introduce you in the first place.
+This document discusses how IPv8 provides you your first contact.
+
+Bootstrap servers (rendezvous nodes)
+------------------------------------
+
+To provide you an initial point of introduction, IPv8 mainly uses bootstrap servers (also known as rendezvous nodes).
+You can connect to these servers to attempt to find other Peers for your overlay.
+A bootstrap server will then respond to your request for Peers with Peers that have contacted it for the same overlay.
+However, these bootstrap servers only introduce you to other Peers, they do not (and can not) actually join any overlay.
+A bootstrap server also has no way of knowing what your overlay does, it only knows its 20-byte identifier.
+
+By default, IPv8 comes supplied with a handful of bootstrap IP addresses and bootstrap DNS addresses.
+You can freely extend or replace the default servers with your own.
+To tell IPv8 what bootstrap IP addresses and bootstrap DNS addresses it should connect to, you can use the ``DispersyBootstrapper`` class.
+
+Using bootstrap servers
+^^^^^^^^^^^^^^^^^^^^^^^
+
+To have IPv8 load a bootstrapper for your overlay, you can simply add it to your ``ConfigBuilder.add_overlay()`` step.
+This is the easiest way to load a bootstrapper.
+For most intents and purposes you can simply use ``default_bootstrap_defs`` provided by ``ipv8.configuration`` (see `the overlay tutorial <../../basics/overlay_tutorial>`_).
+However, you can also completely change the bootstrap servers you use.
+For example, this code sets two bootstrap addresses (the IP address 1.2.3.4 with port 5 and the DNS address tribler.org with port 5):
+
+ .. code-block:: python
+
+    ConfigBuilder().add_overlay("MyCommunity",
+                                "my id",
+                                [WalkerDefinition(Strategy.RandomWalk, 42, {'timeout': 3.0})],
+                                [BootstrapperDefinition(Bootstrapper.DispersyBootstrapper,
+                                                        {'ip_addresses': [('1.2.3.4', 5)],
+                                                         'dns_addresses': [('tribler.org', 5)]})],
+                                {},
+                                [])
+
+If you are using the ``loader`` instead of ``configuration`` you can load a bootstrapper into your launcher as follows:
+
+ .. code-block:: python
+
+    @overlay('my_module.some_submodule', 'MyCommunity')
+    @walk_strategy(RandomWalk)
+    @bootstrapper(DispersyBootstrapper, kw_args={'ip_addresses': [('1.2.3.4', 5)], 'dns_addresses': [('tribler.org', 5)]})
+    class MyLauncher(CommunityLauncher):
+        pass
+
+If you are using neither the ``loader`` nor the ``configuration``, you can manually add a ``DispersyBootstrapper`` instance to your overlay's ``bootstrappers`` field.
+However, you should do so before the overlay starts discovering Peers (i.e., before `IPv8.start()` is invoked).
+
+Running a bootstrap server
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+To run your own bootstrap server simply call ``scripts/tracker_plugin.py``.
+For example, this code will attempt to bind to port 12345:
+
+ .. code-block:: bash
+
+    python tracker_plugin.py --listen_port=12345
+
+You are responsible to configure your port forwarding over your hardware in such a way that the specified listen port is connectable.
+
+UDP broadcasts
+--------------
+
+Next to bootstrap servers, IPv8 also allows serverless Peer discovery for LANs.
+This is done using UDP broadcast sockets.
+These broadcasts consist of sending an IPv8 probe UDP packet to all possible ports of the IPv4 broadcast address.
+You should consider this option if you are having trouble connecting to other Peers in your home network.
+This method is usually very effective for simple home networks.
+However, complex home (or work) network setups may still fail to discover these local Peers.
+
+Using UDP broadcasts
+^^^^^^^^^^^^^^^^^^^^
+Loading UDP broadcast bootstrapping for your overlay functions much the same as using bootstrap servers.
+Again, you can simply add it to your ``ConfigBuilder.add_overlay()`` step:
+
+ .. code-block:: python
+
+    ConfigBuilder().add_overlay("MyCommunity",
+                                "my id",
+                                [WalkerDefinition(Strategy.RandomWalk, 42, {'timeout': 3.0})],
+                                [BootstrapperDefinition(Bootstrapper.UDPBroadcastBootstrapper, {})],
+                                {},
+                                [])
+
+If you are using the ``loader`` instead of ``configuration`` you can load a bootstrapper into your launcher as follows:
+
+ .. code-block:: python
+
+    @overlay('my_module.some_submodule', 'MyCommunity')
+    @walk_strategy(RandomWalk)
+    @bootstrapper(UDPBroadcastBootstrapper)
+    class MyLauncher(CommunityLauncher):
+        pass
+
+If you are using neither the ``loader`` nor the ``configuration``, you can manually add a ``UDPBroadcastBootstrapper`` instance to your overlay's ``bootstrappers`` field.
+
+Making your own Bootstrapper
+----------------------------
+
+As you may have noticed, loading a ``DispersyBootstrapper`` and a ``UDPBroadcastBootstrapper`` is highly similar.
+This is because they both inherit from the ``Bootstrapper`` interface.
+You can fulfill the same interface to provide your own bootstrapping mechanism.
+To use custom bootstrappers you will either have to use the ``loader`` or manual loading methods.

--- a/doc/reference/configuration.rst
+++ b/doc/reference/configuration.rst
@@ -52,6 +52,7 @@ Each of the overlay specifications is a dictionary following the following stand
    "class", "The overlay class to load. Do note that any external overlay definitions will have to be registered in IPv8, see also the overlay creation tutorial."
    "key", "The alias of the key to use for the particular overlay."
    "walkers", "The walker to employ."
+   "bootstrappers", "The bootstrappers to use."
    "initialize", "The additional arguments to pass to the constructor of the overlay."
    "on_start", "A list of tuples containing method names and their arguments. These methods are invoked when IPv8 has started."
 
@@ -59,11 +60,10 @@ Each of the overlay specifications is a dictionary following the following stand
 By default, the ``RandomWalk`` and ``EdgeWalk`` strategies are known to IPv8.
 Respectively these will take care of performing random walks and random walks with reset probability for peer discovery.
 Each overlay may also specify further custom strategies.
+Check out the `the bootstrapping documentation <../../reference/bootstrapping>`_ for more information on configuring bootstrappers per overlay.
+
 By default, IPv8 loads the following overlays:
 
-- AttestationCommunity
 - DiscoveryCommunity
 - HiddenTunnelCommunity
-- IdentityCommunity
-- TunnelCommunity
 - DHTDiscoveryCommunity

--- a/ipv8/loader.py
+++ b/ipv8/loader.py
@@ -226,11 +226,11 @@ def bootstrapper(str_module_or_class, str_definition=None, kw_args=None):
            ...
 
         from my_module.some_submodule import MyBootstrapper
-        @walk_strategy(MyBootstrapper)
+        @bootstrapper(MyBootstrapper)
         class A(CommunityLauncher):
            ...
 
-        @walk_strategy('my_module.some_submodule', 'MyBootstrapper', kwargs={'a key': 'a value'})
+        @bootstrapper('my_module.some_submodule', 'MyBootstrapper', kw_args={'a key': 'a value'})
         class A(CommunityLauncher):
            ...
 
@@ -238,7 +238,7 @@ def bootstrapper(str_module_or_class, str_definition=None, kw_args=None):
             from my_module.some_submodule import MyBootstrapper
             return MyBootstrapper
 
-        @walk_strategy(my_bootstrapper_class)
+        @bootstrapper(my_bootstrapper_class)
         class A(CommunityLauncher):
             ...
 


### PR DESCRIPTION
Fixes #976

This PR:

 - Adds bootstrapping documentation.
 - Fixes the configuration documentation to include the bootstrapping configuration key.
 - Fixes the configuration documentation to accurately list what overlays are loaded by default.
 - Fixes the `loader.py` `bootstrapper` docstring.

