### PR TITLE
Automated Version Update

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -22,13 +22,13 @@
 # -- Project information -----------------------------------------------------
 
 project = u'IPv8'
-copyright = '2017-2021, Tribler'  # Do not change manually! Handled by github_increment_version.py
+copyright = '2017-2022, Tribler'  # Do not change manually! Handled by github_increment_version.py
 author = u'Tribler'
 
 # The short X.Y version
-version = '2.8'  # Do not change manually! Handled by github_increment_version.py
+version = '2.9'  # Do not change manually! Handled by github_increment_version.py
 # The full version, including alpha/beta/rc tags
-release = '2.8.0'  # Do not change manually! Handled by github_increment_version.py
+release = '2.9.0'  # Do not change manually! Handled by github_increment_version.py
 
 
 # -- General configuration ---------------------------------------------------

--- a/ipv8/REST/rest_manager.py
+++ b/ipv8/REST/rest_manager.py
@@ -84,7 +84,7 @@ class RESTManager:
         aiohttp_apispec = AiohttpApiSpec(
             app=self.root_endpoint.app,
             title="IPv8 REST API documentation",
-            version="v2.8",  # Do not change manually! Handled by github_increment_version.py
+            version="v2.9",  # Do not change manually! Handled by github_increment_version.py
             url="/docs/swagger.json",
             swagger_path="/docs",
         )

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     description='The Python implementation of the IPV8 library',
     long_description=long_description,
     long_description_content_type='text/markdown',
-    version='2.8.0',  # Do not change manually! Handled by github_increment_version.py
+    version='2.9.0',  # Do not change manually! Handled by github_increment_version.py
     url='https://github.com/Tribler/py-ipv8',
     package_data={'': ['*.*']},
     packages=find_packages(),


### PR DESCRIPTION
Suggested release message
---
Tag version: 2.9
Release title: IPv8 v2.9.1852 release
Body:
Includes the first 1852 commits (+43 since v2.8) for IPv8, containing:

 - Added ConfigBuilder ephemeral key shortcut
 - Added UDP broadcast bootstrap timeout
 - Added documentation on third-party serialization (and nested payloads)
 - Fixed GitHub issue template labels
 - Fixed `CommunityLauncher` and `test_loader` `super()` usage
 - Fixed `vp_compile` decorator having wrong return type
 - Fixed anonymization utils using absolute import
 - Fixed bootstrap received addresses callback not checking for cancel
 - Fixed duplicate schema in tunnel REST endpoint
 - Fixed idna Lookup Error
 - Fixed shutdown of RequestCache in tests
 - Fixed test suite crash with 0.0.0.0 subnet mask
 - Updated error when community_id is missing
 - Updated exit data rules
 - Updated issue templates for new tags
 - Updated overlay tutorial to use dataclass payloads
 - Updated retry cache for circuits
 - Updated support for different coverage versions