### PR TITLE
Added auto PR review

### DIFF
--- a/.github/workflows/autoprreview.yml
+++ b/.github/workflows/autoprreview.yml
@@ -1,0 +1,18 @@
+name: autoprreview
+on:
+  pull_request_review:
+    types: [submitted]
+jobs:
+  build:
+  if: github.event.review.state == 'approved'
+  runs-on: ubuntu-latest
+  permissions:
+    pull-requests: write
+  steps:
+    - uses: tspascoal/get-user-teams-membership@v1
+      id: checkUserMember
+      with:
+         username: ${{ github.event.review.user.login }}
+         team: 'Tribler/core'
+    - uses: hmarr/auto-approve-action@v2
+      if: github.actor != 'github-actions' && ${{ steps.checkUserMember.outputs.isTeamMember == 'true' }}


### PR DESCRIPTION
Fixes #1100

This PR:

 - Adds a workflow to approve PRs that have been approved by `Tribler/core` members
