### PR TITLE
Updated exit data rules

### DIFF
--- a/ipv8/messaging/anonymization/tunnel.py
+++ b/ipv8/messaging/anonymization/tunnel.py
@@ -211,7 +211,7 @@ class TunnelExitSocket(Tunnel, DatagramProtocol, TaskManager):
         if not (is_bt and PEER_FLAG_EXIT_BT in self.overlay.settings.peer_flags) \
            and not (is_ipv8 and PEER_FLAG_EXIT_IPV8 in self.overlay.settings.peer_flags) \
            and not (is_ipv8 and self.overlay._prefix == data[:22]):
-            self.logger.error("Dropping data packets, refusing to be an exit node (BT=%s, IPv8=%s)", is_bt, is_ipv8)
+            self.logger.warning("Dropping data packets, refusing to be an exit node (BT=%s, IPv8=%s)", is_bt, is_ipv8)
             return False
         return True
 

--- a/ipv8/messaging/anonymization/tunnel.py
+++ b/ipv8/messaging/anonymization/tunnel.py
@@ -56,14 +56,34 @@ class DataChecker(object):
 
     @staticmethod
     def could_be_utp(data):
+        """
+        Check if this data could be uTP (see also https://www.bittorrent.org/beps/bep_0029.html).
+
+        Packets should be 20 bytes or larger.
+
+        The type should be 0..4:
+         - 0: ST_DATA
+         - 1: ST_FIN
+         - 2: ST_STATE
+         - 3: ST_RESET
+         - 4: ST_SYN
+
+        The version should be 1.
+
+        The extension should be 0..3:
+         - 0: No extension
+         - 1: Selective ACK
+         - 2: Deprecated
+         - 3: Close reason
+        """
         if len(data) < 20:
             return False
         byte1, byte2 = unpack_from('!BB', data)
-        # Type should be 0..4, Ver should be 1
+        # Type and version
         if not (0 <= (byte1 >> 4) <= 4 and (byte1 & 15) == 1):
             return False
-        # Extension should be 0..2
-        if not (0 <= byte2 <= 2):
+        # Extension
+        if not (0 <= byte2 <= 3):
             return False
         return True
 

--- a/ipv8/test/messaging/anonymization/test_datachecker.py
+++ b/ipv8/test/messaging/anonymization/test_datachecker.py
@@ -6,6 +6,7 @@ from ....messaging.anonymization.tunnel import DataChecker
 tracker_pkt = unhexlify('00000417271019800000000012345678')
 dht_pkt = b'd1:ad2:id20:abcdefghij01234567899:info_hash20:mnopqrstuvwxyz123456e1:q9:get_peers1:t2:aa1:y1:qe'
 utp_pkt = unhexlify('210086446ed69ec1ddbd9e6000100000f32e86be')
+utp_ext3_pkt = unhexlify('110309d69087c1e7b69c0980001000009868b984000400000008')
 ipv8_pkt = unhexlify('0002123456789abcdef123456789abcdef123456789a00000001')
 tunnel_pkt = unhexlify('000281ded07332bdc775aa5a46f96de9f8f390bbc9f300000001')
 
@@ -39,6 +40,7 @@ class TestDataChecker(TestBase):
         self.assertFalse(DataChecker.could_be_utp(tracker_pkt))
         self.assertFalse(DataChecker.could_be_utp(dht_pkt))
         self.assertTrue(DataChecker.could_be_utp(utp_pkt))
+        self.assertTrue(DataChecker.could_be_utp(utp_ext3_pkt))  # non-BEP29 extension 3 (close reason)
         self.assertFalse(DataChecker.could_be_utp(ipv8_pkt))
         self.assertFalse(DataChecker.could_be_utp(tunnel_pkt))
 


### PR DESCRIPTION
Fixes #1079

This PR:

 - Updates the `DataChecker` to allow uTP packets with extension `3`.
 - Updates the log level of `TunnelExitSocket.is_allowed` to warning, matching the level of `TunnelExitSocket.datagram_received`.
