### PR TITLE
Updated `MockRestIPv8` to not use real socket

### DIFF
--- a/ipv8/REST/rest_manager.py
+++ b/ipv8/REST/rest_manager.py
@@ -101,6 +101,9 @@ class RESTManager:
 
         runner = web.AppRunner(self.root_endpoint.app, access_log=None)
         await runner.setup()
+        await self.start_site(runner, host, port, ssl_context)
+
+    async def start_site(self, runner, host, port, ssl_context):
         # If localhost is used as hostname, it will randomly either use 127.0.0.1 or ::1
         self.site = web.TCPSite(runner, host, port, ssl_context=ssl_context)
         await self.site.start()


### PR DESCRIPTION
Fixes #1149

This PR:

 - Updates the `MockRestIPv8` to use `Transport` instances based on IPv8's `MockEndpoint` (circumventing real sockets).

Notes:

 - Looking at the data, this PR makes the tests **slower** instead of faster: from `608 tests in 5.55 seconds (39.29 seconds total in tests)` to `7.03 seconds (44.46 seconds total in tests)`.
