### PR TITLE
Added dataclass Payload

### DIFF
--- a/doc/reference/serialization.rst
+++ b/doc/reference/serialization.rst
@@ -17,11 +17,12 @@ You can use the ``Serializer`` with classes of the following types:
    "Serializable", "ipv8/messaging/serialization.py", "Base class for all things serializable. Should support the instance method to_pack_list() and the class method from_unpack_list()."
    "Payload", "ipv8/messaging/payload.py", "Extension of the Serializable class with logic for pretty printing."
    "VariablePayload", "ipv8/messaging/lazy_payload.py", "Less verbose way to specify Payloads, at the cost of performance."
+   "dataclass", "ipv8/messaging/payload_dataclass.py", "Use dataclasses to send messages, at the cost of control and performance."
 
 
-Each of these serializable classes specifies a list of primitive data types it will serialize to and from.
+Other than the ``dataclass``, each of these serializable classes specifies a list of primitive data types it will serialize to and from.
 The primitive data types are specified in the :ref:`data types<Datatypes Section>` Section.
-Each serializable class has to specify the following class members:
+Each serializable class has to specify the following class members (``dataclass`` does this automatically):
 
 .. csv-table:: Serializable class members
    :header: "member", "description"
@@ -31,27 +32,26 @@ Each serializable class has to specify the following class members:
    "names", "Only for VariablePayload classes, the instance fields to bind the data types to."
 
 
-As an example, we will now define three completely wire-format compatible messages using the three classes.
+As an example, we will now define four completely wire-format compatible messages using the four classes.
 Each of the messages will serialize to a (four byte) unsigned integer followed by an (two byte) unsigned short.
+If the ``dataclass`` had used normal ``int`` types, these would have been two signed 8-byte integers instead.
 Each instance will have two fields: ``field1`` and ``field2`` corresponding to the integer and short.
 
-.. code-block:: python
-
 .. literalinclude:: serialization_1.py
-   :lines: 8-48
+   :lines: 11-61
 
 
 To show some of the differences, let's check out the output of the following script using these definitions:
 
 
 .. literalinclude:: serialization_1.py
-   :lines: 51-78
+   :lines: 64-75
 
 
 .. code-block:: bash
 
     As string:
-    <__main__.MySerializable object at 0x00000127F1B91F70>
+    <__main__.MySerializable object at 0x7f732a23c1f0>
     MyPayload
     | field1: 1
     | field2: 2
@@ -61,21 +61,10 @@ To show some of the differences, let's check out the output of the following scr
     MyCVariablePayload
     | field1: 1
     | field2: 2
-    Field values:
-    1 2
-    1 2
-    1 2
-    1 2
-    Serialization speed:
-    0.00020690000000000985
-    0.00020630000000000648
-    0.0015785999999999994
-    0.0002122999999999986
-    Unserialization speed:
-    0.0003621000000000041
-    0.00036540000000000183
-    0.0036703999999999903
-    0.00045059999999999545
+    MyDataclassPayload
+    | field1: 1
+    | field2: 2
+
 
 .. _Datatypes Section:
 
@@ -119,6 +108,7 @@ A ``Serializer`` can be extended with additional data types by calling ``seriali
    "raw", "?", "str (length ?)"
    "varlenBx2", "1 + ? * 2", "[str (length = 2), \.\.\. ] (length < 256)"
    "varlenH", "2 + ?", "str (length ? < 65356)"
+   "varlenHutf8", "2 + ?", "str (encoded length ? < 65356)"
    "varlenHx20", "2 + ? * 20", "[str (length = 20), \.\.\. ] (length < 65356)"
    "varlenH-list", "1 + ? * (2 + ??)", "[str (length < 65356)] (length < 256)"
    "varlenI", "4 + ?", "str (length < 4294967295)"
@@ -172,5 +162,8 @@ It is recommended (but not obligatory) to have single payload messages store the
 .. literalinclude:: serialization_3.py
    :lines: 31,32,53,56
    :dedent: 4
+
+If you are using the ``@dataclass`` wrapper you can specify the message identifier through an argument instead.
+For example, ``@dataclass(msg_id=42)`` would set the message identifier to ``42``.
 
 Of course, IPv8 also ships with various ``Community`` subclasses of its own, if you need inspiration.

--- a/doc/reference/serialization_1.py
+++ b/doc/reference/serialization_1.py
@@ -1,8 +1,11 @@
-import timeit
+from dataclasses import dataclass
 
 from pyipv8.ipv8.messaging.lazy_payload import VariablePayload, vp_compile
 from pyipv8.ipv8.messaging.payload import Payload
+from pyipv8.ipv8.messaging.payload_dataclass import overwrite_dataclass, type_from_format
 from pyipv8.ipv8.messaging.serialization import Serializable
+
+dataclass = overwrite_dataclass(dataclass)
 
 
 class MySerializable(Serializable):
@@ -48,31 +51,25 @@ class MyCVariablePayload(VariablePayload):
     names = ['field1', 'field2']
 
 
+I = type_from_format('I')
+H = type_from_format('H')
+
+
+@dataclass
+class MyDataclassPayload:
+    field1: I
+    field2: H
+
+
 serializable1 = MySerializable(1, 2)
 serializable2 = MyPayload(1, 2)
 serializable3 = MyVariablePayload(1, 2)
 serializable4 = MyCVariablePayload(1, 2)
+serializable5 = MyDataclassPayload(1, 2)
 
 print("As string:")
 print(serializable1)
 print(serializable2)
 print(serializable3)
 print(serializable4)
-
-print("Field values:")
-print(serializable1.field1, serializable1.field2)
-print(serializable2.field1, serializable2.field2)
-print(serializable3.field1, getattr(serializable3, 'field2', '<undefined>'))
-print(serializable4.field1, getattr(serializable4, 'field2', '<undefined>'))
-
-print("Serialization speed:")
-print(timeit.timeit('serializable1.to_pack_list()', number=1000, globals=locals()))
-print(timeit.timeit('serializable2.to_pack_list()', number=1000, globals=locals()))
-print(timeit.timeit('serializable3.to_pack_list()', number=1000, globals=locals()))
-print(timeit.timeit('serializable4.to_pack_list()', number=1000, globals=locals()))
-
-print("Unserialization speed:")
-print(timeit.timeit('serializable1.from_unpack_list(1, 2)', number=1000, globals=locals()))
-print(timeit.timeit('serializable2.from_unpack_list(1, 2)', number=1000, globals=locals()))
-print(timeit.timeit('serializable3.from_unpack_list(1, 2)', number=1000, globals=locals()))
-print(timeit.timeit('serializable4.from_unpack_list(1, 2)', number=1000, globals=locals()))
+print(serializable5)

--- a/ipv8/lazy_community.py
+++ b/ipv8/lazy_community.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from functools import wraps
-from typing import Iterable, List, Tuple, Type, Union
+from typing import Any, Iterable, List, Tuple, Type, Union
 
 from .keyvault.crypto import default_eccrypto
 from .messaging.payload_headers import BinMemberAuthenticationPayload, GlobalTimeDistributionPayload
@@ -57,7 +57,7 @@ def retrieve_cache(cache_class: Type[NumberCache]):
     return decorator
 
 
-def lazy_wrapper(*payloads: Type[Payload]):
+def lazy_wrapper(*payloads: Union[Type[Payload], Type[Any]]):
     """
     This function wrapper will unpack the BinMemberAuthenticationPayload for you.
 
@@ -90,7 +90,7 @@ def lazy_wrapper(*payloads: Type[Payload]):
     return decorator
 
 
-def lazy_wrapper_wd(*payloads: Type[Payload]):
+def lazy_wrapper_wd(*payloads: Union[Type[Payload], Type[Any]]):
     """
     This function wrapper will unpack the BinMemberAuthenticationPayload for you, as well as pass the raw data to the
     decorated function
@@ -126,7 +126,7 @@ def lazy_wrapper_wd(*payloads: Type[Payload]):
     return decorator
 
 
-def lazy_wrapper_unsigned(*payloads: Type[Payload]):
+def lazy_wrapper_unsigned(*payloads: Union[Type[Payload], Type[Any]]):
     """
     This function wrapper will unpack just the normal payloads for you.
 
@@ -150,7 +150,7 @@ def lazy_wrapper_unsigned(*payloads: Type[Payload]):
     return decorator
 
 
-def lazy_wrapper_unsigned_wd(*payloads: Type[Payload]):
+def lazy_wrapper_unsigned_wd(*payloads: Union[Type[Payload], Type[Any]]):
     """
     This function wrapper will unpack just the normal payloads for you, as well as pass the raw data to the decorated
     function
@@ -245,7 +245,7 @@ class EZPackOverlay(Overlay, ABC):
         return ec.is_valid_signature(public_key, data[:-signature_length], signature), remainder
 
     def _ez_unpack_auth(self,
-                        payload_class: Type[Payload],
+                        payload_class: Union[Type[Payload], Type[Any]],
                         data: bytes) -> Tuple[BinMemberAuthenticationPayload, GlobalTimeDistributionPayload, Payload]:
         # UNPACK
         auth, _ = self.serializer.unpack_serializable(BinMemberAuthenticationPayload, data, offset=23)
@@ -259,7 +259,7 @@ class EZPackOverlay(Overlay, ABC):
         return auth, unpacked[0], unpacked[1]
 
     def _ez_unpack_noauth(self,
-                          payload_class: Type[Payload],
+                          payload_class: Union[Type[Payload], Type[Any]],
                           data: bytes,
                           global_time: bool = True) -> Union[List[Payload], Payload]:
         # UNPACK

--- a/ipv8/messaging/payload_dataclass.py
+++ b/ipv8/messaging/payload_dataclass.py
@@ -1,0 +1,87 @@
+from dataclasses import dataclass as ogdataclass
+from functools import partial
+from typing import List, Type, TypeVar, Union, cast, get_type_hints
+
+from .lazy_payload import VariablePayload, vp_compile
+from .serialization import Serializable
+
+
+def type_from_format(fmt: str) -> TypeVar:
+    """
+    Convert a Serializer format directive to a type usable with @dataclass.
+    """
+    out = object.__new__(TypeVar)
+    out.__init__(fmt)
+    return out
+
+
+def type_map(t: Type) -> Union[str, Serializable, List[Serializable]]:
+    if t is bool:
+        return "?"
+    elif t is int:
+        return "q"
+    elif t is bytes:
+        return "varlenH"
+    elif t is str:
+        return "varlenHutf8"
+    elif isinstance(t, TypeVar):
+        return t.__name__
+    elif hasattr(t, '__origin__') and t.__origin__ in (tuple, list, set):
+        return [t.__args__[0]]
+    elif isinstance(t, (tuple, list, set)) or Serializable in t.mro():
+        return cast(Serializable, t)
+    else:
+        raise NotImplementedError(t, " unknown")
+
+
+def dataclass(cls=None, *, init=True, repr=True,  # pylint: disable=W0622
+              eq=True, order=False, unsafe_hash=False, frozen=False, msg_id=None):
+    """
+    Equivalent to ``@dataclass``, but also makes the wrapped class a ``VariablePayload``.
+
+    See ``dataclasses.dataclass`` for argument descriptions.
+    """
+    if cls is None:
+        return partial(dataclass, init=init, repr=repr, eq=eq, order=order, unsafe_hash=unsafe_hash,
+                       frozen=frozen, msg_id=msg_id)
+
+    origin = ogdataclass(cls, init=init, repr=repr, eq=eq, order=order, unsafe_hash=unsafe_hash,
+                         frozen=frozen)
+
+    class DataClassPayload(origin, VariablePayload):
+        names = list(get_type_hints(cls).keys())
+        format_list = list(map(type_map, get_type_hints(cls).values()))
+
+    if msg_id is not None:
+        setattr(DataClassPayload, "msg_id", msg_id)
+    DataClassPayload.__name__ = cls.__name__
+    DataClassPayload.__qualname__ = cls.__qualname__
+    return vp_compile(DataClassPayload)
+
+
+def overwrite_dataclass(old_dataclass):
+    """
+    In order to get type hinting you have to do the following:
+
+    .. code-block:: python
+
+        from dataclasses import dataclass
+        from ipv8.messaging.payload_dataclass import dataclass
+
+    Linters don't like this. Instead, you can use this function to have a linter friendly alternative:
+
+    .. code-block:: python
+
+        from dataclasses import dataclass
+        from ipv8.messaging.payload_dataclass import overwrite_dataclass
+
+        dataclass = overwrite_dataclass(dataclass)
+
+    :param old_dataclass: the dataclass.dataclass definition.
+    :returns: the new dataclass definition
+    """
+    assert old_dataclass  # Though unused, we reference the variable to placate the linters.
+    return dataclass
+
+
+__all__ = ['overwrite_dataclass', 'type_from_format']

--- a/ipv8/messaging/serialization.py
+++ b/ipv8/messaging/serialization.py
@@ -140,7 +140,7 @@ class Raw(object):
         return len(data)
 
 
-class VarLen(object):
+class VarLen:
     """
     Pack/unpack from an encoded length + data string.
     """
@@ -157,6 +157,20 @@ class VarLen(object):
         str_length = unpack_from(self.length_format, data, offset)[0] * self.base
         unpack_list.append(data[offset + self.length_size: offset + self.length_size + str_length])
         return offset + self.length_size + str_length
+
+
+class VarLenUtf8(VarLen):
+    """
+    Pack/unpack from an unencoded utf8 length + data string.
+    """
+    def pack(self, data):
+        return super().pack(data.encode())
+
+    def unpack(self, data, offset, unpack_list):
+        encoded_data = []
+        out = super().unpack(data, offset, encoded_data)
+        unpack_list.append(encoded_data[0].decode())
+        return out
 
 
 class IPv4:
@@ -279,6 +293,7 @@ class Serializer(object):
             'raw': Raw(),
             'varlenBx2': VarLen('>B', 2),
             'varlenH': VarLen('>H'),
+            'varlenHutf8': VarLenUtf8('>H'),
             'varlenHx20': VarLen('>H', 20),
             'varlenH-list': ListOf(VarLen('>H')),
             'varlenI': VarLen('>I'),

--- a/ipv8/test/messaging/test_payload_dataclass.py
+++ b/ipv8/test/messaging/test_payload_dataclass.py
@@ -1,0 +1,378 @@
+from dataclasses import dataclass, is_dataclass
+from typing import List
+
+from ..base import TestBase
+from ...messaging.payload_dataclass import overwrite_dataclass, type_from_format
+from ...messaging.serialization import default_serializer
+
+ogdataclass = dataclass
+dataclass = overwrite_dataclass(dataclass)
+varlenH = type_from_format('varlenH')
+
+
+@dataclass
+class NativeBool:
+    a: bool
+
+
+@dataclass
+class NativeInt:
+    a: int
+
+
+@dataclass
+class NativeBytes:
+    a: bytes
+
+
+@dataclass
+class NativeStr:
+    a: str
+
+
+@dataclass
+class SerializerType:
+    a: varlenH
+
+
+@dataclass
+class NestedType:
+    a: NativeInt
+
+
+@dataclass
+class NestedListType:
+    a: [NativeInt]
+
+
+@dataclass
+class NestedListTypeType:
+    a: List[NativeInt]
+
+
+@ogdataclass
+class Unknown:
+    """
+    To whomever is reading this and wondering why dict is not supported: use a nested payload instead.
+    """
+    a: dict
+
+
+@dataclass
+class A:
+    a: int
+    b: int
+
+
+@dataclass(eq=False)
+class FwdDataclass:
+    a: int
+
+
+@dataclass
+class StripMsgId:
+    a: int
+    msg_id = 1
+
+
+@dataclass(msg_id=1)
+class FwdMsgId:
+    a: int
+
+
+@dataclass
+@ogdataclass
+class Everything:
+    @dataclass
+    class Item:
+        a: bool
+
+    a: int
+    b: bytes
+    c: varlenH
+    d: Item
+    e: [Item]
+    f: str
+    g: List[Item]
+
+
+class TestDataclassPayload(TestBase):  # pylint: disable=R0904
+
+    @staticmethod
+    def _pack_and_unpack(payload, instance):
+        """
+        Serialize and unserialize an instance of payload.
+        :param payload: the payload class to serialize for
+        :type payload: type(Payload)
+        :param instance: the payload instance to serialize
+        :type instance: Payload
+        :return: the repacked instance
+        """
+        serialized = default_serializer.pack_serializable(instance)
+        deserialized, _ = default_serializer.unpack_serializable(payload, serialized)  # pylint: disable=E0632
+        return deserialized
+
+    def test_base_unnamed(self):
+        """
+        Check if the wrapper returns the payload correctly with unnamed arguments.
+        """
+        payload = A(42, 1337)
+
+        deserialized = self._pack_and_unpack(A, payload)
+
+        self.assertEqual(payload.a, 42)
+        self.assertEqual(payload.b, 1337)
+        self.assertEqual(deserialized.a, 42)
+        self.assertEqual(deserialized.b, 1337)
+
+    def test_base_named(self):
+        """
+        Check if the wrapper returns the payload correctly with named arguments.
+        """
+        payload = A(b=1337, a=42)
+
+        deserialized = self._pack_and_unpack(A, payload)
+
+        self.assertEqual(payload.a, 42)
+        self.assertEqual(payload.b, 1337)
+        self.assertEqual(deserialized.a, 42)
+        self.assertEqual(deserialized.b, 1337)
+
+    def test_nativebool_t_payload(self):
+        """
+        Check if unpacked BitPayload(true) works correctly.
+        """
+        payload = NativeBool(True)
+
+        deserialized = self._pack_and_unpack(NativeBool, payload)
+
+        self.assertEqual(payload.a, True)
+        self.assertEqual(deserialized.a, True)
+
+    def test_nativebool_f_payload(self):
+        """
+        Check if unpacked BitPayload(false) works correctly.
+        """
+        payload = NativeBool(False)
+
+        deserialized = self._pack_and_unpack(NativeBool, payload)
+
+        self.assertEqual(payload.a, False)
+        self.assertEqual(deserialized.a, False)
+
+    def test_nativeint_negative_payload(self):
+        """
+        Check if unpacked NativeInt(-1) works correctly.
+        """
+        payload = NativeInt(-1)
+
+        deserialized = self._pack_and_unpack(NativeInt, payload)
+
+        self.assertEqual(payload.a, -1)
+        self.assertEqual(deserialized.a, -1)
+
+    def test_nativeint_zero_payload(self):
+        """
+        Check if unpacked NativeInt(0) works correctly.
+        """
+        payload = NativeInt(0)
+
+        deserialized = self._pack_and_unpack(NativeInt, payload)
+
+        self.assertEqual(payload.a, 0)
+        self.assertEqual(deserialized.a, 0)
+
+    def test_nativeint_positive_payload(self):
+        """
+        Check if unpacked NativeInt(1) works correctly.
+        """
+        payload = NativeInt(1)
+
+        deserialized = self._pack_and_unpack(NativeInt, payload)
+
+        self.assertEqual(payload.a, 1)
+        self.assertEqual(deserialized.a, 1)
+
+    def test_nativebytes_empty_payload(self):
+        """
+        Check if unpacked NativeBytes(b'') works correctly.
+        """
+        payload = NativeBytes(b'')
+
+        deserialized = self._pack_and_unpack(NativeBytes, payload)
+
+        self.assertEqual(payload.a, b'')
+        self.assertEqual(deserialized.a, b'')
+
+    def test_nativebytes_filled_payload(self):
+        """
+        Check if unpacked NativeBytes(b'hi') works correctly.
+        """
+        payload = NativeBytes(b'hi')
+
+        deserialized = self._pack_and_unpack(NativeBytes, payload)
+
+        self.assertEqual(payload.a, b'hi')
+        self.assertEqual(deserialized.a, b'hi')
+
+    def test_nativestr_empty_payload(self):
+        """
+        Check if unpacked NativeStr('') works correctly.
+        """
+        payload = NativeStr('')
+
+        deserialized = self._pack_and_unpack(NativeStr, payload)
+
+        self.assertEqual(payload.a, '')
+        self.assertEqual(deserialized.a, '')
+
+    def test_nativestr_filled_payload(self):
+        """
+        Check if unpacked NativeStr('hi') works correctly.
+        """
+        payload = NativeStr('hi')
+
+        deserialized = self._pack_and_unpack(NativeStr, payload)
+
+        self.assertEqual(payload.a, 'hi')
+        self.assertEqual(deserialized.a, 'hi')
+
+    def test_serializertype_payload(self):
+        """
+        Check if a custom SerializerType ("varlenH") works correctly.
+        """
+        payload = SerializerType(b'hi')
+
+        deserialized = self._pack_and_unpack(SerializerType, payload)
+
+        self.assertEqual(payload.a, b'hi')
+        self.assertEqual(deserialized.a, b'hi')
+
+    def test_nested_payload(self):
+        """
+        Check if a nested payload works correctly.
+        """
+        payload = NestedType(NativeInt(42))
+
+        deserialized = self._pack_and_unpack(NestedType, payload)
+
+        self.assertEqual(payload.a, NativeInt(42))
+        self.assertEqual(deserialized.a, NativeInt(42))
+
+    def test_nestedlist_empty_payload(self):
+        """
+        Check if an empty list of nested payloads works correctly.
+        """
+        payload = NestedListType([])
+
+        deserialized = self._pack_and_unpack(NestedListType, payload)
+
+        self.assertListEqual(payload.a, [])
+        self.assertListEqual(deserialized.a, [])
+
+    def test_nestedlist_filled_payload(self):
+        """
+        Check if a list of nested payloads works correctly.
+        """
+        payload = NestedListType([NativeInt(42), NativeInt(1337)])
+
+        deserialized = self._pack_and_unpack(NestedListType, payload)
+
+        self.assertListEqual(payload.a, [NativeInt(42), NativeInt(1337)])
+        self.assertListEqual(deserialized.a, [NativeInt(42), NativeInt(1337)])
+
+    def test_nestedlisttype_empty_payload(self):
+        """
+        Check if an empty list type of nested payloads works correctly.
+        """
+        payload = NestedListTypeType([])
+
+        deserialized = self._pack_and_unpack(NestedListTypeType, payload)
+
+        self.assertListEqual(payload.a, [])
+        self.assertListEqual(deserialized.a, [])
+
+    def test_unknown_payload(self):
+        """
+        Check if an unknown type raises an error.
+        """
+        self.assertRaises(NotImplementedError, dataclass, Unknown)
+
+    def test_nestedlisttype_filled_payload(self):
+        """
+        Check if a list type of nested payloads works correctly.
+        """
+        payload = NestedListTypeType([NativeInt(42), NativeInt(1337)])
+
+        deserialized = self._pack_and_unpack(NestedListTypeType, payload)
+
+        self.assertListEqual(payload.a, [NativeInt(42), NativeInt(1337)])
+        self.assertListEqual(deserialized.a, [NativeInt(42), NativeInt(1337)])
+
+    def test_fwd_args(self):
+        """
+        Check if ``dataclass_payload`` forwards its arguments to ``dataclass``.
+
+        We forward ``eq=False`` because it's easy to test.
+        """
+        self.assertEqual(NativeInt(1), NativeInt(1))
+        self.assertNotEqual(FwdDataclass(3), FwdDataclass(3))
+
+    def test_strip_msg_id(self):
+        """
+        Check if the ``msg_id`` field is identifier and stripped.
+        """
+        payload = StripMsgId(42)
+
+        self.assertIn("a", payload.names)
+        self.assertNotIn("msg_id", payload.names)
+        self.assertListEqual(["q"], payload.format_list)
+        self.assertEqual(payload.msg_id, 1)
+
+    def test_fwd_msg_id(self):
+        """
+        Check if the ``msg_id`` argument is sets the Payload ``msg_id``.
+        """
+        payload = FwdMsgId(42)
+
+        self.assertIn("a", payload.names)
+        self.assertNotIn("msg_id", payload.names)
+        self.assertListEqual(["q"], payload.format_list)
+        self.assertEqual(payload.msg_id, 1)
+
+    def test_everything(self):
+        """
+        Check if the wrapper handles all of the different data types together.
+        """
+        a = Everything(42,
+                       b'1337',
+                       b'1337',
+                       Everything.Item(True),
+                       [Everything.Item(False), Everything.Item(True)],
+                       "hi",
+                       [Everything.Item(True), Everything.Item(False)])
+
+        self.assertTrue(is_dataclass(a))
+
+        r = self._pack_and_unpack(Everything, a)
+
+        self.assertEqual(a.a, 42)
+        self.assertEqual(r.a, 42)
+
+        self.assertEqual(a.b, b'1337')
+        self.assertEqual(r.b, b'1337')
+
+        self.assertEqual(a.c, b'1337')
+        self.assertEqual(r.c, b'1337')
+
+        self.assertEqual(a.d, Everything.Item(True))
+        self.assertEqual(r.d, Everything.Item(True))
+
+        self.assertListEqual(a.e, [Everything.Item(False), Everything.Item(True)])
+        self.assertListEqual(r.e, [Everything.Item(False), Everything.Item(True)])
+
+        self.assertEqual(a.f, "hi")
+        self.assertEqual(r.f, "hi")
+
+        self.assertListEqual(a.g, [Everything.Item(True), Everything.Item(False)])
+        self.assertListEqual(r.g, [Everything.Item(True), Everything.Item(False)])


### PR DESCRIPTION
Fixes #1011

This PR:

 - Adds `pyipv8.ipv8.messaging.payload_dataclass.dataclass` to specify dataclasses that are also VariablePayloads.
 - Adds `varlenHutf8` as a format to the `Serializer` (for utf-8 `str` instances).
 - Removes the timing experiment from the serialization documentation.

Note:

While playing "linter whack-a-mole" I changed the importing slightly from what was described in #1011, which used to be:

```python
from dataclasses import dataclass
from ipv8.messaging.payload_dataclass import dataclass
```

The linters DO NOT like this and would trigger for everyone everywhere all the time this would be used (annoying!). Therefore, I settled for a bit longer approach that does not trigger the linters:


```python
from dataclasses import dataclass
from ipv8.messaging.payload_dataclass import overwrite_dataclass

dataclass = overwrite_dataclass(dataclass)
```

