### PR TITLE
Fixed readthedocs links

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,6 @@ python3 create_test_coverage_report.py
 ```
 
 ### Getting started
-You can start creating your first network overlay by following [the overlay creation tutorial](https://py-ipv8.readthedocs.io/en/latest/basics/overlay_tutorial/).
+You can start creating your first network overlay by following [the overlay creation tutorial](https://py-ipv8.readthedocs.io/en/latest/basics/overlay_tutorial.html).
 
-We provide additional documentation on [configuration](https://py-ipv8.readthedocs.io/en/latest/reference/configuration/), [key generation](https://py-ipv8.readthedocs.io/en/latest/reference/keys/) and [message serialization formats](https://py-ipv8.readthedocs.io/en/latest/reference/serialization/) on [our ReadTheDocs page](https://py-ipv8.readthedocs.io/en/latest/).
+We provide additional documentation on [configuration](https://py-ipv8.readthedocs.io/en/latest/reference/configuration.html), [key generation](https://py-ipv8.readthedocs.io/en/latest/reference/keys.html) and [message serialization formats](https://py-ipv8.readthedocs.io/en/latest/reference/serialization.html) on [our ReadTheDocs page](https://py-ipv8.readthedocs.io/en/latest/).

--- a/doc/basics/discoverystrategy_tutorial.rst
+++ b/doc/basics/discoverystrategy_tutorial.rst
@@ -1,7 +1,7 @@
 Network IO and the DiscoveryStrategy
 ====================================
 
-This document assumes you have a basic understanding of asyncio tasks, as documented in `the tasks tutorial <../../basics/tasks_tutorial>`_.
+This document assumes you have a basic understanding of asyncio tasks, as documented in `the tasks tutorial <../basics/tasks_tutorial.html>`_.
 You will learn how to use the IPv8's ``DiscoveryStrategy`` class to avoid network congestion.
 
 The DiscoveryStrategy

--- a/doc/basics/identity_tutorial.rst
+++ b/doc/basics/identity_tutorial.rst
@@ -2,17 +2,17 @@
 Using the IPv8 attestation service
 ==================================
 
-This document assumes you have a basic understanding of network overlays in IPv8, as documented in `the overlay tutorial <../../basics/overlay_tutorial>`_.
+This document assumes you have a basic understanding of network overlays in IPv8, as documented in `the overlay tutorial <../basics/overlay_tutorial.html>`_.
 You will learn how to use the IPv8 attestation *HTTP REST API*.
 This tutorial will use ``curl`` to perform HTTP ``GET`` and ``POST`` requests.
 
 This document will cover the basic flows of identification.
-If you plan on using real identity data, you will need to familiarize yourself with the `the advanced identity controls <../../further-reading/advanced_identity>`_.
+If you plan on using real identity data, you will need to familiarize yourself with the `the advanced identity controls <../further-reading/advanced_identity.html>`_.
 
 Files
 -----
 
-This tutorial will follow the same file structure as `the overlay tutorial <../../basics/overlay_tutorial>`_.
+This tutorial will follow the same file structure as `the overlay tutorial <../basics/overlay_tutorial.html>`_.
 In this tutorial all of the files are placed in the ``~/Documents/ipv8_tutorial`` directory.
 
 

--- a/doc/basics/requestcache_tutorial.rst
+++ b/doc/basics/requestcache_tutorial.rst
@@ -1,7 +1,7 @@
 Storing states in IPv8
 ======================
 
-This document assumes you have a basic understanding of network overlays in IPv8, as documented in `the overlay tutorial <../../basics/overlay_tutorial>`_.
+This document assumes you have a basic understanding of network overlays in IPv8, as documented in `the overlay tutorial <../basics/overlay_tutorial.html>`_.
 You will learn how to use the IPv8's ``RequestCache`` class to store the state of message flows.
 
 When you need a state

--- a/doc/basics/tasks_tutorial.rst
+++ b/doc/basics/tasks_tutorial.rst
@@ -1,7 +1,7 @@
 Task Management
 ===============
 
-This document assumes you have a basic understanding of network overlays in IPv8, as documented in `the overlay tutorial <../../basics/overlay_tutorial>`_.
+This document assumes you have a basic understanding of network overlays in IPv8, as documented in `the overlay tutorial <../basics/overlay_tutorial.html>`_.
 You will learn how to use the IPv8's ``TaskManager`` class to manage ``asyncio`` tasks and how to use ``NumberCache`` to manage ``Future`` instances.
 
 What is a task?
@@ -99,7 +99,7 @@ Futures and caches
 ^^^^^^^^^^^^^^^^^^
 
 Sometimes you may find that certain tasks belong to a message context.
-In other words, you may have a task that belongs to a *cache* (see `the storing states tutorial <../../basics/overlay_tutorial>`_).
+In other words, you may have a task that belongs to a *cache* (see `the storing states tutorial <../basics/overlay_tutorial.html>`_).
 By registering a ``Future`` instance in your ``NumberCache`` subclass it will automatically be canceled when the ``NumberCache`` gets canceled or times out.
 You can do so using the ``register_future()`` method.
 This is a complete example:

--- a/doc/basics/testbase_tutorial.rst
+++ b/doc/basics/testbase_tutorial.rst
@@ -1,7 +1,7 @@
 Unit Testing Overlays
 =====================
 
-This document assumes you have a basic understanding of network overlays in IPv8, as documented in `the overlay tutorial <../../basics/overlay_tutorial>`_.
+This document assumes you have a basic understanding of network overlays in IPv8, as documented in `the overlay tutorial <../basics/overlay_tutorial.html>`_.
 You will learn how to use the IPv8's ``TestBase`` class to unit test your overlays.
 
 Files

--- a/doc/deprecated/attestation_tutorial.rst
+++ b/doc/deprecated/attestation_tutorial.rst
@@ -2,7 +2,7 @@
 Using the IPv8 attestation service
 ==================================
 
-This document assumes you have a basic understanding of network overlays in IPv8, as documented in `the overlay tutorial <../../basics/overlay_tutorial>`_.
+This document assumes you have a basic understanding of network overlays in IPv8, as documented in `the overlay tutorial <../basics/overlay_tutorial.html>`_.
 You will learn how to use the IPv8 attestation *HTTP REST API*.
 This tutorial will use ``curl`` to perform HTTP ``GET`` and ``POST`` requests.
 
@@ -12,7 +12,7 @@ Note that this tutorial will make use of the Python IPv8 service.
 Files
 -----
 
-This tutorial will follow the same file structure as `the overlay tutorial <../../basics/overlay_tutorial>`_.
+This tutorial will follow the same file structure as `the overlay tutorial <../basics/overlay_tutorial.html>`_.
 In this tutorial all of the files are placed in the ``~/Documents/ipv8_tutorial`` directory.
 
 

--- a/doc/further-reading/advanced_identity.rst
+++ b/doc/further-reading/advanced_identity.rst
@@ -2,7 +2,7 @@
 Advanced attestation service usage
 ==================================
 
-This document assumes you have a basic understanding of identification flows in IPv8, as documented in `the overlay tutorial <../../basics/identity_tutorial>`_.
+This document assumes you have a basic understanding of identification flows in IPv8, as documented in `the overlay tutorial <../basics/identity_tutorial.html>`_.
 This document addresses the following three topics:
 
 - Enabling anonymization.

--- a/doc/reference/bootstrapping.rst
+++ b/doc/reference/bootstrapping.rst
@@ -1,7 +1,7 @@
 IPv8 bootstrapping
 ==================
 
-Peers discover each other through other Peers, as specified in the `the Peer discovery basics <../../reference/peer_discovery>`_.
+Peers discover each other through other Peers, as specified in the `the Peer discovery basics <../reference/peer_discovery.html>`_.
 We call this type of Peer discovery *introduction*.
 However, you cannot be introduced to a new Peer if you don't know anyone to introduce you in the first place.
 This document discusses how IPv8 provides you your first contact.
@@ -24,7 +24,7 @@ Using bootstrap servers
 
 To have IPv8 load a bootstrapper for your overlay, you can simply add it to your ``ConfigBuilder.add_overlay()`` step.
 This is the easiest way to load a bootstrapper.
-For most intents and purposes you can simply use ``default_bootstrap_defs`` provided by ``ipv8.configuration`` (see `the overlay tutorial <../../basics/overlay_tutorial>`_).
+For most intents and purposes you can simply use ``default_bootstrap_defs`` provided by ``ipv8.configuration`` (see `the overlay tutorial <../basics/overlay_tutorial.html>`_).
 However, you can also completely change the bootstrap servers you use.
 For example, this code sets two bootstrap addresses (the IP address 1.2.3.4 with port 5 and the DNS address tribler.org with port 5):
 

--- a/doc/reference/configuration.rst
+++ b/doc/reference/configuration.rst
@@ -62,7 +62,7 @@ Each of the overlay specifications is a dictionary following the following stand
 By default, the ``RandomWalk`` and ``EdgeWalk`` strategies are known to IPv8.
 Respectively these will take care of performing random walks and random walks with reset probability for peer discovery.
 Each overlay may also specify further custom strategies.
-Check out the `the bootstrapping documentation <../../reference/bootstrapping>`_ for more information on configuring bootstrappers per overlay.
+Check out the `the bootstrapping documentation <../reference/bootstrapping.html>`_ for more information on configuring bootstrappers per overlay.
 
 By default, IPv8 loads the following overlays:
 

--- a/doc/reference/serialization.rst
+++ b/doc/reference/serialization.rst
@@ -161,7 +161,7 @@ Simply supply the payload classes you wish to unserialize to, to the decorator.
 
 As some internal messages and deprecated messages use some of the message range, you have the messages identifiers from 0 through 234 available for your custom message definitions.
 Once you register the message handler and have the appropriate decorator on the specified handler method your overlay can communicate with the Internet.
-In practice, given a ``COMMUNITY_ID`` and the payload definitions ``MyMessagePayload1`` and ``MyMessagePayload2``, this will look something like this example (see `the overlay tutorial <../../basics/overlay_tutorial>`_ for a complete runnable example):
+In practice, given a ``COMMUNITY_ID`` and the payload definitions ``MyMessagePayload1`` and ``MyMessagePayload2``, this will look something like this example (see `the overlay tutorial <../basics/overlay_tutorial.html>`_ for a complete runnable example):
 
 
 .. literalinclude:: serialization_2.py


### PR DESCRIPTION
Fixes #1041

This PR:

 - Updates the relative links in the documentation (`doc` directory) to use the new ReadTheDocs format.
 - Updates the absolute links in `README.md` to use the new ReadTheDocs format.
 
New ReadTheDocs behavior example:
https://py-ipv8.readthedocs.io/en/basics/overlay_tutorial
is now
https://py-ipv8.readthedocs.io/en/latest/basics/overlay_tutorial.html

This means that all relative links are now only one folder up and have to refer to other pages with `.html`. Therefore:
`../../basics/tasks_tutorial`
is now
`../basics/tasks_tutorial.html`

