### PR TITLE
Updated Endpoint initialization to use 'interfaces' configuration

### DIFF
--- a/doc/reference/configuration.rst
+++ b/doc/reference/configuration.rst
@@ -7,7 +7,11 @@ By invoking ``get_default_configuration()``, you can get a dictionary copy of th
 
 .. |snip1| raw:: html
 
-  "0.0.0.0"
+  <small>[{<br />
+  &emsp;<nobr>'interface':<nobr>"UDPIPv4",<br />
+  &emsp;<nobr>'ip':<nobr>"0.0.0.0",<br />
+  &emsp;<nobr>'port':<nobr>8090<br />
+  }]</small>
 
 
 .. |nl| raw:: html
@@ -35,8 +39,7 @@ By invoking ``get_default_configuration()``, you can get a dictionary copy of th
    :header: "key", "default", "description"
    :widths: 20, 40, 80
 
-   "address", |snip1|, "The IPv4-address to bind to."
-   "port", 8090, "The (UDP) port to try and open. If blocked, IPv8 will attempt the next free port (up to 10,000 ports over the specified port)."
+   "interfaces", |snip1|, "The interfaces to bind to (``UDPIPv4`` or ``UDPIPv6``) using an IP address and port. If the specified port is blocked, IPv8 will attempt the next free port (up to 10,000 ports over the specified port)."
    "keys", |snip2|, "Specify a list of keys, by alias, for IPv8 to use. The curve should be picked from those available in the ECCrypto class. IPv8 will generate a new key if the key file does not exist."
    "logger", |snip3|, "The logger intialization arguments, also see the default Python logger facilities."
    "walker_interval", 0.5, "The time interval between IPv8 updates. Each update will trigger all registered strategies to update, mostly this concerns peer discovery."

--- a/ipv8/test/test_configuration.py
+++ b/ipv8/test/test_configuration.py
@@ -26,37 +26,13 @@ class TestConfiguration(TestBase):
 
         self.assertEqual(0, len(builder.finalize()['overlays']))
 
-    def test_add_illegal_port_negative(self):
-        """
-        Check if negative ports raise an error on finalization.
-        """
-        builder = ConfigBuilder().set_port(-1)
-
-        self.assertRaises(AssertionError, builder.finalize)
-
-    def test_add_illegal_port_big(self):
-        """
-        Check if ports over 65535 raise an error on finalization.
-        """
-        builder = ConfigBuilder().set_port(100000)
-
-        self.assertRaises(AssertionError, builder.finalize)
-
     def test_change_port(self):
         """
         Check if changes to the port are finalized.
         """
         builder = ConfigBuilder().set_port(1000)
 
-        self.assertEqual(1000, builder.finalize()['port'])
-
-    def test_add_illegal_address(self):
-        """
-        Check if wrong IP addresses raise an error immediately.
-        """
-        builder = ConfigBuilder()
-
-        self.assertRaises(AssertionError, builder.set_address, "1.1.1")
+        self.assertEqual(1000, builder.finalize()['interfaces'][0]['port'])
 
     def test_change_address(self):
         """
@@ -64,7 +40,7 @@ class TestConfiguration(TestBase):
         """
         builder = ConfigBuilder().set_address("1.1.1.1")
 
-        self.assertEqual("1.1.1.1", builder.finalize()['address'])
+        self.assertEqual("1.1.1.1", builder.finalize()['interfaces'][0]['ip'])
 
     def test_set_illegal_log_level(self):
         """
@@ -230,32 +206,6 @@ class TestConfiguration(TestBase):
         }
 
         self.assertDictInDict(expected, builder.finalize()['overlays'])
-
-    def test_illegal_random_churn_strategy(self):
-        """
-        Only the DiscoveryCommunity may use the RandomChurn strategy.
-        """
-        builder = ConfigBuilder().add_overlay("MyCommunity",
-                                              "anonymous id",
-                                              [WalkerDefinition(Strategy.RandomChurn, 20, {})],
-                                              [],
-                                              {},
-                                              [])
-
-        self.assertRaises(AssertionError, builder.finalize)
-
-    def test_illegal_periodic_similarity_strategy(self):
-        """
-        Only the DiscoveryCommunity may use the PeriodicSimilarity strategy.
-        """
-        builder = ConfigBuilder().add_overlay("MyCommunity",
-                                              "anonymous id",
-                                              [WalkerDefinition(Strategy.PeriodicSimilarity, 20, {})],
-                                              [],
-                                              {},
-                                              [])
-
-        self.assertRaises(AssertionError, builder.finalize)
 
     def test_correct_random_churn_strategy(self):
         """


### PR DESCRIPTION
Fixes #1036

This PR:

 - Adds configurable `DispatcherEndpoint` initialization in `ipv8_service.py`.
 - Adds a warning if the old `"address"` and `"port"` configuration is used. Old configurations still work though.
 - Updates the `configuration.rst` documentation to showcase the use of `'interfaces'` instead of `"address"` and `"port"`.
 - Updates the `configuration.py` to use the new `'interfaces'` configuration.
 - Removes some `asserts` (and corresponding tests) from `ConfigBuilder.finalize()` that were too strict or no longer generic enough for `'interfaces'`. For example, it is allowed (but unconventional) to launch IPv8 without any network interfaces at all.

Preview of documentation change:

![preview](https://user-images.githubusercontent.com/3630389/135269534-6eb173fe-d5c7-482c-b95c-d5572537f2b4.png)
