### PR TITLE
Added option to configure IPv8 with raw private key material

### DIFF
--- a/doc/reference/configuration.rst
+++ b/doc/reference/configuration.rst
@@ -42,6 +42,8 @@ By invoking ``get_default_configuration()``, you can get a dictionary copy of th
    "walker_interval", 0.5, "The time interval between IPv8 updates. Each update will trigger all registered strategies to update, mostly this concerns peer discovery."
    "overlays", [ .\.\. ], "The list of overlay definitions and their respective walking strategies. See the overlay definition section for further details."
 
+Overlay Specifications
+----------------------
 
 Each of the overlay specifications is a dictionary following the following standard:
 
@@ -67,3 +69,24 @@ By default, IPv8 loads the following overlays:
 - DiscoveryCommunity
 - HiddenTunnelCommunity
 - DHTDiscoveryCommunity
+
+Key Specifications
+------------------
+
+Each of the key specifications is a dictionary following the following standard:
+
+.. csv-table:: Key definitions
+   :header: "key", "description"
+   :widths: 20, 80
+
+   "alias", "The name by which this key can be referenced in overlay configuration."
+   "file", "The optional file to store the key in."
+   "generation", "The curve to use if this key needs to be generated."
+   "bin", "The b64 encoded raw key material to use."
+
+It is always required to specify a key ``alias``.
+If you specify a ``file`` IPv8 will attempt to load your key from this file.
+Only if the file does not exist, will the ``generation`` or ``bin`` be referenced.
+If a ``file`` has been specified, once a key has been loaded it will be written to the specified ``file``.
+If you specify a ``bin``, IPv8 will prefer to use this raw key material over generating a new key from the key curve specified by ``generation``.
+You must provide IPv8 with at least one of the key source material options (a ``file``, a ``bin`` or a ``generation``) to have a valid key configuration.

--- a/ipv8/configuration.py
+++ b/ipv8/configuration.py
@@ -320,6 +320,29 @@ class ConfigBuilder(object):
         })
         return self
 
+    def add_key_from_bin(self, alias: str, key_bin_b64: str, file_path: typing.Optional[str] = None):
+        """
+        Add a key by alias and  its raw key material, possibly stored at a certain file path.
+
+        If a key already exists at the given file path, that will be loaded instead of the given key material.
+
+        :param alias: the alias used to reference this key
+        :param key_bin_b64: the base64 encoded private key material
+        :param file_path: the optional file path to save the key to
+        """
+        if 'keys' in self.config:
+            self.config['keys'] = [key for key in self.config['keys'] if key['alias'] != alias]
+        else:
+            self.config['keys'] = []
+        key_config = {
+            'alias': alias,
+            'bin': key_bin_b64
+        }
+        if file_path is not None:
+            key_config['file'] = file_path
+        self.config['keys'].append(key_config)
+        return self
+
     def add_overlay(self,
                     overlay_class: str,
                     key_alias: str,

--- a/ipv8/test/test_configuration.py
+++ b/ipv8/test/test_configuration.py
@@ -122,6 +122,41 @@ class TestConfiguration(TestBase):
         self.assertEqual(1 + len(get_default_configuration()['keys']), len(keys))
         self.assertTrue(any(set(entry.items()) == set(expected.items()) for entry in keys))
 
+    def test_add_key_from_bin(self):
+        """
+        Check if changes to the keys are finalized in bin mode.
+        """
+        key_material = ("MG0CAQEEHUkphrkiuNhcofjWfaplwoAk0i7tBIDq93ATwaTKoAcGBSuBBAAaoUADPgAEANBoqp"
+                        "ZtJ3z0fbt2knDEBC6nLk2P0AHEWKHoCOzRAAloM3NgRObfmRlkuiQANY0VWRMn1TAjIZqogwBD")
+        builder = ConfigBuilder().add_key_from_bin("my new key", key_material)
+
+        expected = {
+            'alias': "my new key",
+            'bin': key_material
+        }
+        keys = builder.finalize()['keys']
+
+        self.assertEqual(1 + len(get_default_configuration()['keys']), len(keys))
+        self.assertTrue(any(set(entry.items()) == set(expected.items()) for entry in keys))
+
+    def test_add_key_from_bin_file(self):
+        """
+        Check if changes to the keys are finalized in bin mode with a file.
+        """
+        key_material = ("MG0CAQEEHUkphrkiuNhcofjWfaplwoAk0i7tBIDq93ATwaTKoAcGBSuBBAAaoUADPgAEANBoqp"
+                        "ZtJ3z0fbt2knDEBC6nLk2P0AHEWKHoCOzRAAloM3NgRObfmRlkuiQANY0VWRMn1TAjIZqogwBD")
+        builder = ConfigBuilder().add_key_from_bin("my new key", key_material, "some file")
+
+        expected = {
+            'alias': "my new key",
+            'bin': key_material,
+            'file': "some file"
+        }
+        keys = builder.finalize()['keys']
+
+        self.assertEqual(1 + len(get_default_configuration()['keys']), len(keys))
+        self.assertTrue(any(set(entry.items()) == set(expected.items()) for entry in keys))
+
     def test_add_overlay_overwrite(self):
         """
         Check if the allow duplicate flag does not introduce duplicates.

--- a/ipv8_service.py
+++ b/ipv8_service.py
@@ -17,7 +17,7 @@ else:
         from ipv8.attestation.wallet.community import AttestationCommunity
         from ipv8.bootstrapping.dispersy.bootstrapper import DispersyBootstrapper
         from ipv8.bootstrapping.udpbroadcast.bootstrapper import UDPBroadcastBootstrapper
-        from ipv8.keyvault.crypto import default_eccrypto
+        from ipv8.keyvault.crypto import default_eccrypto as crypto
         from ipv8.keyvault.private.m2crypto import M2CryptoSK
         from ipv8.messaging.anonymization.community import TunnelCommunity
         from ipv8.messaging.anonymization.endpoint import TunnelEndpoint
@@ -36,7 +36,7 @@ else:
         from .ipv8.attestation.wallet.community import AttestationCommunity
         from .ipv8.bootstrapping.dispersy.bootstrapper import DispersyBootstrapper
         from .ipv8.bootstrapping.udpbroadcast.bootstrapper import UDPBroadcastBootstrapper
-        from .ipv8.keyvault.crypto import default_eccrypto
+        from .ipv8.keyvault.crypto import default_eccrypto as crypto
         from .ipv8.keyvault.private.m2crypto import M2CryptoSK
         from .ipv8.messaging.anonymization.community import TunnelCommunity
         from .ipv8.messaging.anonymization.endpoint import TunnelEndpoint
@@ -96,7 +96,7 @@ else:
                         content = f.read()
                         try:
                             # IPv8 Standardized bin format
-                            self.keys[key_block['alias']] = Peer(default_eccrypto.key_from_private_bin(content))
+                            self.keys[key_block['alias']] = Peer(crypto.key_from_private_bin(content))
                         except ValueError:
                             try:
                                 # Try old Tribler M2Crypto PEM format
@@ -107,9 +107,11 @@ else:
                             except Exception:
                                 # Try old LibNacl format
                                 content = "LibNaCLSK:" + content
-                                self.keys[key_block['alias']] = Peer(default_eccrypto.key_from_private_bin(content))
+                                self.keys[key_block['alias']] = Peer(crypto.key_from_private_bin(content))
                 else:
-                    self.keys[key_block['alias']] = Peer(default_eccrypto.generate_key(key_block['generation']))
+                    self.keys[key_block['alias']] = Peer(crypto.key_from_private_bin(b64decode(key_block['bin']))
+                                                         if 'bin' in key_block else
+                                                         crypto.generate_key(key_block['generation']))
                     if key_block['file']:
                         with open(key_block['file'], 'wb') as f:
                             f.write(self.keys[key_block['alias']].key.key_to_bin())

--- a/ipv8_service.py
+++ b/ipv8_service.py
@@ -18,7 +18,6 @@ else:
         from ipv8.bootstrapping.dispersy.bootstrapper import DispersyBootstrapper
         from ipv8.bootstrapping.udpbroadcast.bootstrapper import UDPBroadcastBootstrapper
         from ipv8.keyvault.crypto import default_eccrypto as crypto
-        from ipv8.keyvault.private.m2crypto import M2CryptoSK
         from ipv8.messaging.anonymization.community import TunnelCommunity
         from ipv8.messaging.anonymization.endpoint import TunnelEndpoint
         from ipv8.messaging.anonymization.hidden_services import HiddenTunnelCommunity
@@ -37,7 +36,6 @@ else:
         from .ipv8.bootstrapping.dispersy.bootstrapper import DispersyBootstrapper
         from .ipv8.bootstrapping.udpbroadcast.bootstrapper import UDPBroadcastBootstrapper
         from .ipv8.keyvault.crypto import default_eccrypto as crypto
-        from .ipv8.keyvault.private.m2crypto import M2CryptoSK
         from .ipv8.messaging.anonymization.community import TunnelCommunity
         from .ipv8.messaging.anonymization.endpoint import TunnelEndpoint
         from .ipv8.messaging.anonymization.hidden_services import HiddenTunnelCommunity
@@ -93,21 +91,7 @@ else:
             for key_block in configuration['keys']:
                 if key_block['file'] and isfile(key_block['file']):
                     with open(key_block['file'], 'rb') as f:
-                        content = f.read()
-                        try:
-                            # IPv8 Standardized bin format
-                            self.keys[key_block['alias']] = Peer(crypto.key_from_private_bin(content))
-                        except ValueError:
-                            try:
-                                # Try old Tribler M2Crypto PEM format
-                                content = b64decode(content[31:-30].replace('\n', ''))
-                                peer = Peer(M2CryptoSK(keystring=content))
-                                peer.mid  # This will error out if the keystring is not M2Crypto
-                                self.keys[key_block['alias']] = peer
-                            except Exception:
-                                # Try old LibNacl format
-                                content = "LibNaCLSK:" + content
-                                self.keys[key_block['alias']] = Peer(crypto.key_from_private_bin(content))
+                        self.keys[key_block['alias']] = Peer(crypto.key_from_private_bin(f.read()))
                 else:
                     self.keys[key_block['alias']] = Peer(crypto.key_from_private_bin(b64decode(key_block['bin']))
                                                          if 'bin' in key_block else


### PR DESCRIPTION
Fixes #1037
Fixes #1038

This PR:

 - Adds the option to configure keys with raw private key material (in b64 format).
 - Updates the configuration documentation to have a section for the key format.
 - Removes ancient (and ugly!) key loading practices.
 

