### PR TITLE
Fix discovery cache creation

### DIFF
--- a/ipv8/peerdiscovery/network.py
+++ b/ipv8/peerdiscovery/network.py
@@ -274,7 +274,6 @@ class Network(object):
         """
         with self.graph_lock:
             self._all_addresses.pop(address, None)
-            self.reverse_service_lookup.pop(address, None)
             # Note that the services_per_peer will never be 0, we abuse the lazy `or` to pop the peers from
             # the services_per_peer mapping if they are no longer included. This is fast.
             self.verified_peers = {peer for peer in self.verified_peers
@@ -290,7 +289,6 @@ class Network(object):
         with self.graph_lock:
             for address in peer.addresses.values():
                 self._all_addresses.pop(address, None)
-                self.reverse_service_lookup.pop(address, None)
             if peer in self.verified_peers:
                 self.verified_peers.remove(peer)
             self.verified_by_public_key_bin.pop(peer.public_key.key_to_bin(), None)

--- a/ipv8/peerdiscovery/network.py
+++ b/ipv8/peerdiscovery/network.py
@@ -110,12 +110,13 @@ class Network(object):
             else:
                 self.services_per_peer[key_material] |= set(services)
             for service in services:
-                service_cache = self.reverse_service_lookup.get(service, [])
-                # Ensure that the peer instance in the cache is the same one as in verified_peers.
-                if peer in service_cache:
-                    service_cache.remove(peer)
-                service_cache.append(self.verified_by_public_key_bin.get(key_material, peer))
-                self.reverse_service_lookup[service] = service_cache
+                service_cache = self.reverse_service_lookup.get(service, None)
+                if service_cache is not None:
+                    # Ensure that the peer instance in the cache is the same one as in verified_peers.
+                    if peer in service_cache:
+                        service_cache.remove(peer)
+                    service_cache.append(self.verified_by_public_key_bin.get(key_material, peer))
+                    self.reverse_service_lookup[service] = service_cache
 
     def add_verified_peer(self, peer: Peer) -> None:
         """


### PR DESCRIPTION
Fixes #1131

This PR:

 - Fixes `Network.discover_services()` creating new caches instead of just updating existing ones.
 - Removes calls to `Network.reverse_service_lookup.pop()` using peer addresses.
