### PR TITLE
Fixed `create_task` in `DiscreteLoop`

### DIFF
--- a/simulation/discrete_loop.py
+++ b/simulation/discrete_loop.py
@@ -82,7 +82,7 @@ class DiscreteLoop(asyncio.AbstractEventLoop):
     def create_task(self, coro):
         async def wrapper():
             try:
-                await coro
+                return await coro
             except asyncio.CancelledError:
                 pass
             except Exception as e:


### PR DESCRIPTION
This PR:

 - Fixes an issue with the `create_task` method in the discrete event loop. Details: The wrapper inner function in `create_task` in the `DiscreteLoop` is not returning the result of the task. This causes higher-level asyncio routines that depend on this function, such as `gather` and `ensure_future`, to not correctly fire with the right result.
