### PR TITLE
Added API documentation generation

### DIFF
--- a/doc/basics/overlay_tutorial.rst
+++ b/doc/basics/overlay_tutorial.rst
@@ -96,6 +96,12 @@ Running this should yield something like the following output:
    I am: Peer<0.0.0.0:0, VVsH+LxamOUVUkV/5rjemqYMO8w=> 
    I know: ['Peer<10.0.2.15:8090, /zWXEA/4wFeGEKTZ8fckwUwLk3Y=>']
 
+.. warning::
+   You should never use the ``address`` of a ``Peer`` as its identifier.
+   A ``Peer``'s ``address`` can change over time!
+   Instead, use the ``mid`` of a Peer (which is the ``SHA-1`` hash of its public key) or its ``public_key.key_to_bin()`` (the serialized form of the public key).
+   The public key of a ``Peer`` never changes.
+
 Adding messages
 ---------------
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -41,6 +41,7 @@ release = '2.7.0'  # Do not change manually! Handled by github_increment_version
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
+    'autoapi.extension',
     'sphinx.ext.autodoc',
     'sphinx.ext.doctest',
     'sphinx.ext.intersphinx',
@@ -50,6 +51,10 @@ extensions = [
     'sphinx.ext.viewcode',
     'sphinx.ext.githubpages',
 ]
+
+autoapi_type = 'python'
+autoapi_add_toctree_entry = False
+autoapi_dirs = ['../ipv8']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -84,7 +89,7 @@ pygments_style = None
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'alabaster'
+html_theme = 'sphinx_rtd_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -100,5 +100,6 @@ Search
 ======
 
 * :ref:`genindex`
+* :ref:`modindex`
 * :ref:`search`
 


### PR DESCRIPTION
Fixes #1030
Fixes #1032

This PR:

 - Adds `autoapi` API reference documentation generation.
 - Adds a warning not to use `Peer.address` to the overlay tutorial documentation.
 - Updates the documentation theme from `alabaster` to `sphinx_rtd_theme` for readability.

The warning looks as follows:

![warning](https://user-images.githubusercontent.com/3630389/127990597-a092235d-db54-4fd4-afcd-735229edb058.png)

The new module index looks like this (zoomed out, we have a sizable number of classes in IPv8):

![module index](https://user-images.githubusercontent.com/3630389/127990743-e0f17d93-c433-4892-8dfd-6e1c2a361092.png)


