### PR TITLE
Fix _ez_unpack return type

### DIFF
--- a/ipv8/types.py
+++ b/ipv8/types.py
@@ -1,7 +1,17 @@
+import sys
 import typing
 
 Address = typing.Tuple[str, int]
-DataclassPayload = typing.TypeVar('DataclassPayload')
+
+
+if sys.version_info >= (3, 8):
+    class DataclassPayload(typing.Protocol):
+        # Checking for this attribute is currently the most reliable way to ascertain that something is a dataclass.
+        # See https://stackoverflow.com/questions/54668000/type-hint-for-an-instance-of-a-non-specific-dataclass
+        __dataclass_fields__: dict
+else:
+    DataclassPayload = type
+
 
 # pylint: disable=unused-import
 


### PR DESCRIPTION
Fixes #1094

This PR:

 - Fixes result type of `EZPackOverlay._ez_unpack_auth` and `EZPackOverlay._ez_unpack_noauth`;
 - Fixes the definition of `DataclassPayload` type.