### PR TITLE
Added Python 3.11 support

### DIFF
--- a/ipv8/peerdiscovery/churn.py
+++ b/ipv8/peerdiscovery/churn.py
@@ -50,7 +50,7 @@ class RandomChurn(DiscoveryStrategy):
             # Find an inactive or droppable peer
             sample_size = min(len(self.overlay.network.verified_peers), self.sample_size)
             if sample_size:
-                window = sample(self.overlay.network.verified_peers, sample_size)
+                window = sample(list(self.overlay.network.verified_peers), sample_size)
 
                 for peer in window:
                     if self.should_drop(peer) and peer.address in self._pinged:


### PR DESCRIPTION
Fixes #1110

This PR:

 - Adds an `__all__` definition for `base.py` to avoid exporting newly added module-level variables.
 - Adds `TestBase` support for Python 3.11 using `unittest.IsolatedAsyncioTestCase`.
 - Fixes `RandomChurn` using `random.sample` on a `set` (only `list` is supported as of Python 3.11).
 
See original issue for implementation substantiation. Other notes:

 - `TestBase` now inherits from `unittest.IsolatedAsyncioTestCase` for all Python versions `>= 3.8` by default. However, `asynctest` is still supported up to Python 3.10 and `TestBase` subclasses can switch to `asynctest` by setting `__asynctest_compatibility_mode__` to `True`.
 - `loop` has a class scope in `asynctest`, an instance scope in `unittest`, and it needs to be retrieved upon invocation (a `property`) for Python 3.11.
 - `_callSetUp` and `_callTearDown` are overwritten to support the old `TestBase` behavior of allowing both `async def` and `def` setup and teardowns, including its own. For (only) the teardown of `TestBase`, the `asyncTearDown` is still explicitly needed.

