### PR TITLE
Automated Version Update

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -26,9 +26,9 @@ copyright = '2017-2021, Tribler'  # Do not change manually! Handled by github_in
 author = u'Tribler'
 
 # The short X.Y version
-version = '2.7'  # Do not change manually! Handled by github_increment_version.py
+version = '2.8'  # Do not change manually! Handled by github_increment_version.py
 # The full version, including alpha/beta/rc tags
-release = '2.7.0'  # Do not change manually! Handled by github_increment_version.py
+release = '2.8.0'  # Do not change manually! Handled by github_increment_version.py
 
 
 # -- General configuration ---------------------------------------------------

--- a/ipv8/REST/rest_manager.py
+++ b/ipv8/REST/rest_manager.py
@@ -84,7 +84,7 @@ class RESTManager:
         aiohttp_apispec = AiohttpApiSpec(
             app=self.root_endpoint.app,
             title="IPv8 REST API documentation",
-            version="v2.7",  # Do not change manually! Handled by github_increment_version.py
+            version="v2.8",  # Do not change manually! Handled by github_increment_version.py
             url="/docs/swagger.json",
             swagger_path="/docs",
         )

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     description='The Python implementation of the IPV8 library',
     long_description=long_description,
     long_description_content_type='text/markdown',
-    version='2.7.0',  # Do not change manually! Handled by github_increment_version.py
+    version='2.8.0',  # Do not change manually! Handled by github_increment_version.py
     url='https://github.com/Tribler/py-ipv8',
     package_data={'': ['*.*']},
     packages=find_packages(),


### PR DESCRIPTION
Suggested release message
---
Tag version: 2.8
Release title: IPv8 v2.8.1809 release
Body:
Includes the first 1809 commits (+52 since v2.7) for IPv8, containing:

 - Added API documentation generation
 - Added Payload match support
 - Added ReadTheDocs config file
 - Added best practices documentation
 - Added bootstrapping documentation
 - Added dataclass Payload
 - Added option to configure IPv8 with raw private key material
 - Added script to publish standalone TaskManager
 - Added tasks tutorial
 - Allow custom my_peer instead of key curve in MockIPv8
 - Fixed AddressTester using different LAN check
 - Fixed ReadTheDocs unrendered code-blocks
 - Fixed crashing unitialized endpoint on shutdown
 - Fixed dataclass typing
 - Fixed deprecated config not having fallbacks
 - Fixed missing token for TaskManager PyPi project
 - Fixed readthedocs links
 - Move discovery docs
 - Removed old database.py workarounds
 - Updated CONTRIBUTING to exempt tests from linked issues
 - Updated Endpoint initialization to use 'interfaces' configuration
 - Updated MockEndpoint behavior