### PR TITLE
ON HOLD: Added exit node bandwidth throttling

### DIFF
--- a/doc/further-reading/anonymization.rst
+++ b/doc/further-reading/anonymization.rst
@@ -59,7 +59,7 @@ The community can be initialized using the ``TunnelSettings`` class. This class 
 
 * *min_circuits*\ : the minimum amount of circuits to create before ``tunnels_ready()`` gives a value larger than 1.0
 * *max_circuits*\ : the maximum amount of circuits to create
-* *max_relays_or_exits*\ : the maximum amount of circuits, which are not our own, we will partake in
+* *max_joined_circuits*\ : the maximum amount of circuits, which are not our own, we will partake in
 * *max_time*\ : the time after which a circuit will be removed (for security reasons)
 * *max_time_inactive*\ : the time after which an idle circuit is removed
 * *max_traffic*\ : the amount of traffic after which a circuit will be removed (for security reasons)

--- a/ipv8/configuration.py
+++ b/ipv8/configuration.py
@@ -113,7 +113,7 @@ default = {
                 'settings': {
                     'min_circuits': 1,
                     'max_circuits': 1,
-                    'max_relays_or_exits': 100,
+                    'max_joined_circuits': 100,
                     'max_time': 10 * 60,
                     'max_time_inactive': 20,
                     'max_traffic': 250 * 1024 * 1024,

--- a/ipv8/messaging/anonymization/community.py
+++ b/ipv8/messaging/anonymization/community.py
@@ -81,6 +81,10 @@ class TunnelSettings(object):
         # Maximum number of relay_early cells that are allowed to pass a relay.
         self.max_relay_early = 8
 
+        # Maximum uploaded bytes per second for exit traffic, per exit socket (see max_joined_circuits).
+        # This value is only used when running as an exit node and ignored if this value is <=0 (i.e., unlimited).
+        self.max_exit_bps = 0
+
     @classmethod
     def from_dict(cls, d):
         result = cls()
@@ -696,7 +700,7 @@ class TunnelCommunity(Community):
 
         peer = Peer(create_payload.node_public_key, previous_node_address)
         self.request_cache.add(CreatedRequestCache(self, circuit_id, peer, peers_keys, self.settings.unstable_timeout))
-        self.exit_sockets[circuit_id] = TunnelExitSocket(circuit_id, peer, self)
+        self.exit_sockets[circuit_id] = TunnelExitSocket(circuit_id, peer, self, self.settings.max_exit_bps)
 
         candidate_list_bin = self.serializer.pack('varlenH-list', list(peers_keys.keys()))
         candidate_list_enc = self.crypto.encrypt_str(candidate_list_bin,

--- a/ipv8/test/test_configuration.py
+++ b/ipv8/test/test_configuration.py
@@ -356,7 +356,7 @@ class TestConfiguration(TestBase):
                                                   {'settings': {
                                                       'min_circuits': 1,
                                                       'max_circuits': 1,
-                                                      'max_relays_or_exits': 100,
+                                                      'max_joined_circuits': 100,
                                                       'max_time': 10 * 60,
                                                       'max_time_inactive': 20,
                                                       'max_traffic': 250 * 1024 * 1024,


### PR DESCRIPTION
Fixes #1140

This PR:

 - Adds a setting to `TunnelSettings` to limit the uploaded bytes per second per `TunnelExitSocket`. This is also reflected in the `exitnode_ipv8_only_plugin.py` script.
 - Adds a method to the `DataChecker` to keep track of bytes per second.
 - Fixes the documentation and configuration referring to `TunnelSettings.max_relays_or_exits`, which should be `TunnelSettings.max_joined_circuits`.
 - Updates the `TunnelExitSocket` to only allow a certain number of bytes per second to be "uploaded" if the `max_exit_bps` is set.

