### PR TITLE
Set conditional markers for asynctest requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
-cryptography>=2.3dev1
-libnacl>=1.6.1
+cryptography
+libnacl
 netifaces
 aiohttp
 aiohttp_apispec
 pyOpenSSL
 pyasn1
-asynctest
+asynctest; python_version=='3.7'
 marshmallow

--- a/setup.py
+++ b/setup.py
@@ -24,11 +24,10 @@ setup(
         "marshmallow"
     ],
     extras_require={
-        'netifaces': ["netifaces"],
-        'asynctest': ["asynctest"],
-        'coverage': ["coverage"]
+        "all": ["asynctest; python_version=='3.7'", "coverage", "netifaces"],
+        "tests": ["asynctest; python_version=='3.7'", "coverage"],
+        "ifdiscovery": ["netifaces"]
     },
-    tests_require=['coverage', 'asynctest'],
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",


### PR DESCRIPTION
Fixes #1122

This PR:

 - Fixes `setup.py` test extras entry, now included in the `extras_require` dict.
 - Updates the `asynctest` requirement to only install for Python 3.7.
 - Removes the minimum version for `cryptography` and `libnacl` ([the specified versions are wrong](https://github.com/Tribler/py-ipv8/issues/1084)).

Pip output on Python 3.8 (note that a local install doesn't explicitly state that it ignores `asynctest`):

[requirements install]
```cmd
\py-ipv8> python -m pip install -r requirements.txt --dry-run
Ignoring asynctest: markers 'python_version == "3.7"' don't match your environment
 ...
```

[local install]
```cmd
\py-ipv8> python -m pip install .[all] --dry-run
 ...
 >> long list of packages that doesn't include asynctest 
 ...
```