### PR TITLE
Automated Version Update

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -26,9 +26,9 @@ copyright = '2017-2023, Tribler'  # Do not change manually! Handled by github_in
 author = u'Tribler'
 
 # The short X.Y version
-version = '2.10'  # Do not change manually! Handled by github_increment_version.py
+version = '2.11'  # Do not change manually! Handled by github_increment_version.py
 # The full version, including alpha/beta/rc tags
-release = '2.10.0'  # Do not change manually! Handled by github_increment_version.py
+release = '2.11.0'  # Do not change manually! Handled by github_increment_version.py
 
 
 # -- General configuration ---------------------------------------------------

--- a/github_increment_version.py
+++ b/github_increment_version.py
@@ -180,7 +180,7 @@ print("[3/8] Requesting GitHub username and password")
 username = input('Username: ')
 token = getpass.getpass(prompt='Token (needs public_repo access, no token? visit https://github.com/settings/tokens): ', stream=None)
 
-github = Github(token, client_id=username, client_secret=token)
+github = Github(token)
 
 # GET REPOSITORY REFERENCES
 print("[4/8] Retrieving Tribler:py-ipv8 and %s:py-ipv8" % username)

--- a/ipv8/REST/rest_manager.py
+++ b/ipv8/REST/rest_manager.py
@@ -84,7 +84,7 @@ class RESTManager:
         aiohttp_apispec = AiohttpApiSpec(
             app=self.root_endpoint.app,
             title="IPv8 REST API documentation",
-            version="v2.10",  # Do not change manually! Handled by github_increment_version.py
+            version="v2.11",  # Do not change manually! Handled by github_increment_version.py
             url="/docs/swagger.json",
             swagger_path="/docs",
         )

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     description='The Python implementation of the IPV8 library',
     long_description=long_description,
     long_description_content_type='text/markdown',
-    version='2.10.0',  # Do not change manually! Handled by github_increment_version.py
+    version='2.11.0',  # Do not change manually! Handled by github_increment_version.py
     url='https://github.com/Tribler/py-ipv8',
     package_data={'': ['*.*']},
     packages=find_packages(),


### PR DESCRIPTION
Fixes #1116

Suggested release message
---
Tag version: 2.11
Release title: IPv8 v2.11.1899 release
Body:
Includes the first 1899 commits (+29 since v2.10) for IPv8, containing:

 - Added Network PeerObservers
 - Added test for JSON serialization of config
 - Fixed MyPy issues after upgrade
 - Fixed PeriodicSimilarity sampling from set
 - Fixed circuit retry log message
 - Fixed discovery cache creation
 - Fixed truncation in verbose test results
 - Fixed vp_compile not passing default values
 - Removed `asynctest` requirement for Python > 3.7
 - Updated `IPv8` class to guard against `get_peers()`
 - Updated `run_all_tests.py` to handle segfaults
 - Updated LAN interface discovery
 - Updated Windows test runner script