### PR TITLE
Updated issue templates for new tags

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,13 +2,10 @@
 name: Bug report
 about: Create a report to help us improve
 title: ''
-labels: bug
+labels: priority: unknown
 assignees: ''
 
 ---
-
-**Operating System and version**
-Ex. Windows 10, Ubuntu 18.04 or macOS Mojave.
 
 **Traceback and/or steps to reproduce**
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest an idea for this project
 title: ''
-labels: enhancement
+labels: priority: unknown
 assignees: ''
 
 ---


### PR DESCRIPTION
Fixes #1063

This PR:

 - Updates the issue template `bug_report` to start with the label `priority: unknown`.
 - Updates the issue template `feature_request` to start with the label `priority: unknown`.
 - Removes the OS section from the `bug_report` issue template.

