### PR TITLE
Fixed GitHub issue template labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us improve
 title: ''
-labels: priority: unknown
+labels: 'priority: unknown'
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest an idea for this project
 title: ''
-labels: priority: unknown
+labels: 'priority: unknown'
 assignees: ''
 
 ---


### PR DESCRIPTION
Fixes #1069

This PR:

 - Updates automatic labeling with `priority: unknown` to be `'priority: unknown'`.

