### PR TITLE
Fixed AddressTester using different LAN check

### DIFF
--- a/doc/simulation/simulation_tutorial_2.py
+++ b/doc/simulation/simulation_tutorial_2.py
@@ -35,6 +35,7 @@ async def start_communities():
 
         # We assume all peers in our simulation have a public WAN IP (to avoid conflicts with our SimulationEndpoint)
         bootstrap_overlay.my_estimated_lan = ("0.0.0.0", 0)
+        bootstrap_overlay.my_estimated_wan = bootstrap_endpoint.wan_address
         bootstrap_ips.append(bootstrap_endpoint.wan_address)
 
     instances = []
@@ -51,6 +52,7 @@ async def start_communities():
                         extra_communities={'SimpleCommunity': SimpleCommunity})
         # We assume all peers in our simulation have a public WAN IP (to avoid conflicts with our SimulationEndpoint)
         instance.overlays[0].my_estimated_lan = ("0.0.0.0", 0)
+        instance.overlays[0].my_estimated_wan = endpoint.wan_address
         await instance.start()
         instances.append(instance)
 


### PR DESCRIPTION
Fixes #1024

This PR:

 - Fixes `AddressTester` using `_address_is_lan_without_netifaces` instead of `address_is_lan`, like the `Community`.
 - Fixes `AddressTester.is_lan` always returning False.
 - Updates `AddressTester` to be a singleton.
 - Updates `simulation_tutorial_2.py` to set the `my_estimated_wan` for its overlays.

