### PR TITLE
Added documentation on third-party serialization (and nested payloads)

### DIFF
--- a/doc/reference/serialization.rst
+++ b/doc/reference/serialization.rst
@@ -236,3 +236,20 @@ Note that we need to do our own signature checks now.
 
 .. literalinclude:: serialization_6.py
    :lines: 11-37
+
+
+Nested Payloads
+---------------
+
+It is possible to put a ``Payload`` inside another ``Payload``.
+We call these nested payloads.
+You can specify them by using the ``"payload"`` datatype and setting the ``Payload`` class in the format list.
+For a ``VariablePayload`` this looks like the following example.
+
+.. literalinclude:: serialization_7.py
+   :lines: 9-16
+
+For dataclass payloads this nesting is supported by simply specifying nested classes as follows.
+
+.. literalinclude:: serialization_7.py
+   :lines: 19-28

--- a/doc/reference/serialization.rst
+++ b/doc/reference/serialization.rst
@@ -167,3 +167,72 @@ If you are using the ``@dataclass`` wrapper you can specify the message identifi
 For example, ``@dataclass(msg_id=42)`` would set the message identifier to ``42``.
 
 Of course, IPv8 also ships with various ``Community`` subclasses of its own, if you need inspiration.
+
+
+Using external serialization options
+------------------------------------
+
+IPv8 is compatible with pretty much all third-party message serialization packages.
+However, before hooking one of these packages into IPv8 you may want to ask yourself whether you have fallen victim to marketing hype.
+After all, ``XML`` is the one unifying standard we will never switch away from, right?
+Oh wait, no, it's ``JSON``.
+My bad, it's ``Protobuf``.
+Or was it ``ASN.1``?
+You get the point.
+In this world, only the core ``IPv8`` serialization format remains constant.
+
+There are three main ways to hook in external serialization: *per message*, *per Serializer* and *per Community*.
+The three methods can be freely mixed.
+
+Custom serialization per message
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If you only want to use custom seralization for (part of) a single overlay message, you can use ``VariablePayload`` field modification (this also works for dataclass payloads).
+This method involves implementing the methods ``fix_pack_<your field name>`` and ``fix_unpack_<your field name>`` for the fields of your message that use custom serialization.
+Check out the following example:
+
+.. literalinclude:: serialization_4.py
+   :lines: 11-34
+
+In both classes we create a message with a single field ``dictionary``.
+To pack this field, we use ``json.dumps()`` to create a string representation of the dictionary.
+When loading a message, ``json.loads()`` is used to create a dictionary from the serialized data.
+Instead of ``json`` you could also use any serialization of your liking.
+
+Using the same transformations for all fields makes your payloads very lengthy.
+In this case, you may want to look into specifying a custom serialization format.
+
+Custom serialization formats
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+It is possible to specify new formats by adding packing formats to a ``Serializer`` instance.
+You can easily do so by overwriting your ``Community.get_serializer()`` method.
+This ``Serializer`` is sandboxed per ``Community`` instance, so you don't have to worry about breaking other instances.
+Check out the following example and note that the message is now much smaller at the expense of having to define a custom (complicated) packing format.
+
+.. literalinclude:: serialization_5.py
+   :lines: 13-44
+
+The line ``serializer.add_packer('json', PackerJSON())`` adds the new format ``json`` that is used in ``Message``.
+In fact, any further message added to this ``Community`` can now use the ``json`` format.
+However, you may also note some additional complexity in the ``PackerJSON`` class.
+
+Our custom packer ``PackerJSON`` implements two required methods: ``pack()`` and ``unpack()``.
+The former serializes data using custom serialization (``json.dumps()`` in this case).
+We use a big-endian unsigned short (``">H"``) to determine the length of the serialized JSON data.
+The ``unpack()`` method creates JSON objects from the serialized data, returning the new offset in the ``data`` stream and adding the object ot the ``unpack_list`` list.
+
+Custom Community data handling
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+It is possible to circumvent IPv8 message formats altogether.
+In its most extreme form, you can overwrite ``Community.on_packet(packet)`` to inspect all raw data sent to your ``Community`` instance.
+The ``packet`` is a tuple of ``(source_address, data)``.
+You can write raw data back to an address using ``self.endpoint.send(address, data)``.
+
+If you want to mix with other messages, you should use the message byte.
+The following example shows how to use JSON serialization without any IPv8 serialization.
+Note that we need to do our own signature checks now.
+
+.. literalinclude:: serialization_6.py
+   :lines: 11-37

--- a/doc/reference/serialization_4.py
+++ b/doc/reference/serialization_4.py
@@ -1,0 +1,58 @@
+from dataclasses import dataclass
+import json
+
+from pyipv8.ipv8.messaging.payload_dataclass import overwrite_dataclass
+from pyipv8.ipv8.messaging.lazy_payload import VariablePayload, vp_compile
+from pyipv8.ipv8.messaging.serialization import default_serializer
+
+dataclass = overwrite_dataclass(dataclass)
+
+
+@vp_compile
+class VPMessageKeepDict(VariablePayload):
+    msg_id = 1
+    format_list = ['varlenH']
+    names = ["dictionary"]
+
+    def fix_pack_dictionary(self, the_dictionary: dict) -> bytes:
+        return json.dumps(the_dictionary).encode()
+
+    @classmethod
+    def fix_unpack_dictionary(cls, serialized_dictionary: bytes) -> dict:
+        return json.loads(serialized_dictionary.decode())
+
+
+@dataclass(msg_id=2)
+class DCMessageKeepDict:
+    dictionary: str
+
+    def fix_pack_dictionary(self, the_dictionary: dict) -> str:
+        return json.dumps(the_dictionary)
+
+    @classmethod
+    def fix_unpack_dictionary(cls, serialized_dictionary: str) -> dict:
+        return json.loads(serialized_dictionary)
+
+
+data = {"1": 1, "key": "value"}
+
+message1 = VPMessageKeepDict(data)
+message2 = DCMessageKeepDict(data)
+
+assert message1.dictionary["1"] == 1
+assert message1.dictionary["key"] == "value"
+assert message2.dictionary["1"] == 1
+assert message2.dictionary["key"] == "value"
+
+serialized1 = default_serializer.pack_serializable(message1)
+serialized2 = default_serializer.pack_serializable(message2)
+
+assert serialized1 == serialized2
+
+unserialized1, _ = default_serializer.unpack_serializable(VPMessageKeepDict, serialized1)
+unserialized2, _ = default_serializer.unpack_serializable(DCMessageKeepDict, serialized2)
+
+assert unserialized1.dictionary["1"] == 1
+assert unserialized1.dictionary["key"] == "value"
+assert unserialized2.dictionary["1"] == 1
+assert unserialized2.dictionary["key"] == "value"

--- a/doc/reference/serialization_5.py
+++ b/doc/reference/serialization_5.py
@@ -1,0 +1,87 @@
+import json
+import os
+import struct
+from asyncio import ensure_future, get_event_loop
+
+from pyipv8.ipv8.community import Community
+from pyipv8.ipv8.configuration import ConfigBuilder, Strategy, WalkerDefinition, default_bootstrap_defs
+from pyipv8.ipv8.lazy_community import lazy_wrapper
+from pyipv8.ipv8.messaging.lazy_payload import VariablePayload, vp_compile
+from pyipv8.ipv8_service import IPv8
+
+
+@vp_compile
+class Message(VariablePayload):
+    msg_id = 1
+    format_list = ['json', 'json', 'json', 'json']
+    names = ["d1", "d2", "d3", "d4"]
+
+
+class PackerJSON:
+
+    def pack(self, data) -> bytes:
+        packed = json.dumps(data).encode()
+        size = struct.pack(">H", len(packed))
+        return size + packed
+
+    def unpack(self, data, offset, unpack_list):
+        size, = struct.unpack_from(">H", data, offset)
+
+        json_data_start = offset + 2
+        json_data_end = json_data_start + size
+
+        serialized = data[json_data_start:json_data_end]
+        unpack_list.append(json.loads(serialized))
+
+        return json_data_end
+
+
+class MyCommunity(Community):
+
+    def get_serializer(self):
+        serializer = super().get_serializer()
+        serializer.add_packer('json', PackerJSON())
+        return serializer
+
+    community_id = os.urandom(20)
+
+    def __init__(self, my_peer, endpoint, network):
+        super().__init__(my_peer, endpoint, network)
+        self.add_message_handler(Message, self.on_message)
+
+    @lazy_wrapper(Message)
+    def on_message(self, peer, message):
+        self.logger.info(str(peer))
+        self.logger.info(str(message))
+        get_event_loop().stop()
+
+        assert message.d4 == 1337  # Check d4 here to make sure this is not some magic temporary serialization.
+
+    def started(self, peer_id):
+        async def send_message():
+            for p in self.get_peers():
+                message = Message(
+                    {"a": "b", "c": "d"},
+                    {"e": "f", "g": "h"},
+                    ["i", "j", "k", "l"],
+                    42
+                )
+                message.d4 = 1337  # Overwrite 42 here to make sure this is not some magic temporary serialization.
+                self.ez_send(p, message)
+
+        if peer_id == 1:
+            self.register_task("Start Sending Messages", send_message, interval=2.0, delay=0)
+
+
+async def start_communities():
+    for i in [1, 2]:
+        builder = ConfigBuilder().clear_keys().clear_overlays()
+        builder.add_key("my peer", "medium", f"ec{i}.pem")
+        builder.add_overlay("MyCommunity", "my peer", [WalkerDefinition(Strategy.RandomWalk, 10, {'timeout': 3.0})],
+                            default_bootstrap_defs, {}, [("started", i)])
+        ipv8 = IPv8(builder.finalize(), extra_communities={'MyCommunity': MyCommunity})
+        await ipv8.start()
+
+
+ensure_future(start_communities())
+get_event_loop().run_forever()

--- a/doc/reference/serialization_6.py
+++ b/doc/reference/serialization_6.py
@@ -1,0 +1,61 @@
+from binascii import hexlify, unhexlify
+import json
+import os
+from asyncio import ensure_future, get_event_loop
+
+from pyipv8.ipv8.community import Community
+from pyipv8.ipv8.configuration import ConfigBuilder, Strategy, WalkerDefinition, default_bootstrap_defs
+from pyipv8.ipv8_service import IPv8
+
+
+class MyCommunity(Community):
+    community_id = os.urandom(20)
+
+    def __init__(self, my_peer, endpoint, network):
+        super().__init__(my_peer, endpoint, network)
+        self.add_message_handler(1, self.on_message)
+
+    def send_message(self, peer):
+        message = json.dumps({"key": "value", "key2": "value2"})
+        public_key = hexlify(self.my_peer.public_key.key_to_bin()).decode()
+        signature = hexlify(self.my_peer.key.signature(message.encode())).decode()
+
+        signed_message = json.dumps({"message": message,
+                                     "public_key": public_key,
+                                     "signature": signature}).encode()
+        self.endpoint.send(peer.address, self.get_prefix() + b'\x01' + signed_message)
+
+    def on_message(self, source_address, data):
+        header_length = len(self.get_prefix()) + 1  # Account for 1 byte message id
+        received = json.loads(data[header_length:])  # Strip the IPv8 multiplexing data
+
+        public_key = self.crypto.key_from_public_bin(unhexlify(received["public_key"]))
+        valid = self.crypto.is_valid_signature(public_key,
+                                               received["message"].encode(),
+                                               unhexlify(received["signature"]))
+        self.logger.info(f"Received message {received['message']} from {source_address},"
+                         f"the signature is {valid}!")
+
+        get_event_loop().stop()
+
+    def started(self, peer_id):
+        async def send_message():
+            for p in self.get_peers():
+                self.send_message(p)
+
+        if peer_id == 1:
+            self.register_task("Start Sending Messages", send_message, interval=2.0, delay=0)
+
+
+async def start_communities():
+    for i in [1, 2]:
+        builder = ConfigBuilder().clear_keys().clear_overlays()
+        builder.add_key("my peer", "medium", f"ec{i}.pem")
+        builder.add_overlay("MyCommunity", "my peer", [WalkerDefinition(Strategy.RandomWalk, 10, {'timeout': 3.0})],
+                            default_bootstrap_defs, {}, [("started", i)])
+        ipv8 = IPv8(builder.finalize(), extra_communities={'MyCommunity': MyCommunity})
+        await ipv8.start()
+
+
+ensure_future(start_communities())
+get_event_loop().run_forever()

--- a/doc/reference/serialization_7.py
+++ b/doc/reference/serialization_7.py
@@ -1,0 +1,28 @@
+from dataclasses import dataclass
+
+from ipv8.messaging.lazy_payload import VariablePayload
+from ipv8.messaging.payload_dataclass import overwrite_dataclass
+
+dataclass = overwrite_dataclass(dataclass)
+
+
+class A(VariablePayload):
+    format_list = ['I', 'H']
+    names = ["foo", "bar"]
+
+
+class B(VariablePayload):
+    format_list = [A, 'H']  # Note that we pass the class A
+    names = ["a", "baz"]
+
+
+@dataclass(msg_id=1)
+class Message:
+    @dataclass
+    class Item:
+        foo: int
+        bar: int
+
+    item: Item
+    items: [Item]  # Yes, you can even make this a list!
+    baz: int


### PR DESCRIPTION
Fixes #978

This PR:

 - Adds documentation for the three non-destructive ways to hook in third-party serialization.
 - Adds short examples to documentation for nested payloads.
 
Here's the page printed to PDF (doesn't use RTD theme):
[Message serialization — IPv8 2.8.0 documentation.pdf](https://github.com/Tribler/py-ipv8/files/7698920/Message.serialization.IPv8.2.8.0.documentation.pdf)
New stuff starts from the `Using external serialization options` section.

