### PR TITLE
Fixed bootstrap received addresses callback not checking for cancel

### DIFF
--- a/ipv8/community.py
+++ b/ipv8/community.py
@@ -183,7 +183,7 @@ class Community(EZPackOverlay):
             task.add_done_callback(self.received_bootstrapped_addresses)
 
     def received_bootstrapped_addresses(self, addresses):
-        if addresses and addresses.result():
+        if addresses and not addresses.cancelled() and addresses.result():
             for address in list(addresses.result())[:self.max_peers]:
                 self.walk_to(address)
 


### PR DESCRIPTION
Fix for downstream report https://github.com/Tribler/tribler/issues/6648

This PR:

 - Updates `Community.received_bootstrapped_addresses` to check if the passed `Future` is cancelled.
