### PR TITLE
Automated Version Update

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -22,13 +22,13 @@
 # -- Project information -----------------------------------------------------
 
 project = u'IPv8'
-copyright = '2017-2022, Tribler'  # Do not change manually! Handled by github_increment_version.py
+copyright = '2017-2023, Tribler'  # Do not change manually! Handled by github_increment_version.py
 author = u'Tribler'
 
 # The short X.Y version
-version = '2.9'  # Do not change manually! Handled by github_increment_version.py
+version = '2.10'  # Do not change manually! Handled by github_increment_version.py
 # The full version, including alpha/beta/rc tags
-release = '2.9.0'  # Do not change manually! Handled by github_increment_version.py
+release = '2.10.0'  # Do not change manually! Handled by github_increment_version.py
 
 
 # -- General configuration ---------------------------------------------------

--- a/ipv8/REST/rest_manager.py
+++ b/ipv8/REST/rest_manager.py
@@ -84,7 +84,7 @@ class RESTManager:
         aiohttp_apispec = AiohttpApiSpec(
             app=self.root_endpoint.app,
             title="IPv8 REST API documentation",
-            version="v2.9",  # Do not change manually! Handled by github_increment_version.py
+            version="v2.10",  # Do not change manually! Handled by github_increment_version.py
             url="/docs/swagger.json",
             swagger_path="/docs",
         )

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     description='The Python implementation of the IPV8 library',
     long_description=long_description,
     long_description_content_type='text/markdown',
-    version='2.9.0',  # Do not change manually! Handled by github_increment_version.py
+    version='2.10.0',  # Do not change manually! Handled by github_increment_version.py
     url='https://github.com/Tribler/py-ipv8',
     package_data={'': ['*.*']},
     packages=find_packages(),


### PR DESCRIPTION
Suggested release message
---
Tag version: 2.10
Release title: IPv8 v2.10.1870 release
Body:
Includes the first 1870 commits (+18 since v2.9) for IPv8, containing:

 - Added Python 3.11 support
 - Added TestBase 'received by' assertion logic
 - Added advanced discovery docs
 - Added auto PR review
 - Fixed `create_task` in `DiscreteLoop`
 - Removed autoprreview.yml
 - Updated project age in README
 - Updated supported Python versions in `setup.py`