### PR TITLE
Fixed `CommunityLauncher` and `test_loader` `super()` usage

### DIFF
--- a/ipv8/loader.py
+++ b/ipv8/loader.py
@@ -333,7 +333,7 @@ class CommunityLauncher:
     """
 
     def __init__(self):
-        super()
+        super().__init__()
         self.community_args = []
         self.community_kwargs = {}
 

--- a/ipv8/test/test_loader.py
+++ b/ipv8/test/test_loader.py
@@ -78,14 +78,14 @@ class StagedCommunityLauncher(CommunityLauncher):
 
     def finalize(self, ipv8, session: MockSession, community: MockCommunity):
         session.community = community
-        return super()
+        super().finalize(ipv8, session, community)
 
 
 class TestCommunityLauncher(TestBase):
 
     def setUp(self):
         self.staged_launcher = StagedCommunityLauncher()
-        return super()
+        super().setUp()
 
     def test_not_before_list(self):
         """


### PR DESCRIPTION
This PR:

- Fixes `CommunityLauncher` calling `super()` instead of `super().__init__()`.
- Fixes `StagedCommunityLauncher.finalize()` returning `super()` instead of `super().finalize()`.
- Fixes `TestCommunityLauncher.setUp()` returning `super()` instead of `super().setUp()`.
