### PR TITLE
Updated IPv8 scripts to use asyncio.run

### DIFF
--- a/doc/basics/identity_tutorial_1.py
+++ b/doc/basics/identity_tutorial_1.py
@@ -1,8 +1,9 @@
-from asyncio import ensure_future, get_event_loop
+from asyncio import run
 from base64 import b64encode
 
 from pyipv8.ipv8.REST.rest_manager import RESTManager
 from pyipv8.ipv8.configuration import get_default_configuration
+from pyipv8.ipv8.util import run_forever
 from pyipv8.ipv8_service import IPv8
 
 
@@ -23,6 +24,7 @@ async def start_community():
         # Print the peer for reference
         print("Starting peer", b64encode(ipv8.keys["anonymous id"].mid))
 
+    await run_forever()
 
-ensure_future(start_community())
-get_event_loop().run_forever()
+
+run(start_community())

--- a/doc/basics/identity_tutorial_integration/main.py
+++ b/doc/basics/identity_tutorial_integration/main.py
@@ -1,8 +1,9 @@
-from asyncio import ensure_future, get_event_loop
+from asyncio import run
 from base64 import b64encode
 
 from ipv8.REST.rest_manager import RESTManager
 from ipv8.configuration import get_default_configuration
+from ipv8.util import run_forever
 
 from ipv8_service import IPv8
 
@@ -26,6 +27,7 @@ async def start_community():
         # Print the peer for reference
         print("Starting peer", b64encode(ipv8.keys["anonymous id"].mid))
 
+    await run_forever()
 
-ensure_future(start_community())
-get_event_loop().run_forever()
+
+run(start_community())

--- a/doc/basics/overlay_tutorial_1.py
+++ b/doc/basics/overlay_tutorial_1.py
@@ -1,6 +1,7 @@
-from asyncio import ensure_future, get_event_loop
+from asyncio import run
 
 from pyipv8.ipv8.configuration import get_default_configuration
+from pyipv8.ipv8.util import run_forever
 from pyipv8.ipv8_service import IPv8
 
 
@@ -9,10 +10,11 @@ async def start_ipv8():
     ipv8 = IPv8(get_default_configuration())
     await ipv8.start()
 
-# Create a task that runs an IPv8 instance.
-# The task will run as soon as the event loop has started.
-ensure_future(start_ipv8())
+    # Wait forever (or until the user presses Ctrl+C)
+    await run_forever()
 
-# Start the asyncio event loop: this is the engine scheduling all of the
-# asynchronous calls.
-get_event_loop().run_forever()
+    # Shutdown IPv8. To keep things simple, we won't stop IPv8 in the remainder of the tutorial.
+    await ipv8.stop()
+
+# Create a new event loop and run a task that starts an IPv8 instance.
+run(start_ipv8())

--- a/doc/basics/overlay_tutorial_2.py
+++ b/doc/basics/overlay_tutorial_2.py
@@ -1,6 +1,7 @@
-from asyncio import ensure_future, get_event_loop
+from asyncio import run
 
 from pyipv8.ipv8.configuration import get_default_configuration
+from pyipv8.ipv8.util import run_forever
 from pyipv8.ipv8_service import IPv8
 
 
@@ -10,7 +11,7 @@ async def start_ipv8():
     # The second IPv8 will attempt to claim a port.
     # It cannot claim the same port and will end up claiming a different one.
     await IPv8(get_default_configuration()).start()
+    await run_forever()
 
 
-ensure_future(start_ipv8())
-get_event_loop().run_forever()
+run(start_ipv8())

--- a/doc/basics/overlay_tutorial_3.py
+++ b/doc/basics/overlay_tutorial_3.py
@@ -1,9 +1,10 @@
 import os
-from asyncio import ensure_future, get_event_loop
+from asyncio import run
 
 from pyipv8.ipv8.community import Community
 from pyipv8.ipv8.configuration import (ConfigBuilder, Strategy, WalkerDefinition,
                                        default_bootstrap_defs)
+from pyipv8.ipv8.util import run_forever
 from pyipv8.ipv8_service import IPv8
 
 
@@ -34,7 +35,7 @@ async def start_communities():
                             default_bootstrap_defs, {}, [])
         await IPv8(builder.finalize(),
                    extra_communities={'MyCommunity': MyCommunity}).start()
+    await run_forever()
 
 
-ensure_future(start_communities())
-get_event_loop().run_forever()
+run(start_communities())

--- a/doc/basics/overlay_tutorial_4.py
+++ b/doc/basics/overlay_tutorial_4.py
@@ -1,11 +1,12 @@
 import os
-from asyncio import ensure_future, get_event_loop
+from asyncio import run
 
 from pyipv8.ipv8.community import Community
 from pyipv8.ipv8.configuration import (ConfigBuilder, Strategy, WalkerDefinition,
                                        default_bootstrap_defs)
 from pyipv8.ipv8.peerdiscovery.network import PeerObserver
 from pyipv8.ipv8.types import Peer
+from pyipv8.ipv8.util import run_forever
 from pyipv8.ipv8_service import IPv8
 
 
@@ -35,7 +36,7 @@ async def start_communities():
                             default_bootstrap_defs, {}, [('started',)])
         await IPv8(builder.finalize(),
                    extra_communities={'MyCommunity': MyCommunity}).start()
+    await run_forever()
 
 
-ensure_future(start_communities())
-get_event_loop().run_forever()
+run(start_communities())

--- a/doc/basics/overlay_tutorial_5.py
+++ b/doc/basics/overlay_tutorial_5.py
@@ -1,5 +1,5 @@
 import os
-from asyncio import ensure_future, get_event_loop
+from asyncio import run
 from dataclasses import dataclass
 
 from pyipv8.ipv8.community import Community
@@ -7,6 +7,7 @@ from pyipv8.ipv8.configuration import (ConfigBuilder, Strategy, WalkerDefinition
                                        default_bootstrap_defs)
 from pyipv8.ipv8.lazy_community import lazy_wrapper
 from pyipv8.ipv8.messaging.payload_dataclass import overwrite_dataclass
+from pyipv8.ipv8.util import run_forever
 from pyipv8.ipv8_service import IPv8
 
 # Enhance normal dataclasses for IPv8 (see the serialization documentation)
@@ -63,7 +64,7 @@ async def start_communities():
                             default_bootstrap_defs, {}, [('started',)])
         await IPv8(builder.finalize(),
                    extra_communities={'MyCommunity': MyCommunity}).start()
+    await run_forever()
 
 
-ensure_future(start_communities())
-get_event_loop().run_forever()
+run(start_communities())

--- a/doc/basics/requestcache_tutorial_1.py
+++ b/doc/basics/requestcache_tutorial_1.py
@@ -1,10 +1,6 @@
-from asyncio import ensure_future, get_event_loop, sleep
+from asyncio import create_task, run, sleep
 
 from pyipv8.ipv8.requestcache import NumberCache, RequestCache
-
-# We store the RequestCache in this global variable.
-# Normally, you would add this to a network overlay instance.
-REQUEST_CACHE = RequestCache()
 
 
 class MyState(NumberCache):
@@ -14,13 +10,13 @@ class MyState(NumberCache):
         self.state = state
 
 
-async def foo():
+async def foo(request_cache):
     """
     Add a new MyState cache to the global request cache.
     The state variable is set to 42 and the identifier of this cache is 0.
     """
-    cache = MyState(REQUEST_CACHE, 0, 42)
-    REQUEST_CACHE.add(cache)
+    cache = MyState(request_cache, 0, 42)
+    request_cache.add(cache)
 
 
 async def bar():
@@ -28,13 +24,15 @@ async def bar():
     Wait until a MyState cache with identifier 0 is added.
     Then, remove this cache from the global request cache and print its state.
     """
-    while not REQUEST_CACHE.has("my-state", 0):
+    # Normally, you would add this to a network overlay instance.
+    request_cache = RequestCache()
+
+    create_task(foo(request_cache))
+
+    while not request_cache.has("my-state", 0):
         await sleep(0.1)
-    cache = REQUEST_CACHE.pop("my-state", 0)
+    cache = request_cache.pop("my-state", 0)
     print("I found a cache with the state:", cache.state)
-    get_event_loop().stop()
 
 
-ensure_future(foo())
-ensure_future(bar())
-get_event_loop().run_forever()
+run(bar())

--- a/doc/basics/requestcache_tutorial_2.py
+++ b/doc/basics/requestcache_tutorial_2.py
@@ -1,8 +1,6 @@
-from asyncio import ensure_future, get_event_loop
+from asyncio import run, sleep
 
 from pyipv8.ipv8.requestcache import NumberCache, RequestCache
-
-REQUEST_CACHE = RequestCache()
 
 
 class MyState(NumberCache):
@@ -13,7 +11,6 @@ class MyState(NumberCache):
 
     def on_timeout(self):
         print("Oh no! I never received a response!")
-        get_event_loop().stop()
 
     @property
     def timeout_delay(self):
@@ -22,9 +19,10 @@ class MyState(NumberCache):
 
 
 async def foo():
-    cache = MyState(REQUEST_CACHE, 0, 42)
-    REQUEST_CACHE.add(cache)
+    request_cache = RequestCache()
+    cache = MyState(request_cache, 0, 42)
+    request_cache.add(cache)
+    await sleep(4)
 
 
-ensure_future(foo())
-get_event_loop().run_forever()
+run(foo())

--- a/doc/basics/requestcache_tutorial_3.py
+++ b/doc/basics/requestcache_tutorial_3.py
@@ -1,5 +1,5 @@
 import os
-from asyncio import ensure_future, get_event_loop, sleep
+from asyncio import run, sleep
 
 from pyipv8.ipv8.community import Community
 from pyipv8.ipv8.configuration import ConfigBuilder, Strategy, WalkerDefinition, default_bootstrap_defs
@@ -79,8 +79,6 @@ class MyCommunity(Community):
         # Stop the experiment if both peers reach a value of 10.
         if payload.value == 10:
             DONE.append(True)
-            if len(DONE) == 2:
-                get_event_loop().stop()
             return
 
         # Otherwise, do the same thing over again and ask for another increment.
@@ -101,6 +99,8 @@ async def start_communities():
                             default_bootstrap_defs, {}, [('started',)])
         await IPv8(builder.finalize(), extra_communities={'MyCommunity': MyCommunity}).start()
 
+    while len(DONE) < 2:
+        await sleep(1)
 
-ensure_future(start_communities())
-get_event_loop().run_forever()
+
+run(start_communities())

--- a/doc/basics/tasks_tutorial_3.py
+++ b/doc/basics/tasks_tutorial_3.py
@@ -19,8 +19,6 @@ async def main():
     await task_manager.wait_for_tasks()
 
     await task_manager.shutdown_task_manager()
-    print(COMPLETED)
-    asyncio.get_event_loop().stop()
 
-asyncio.ensure_future(main())
-asyncio.get_event_loop().run_forever()
+asyncio.run(main())
+print(COMPLETED)

--- a/doc/basics/tasks_tutorial_4.py
+++ b/doc/basics/tasks_tutorial_4.py
@@ -19,8 +19,6 @@ async def main():
     await task_manager.wait_for_tasks()
 
     await task_manager.shutdown_task_manager()
-    print(COMPLETED)
-    asyncio.get_event_loop().stop()
 
-asyncio.ensure_future(main())
-asyncio.get_event_loop().run_forever()
+asyncio.run(main())
+print(COMPLETED)

--- a/doc/basics/tasks_tutorial_5.py
+++ b/doc/basics/tasks_tutorial_5.py
@@ -22,8 +22,6 @@ async def main():
     await task_manager.wait_for_tasks()
 
     await task_manager.shutdown_task_manager()
-    print(COMPLETED)
-    asyncio.get_event_loop().stop()
 
-asyncio.ensure_future(main())
-asyncio.get_event_loop().run_forever()
+asyncio.run(main())
+print(COMPLETED)

--- a/doc/deprecated/attestation_tutorial_1.py
+++ b/doc/deprecated/attestation_tutorial_1.py
@@ -1,8 +1,9 @@
-from asyncio import ensure_future, get_event_loop
+from asyncio import run
 from base64 import b64encode
 
 from pyipv8.ipv8.REST.rest_manager import RESTManager
 from pyipv8.ipv8.configuration import get_default_configuration
+from pyipv8.ipv8.util import run_forever
 from pyipv8.ipv8_service import IPv8
 
 
@@ -39,6 +40,7 @@ async def start_communities():
         # Print the peer for reference
         print("Starting peer", b64encode(ipv8.keys["anonymous id"].mid))
 
+    await run_forever()
 
-ensure_future(start_communities())
-get_event_loop().run_forever()
+
+run(start_communities())

--- a/doc/deprecated/attestation_tutorial_integration/main.py
+++ b/doc/deprecated/attestation_tutorial_integration/main.py
@@ -1,4 +1,4 @@
-from asyncio import ensure_future, get_event_loop
+from asyncio import run
 from base64 import b64encode
 from binascii import unhexlify
 from sys import argv
@@ -8,6 +8,7 @@ from ipv8.attestation.identity.community import IdentityCommunity
 from ipv8.attestation.wallet.community import AttestationCommunity
 from ipv8.configuration import DISPERSY_BOOTSTRAPPER, get_default_configuration
 from ipv8.peerdiscovery.community import DiscoveryCommunity
+from ipv8.util import run_forever
 
 from ipv8_service import IPv8
 
@@ -114,6 +115,7 @@ async def start_communities():
         # Print the peer for reference
         print("Starting peer", b64encode(ipv8.keys["anonymous id"].mid))
 
+    await run_forever()
 
-ensure_future(start_communities())
-get_event_loop().run_forever()
+
+run(start_communities())

--- a/doc/further-reading/advanced_identity_1.py
+++ b/doc/further-reading/advanced_identity_1.py
@@ -1,8 +1,9 @@
-from asyncio import ensure_future, get_event_loop
+from asyncio import run
 from base64 import b64encode
 
 from pyipv8.ipv8.REST.rest_manager import RESTManager
 from pyipv8.ipv8.configuration import get_default_configuration
+from pyipv8.ipv8.util import run_forever
 from pyipv8.ipv8_service import IPv8
 
 
@@ -24,6 +25,7 @@ async def start_community():
         # Print the peer for reference
         print("Starting peer", b64encode(ipv8.keys["anonymous id"].mid))
 
+    await run_forever()
 
-ensure_future(start_community())
-get_event_loop().run_forever()
+
+run(start_community())

--- a/doc/further-reading/advanced_identity_2.py
+++ b/doc/further-reading/advanced_identity_2.py
@@ -1,11 +1,12 @@
 import os
 import ssl
 import sys
-from asyncio import ensure_future, get_event_loop
+from asyncio import run
 from base64 import b64encode
 
 from pyipv8.ipv8.REST.rest_manager import RESTManager
 from pyipv8.ipv8.configuration import get_default_configuration
+from pyipv8.ipv8.util import run_forever
 from pyipv8.ipv8_service import IPv8
 
 
@@ -33,6 +34,7 @@ async def start_community():
         # Print the peer for reference
         print("Starting peer", b64encode(ipv8.keys["anonymous id"].mid))
 
+    await run_forever()
 
-ensure_future(start_community())
-get_event_loop().run_forever()
+
+run(start_community())

--- a/doc/reference/serialization_6.py
+++ b/doc/reference/serialization_6.py
@@ -1,7 +1,7 @@
 from binascii import hexlify, unhexlify
 import json
 import os
-from asyncio import ensure_future, get_event_loop
+from asyncio import Event, run
 
 from pyipv8.ipv8.community import Community
 from pyipv8.ipv8.configuration import ConfigBuilder, Strategy, WalkerDefinition, default_bootstrap_defs
@@ -13,6 +13,7 @@ class MyCommunity(Community):
 
     def __init__(self, my_peer, endpoint, network):
         super().__init__(my_peer, endpoint, network)
+        self.event = None
         self.add_message_handler(1, self.on_message)
 
     def send_message(self, peer):
@@ -36,9 +37,12 @@ class MyCommunity(Community):
         self.logger.info(f"Received message {received['message']} from {source_address},"
                          f"the signature is {valid}!")
 
-        get_event_loop().stop()
+        if self.event:
+            self.event.set()
 
-    def started(self, peer_id):
+    def started(self, event, peer_id):
+        self.event = event
+
         async def send_message():
             for p in self.get_peers():
                 self.send_message(p)
@@ -48,14 +52,17 @@ class MyCommunity(Community):
 
 
 async def start_communities():
+    event = Event()
+
     for i in [1, 2]:
         builder = ConfigBuilder().clear_keys().clear_overlays()
         builder.add_key("my peer", "medium", f"ec{i}.pem")
         builder.add_overlay("MyCommunity", "my peer", [WalkerDefinition(Strategy.RandomWalk, 10, {'timeout': 3.0})],
-                            default_bootstrap_defs, {}, [("started", i)])
+                            default_bootstrap_defs, {}, [("started", event, i)])
         ipv8 = IPv8(builder.finalize(), extra_communities={'MyCommunity': MyCommunity})
         await ipv8.start()
 
+    await event.wait()
 
-ensure_future(start_communities())
-get_event_loop().run_forever()
+
+run(start_communities())

--- a/doc/simulation/simulation_tutorial_1.py
+++ b/doc/simulation/simulation_tutorial_1.py
@@ -1,12 +1,12 @@
 import os
-from asyncio import get_running_loop, run, set_event_loop, sleep
+from asyncio import get_running_loop, run, set_event_loop_policy, sleep
 
 from pyipv8.ipv8.community import Community
 from pyipv8.ipv8.configuration import ConfigBuilder
 from pyipv8.ipv8.lazy_community import lazy_wrapper
 from pyipv8.ipv8.messaging.lazy_payload import VariablePayload, vp_compile
 from pyipv8.ipv8_service import IPv8
-from pyipv8.simulation.discrete_loop import DiscreteLoop
+from pyipv8.simulation.discrete_loop import DiscreteEventLoopPolicy
 from pyipv8.simulation.simulation_endpoint import SimulationEndpoint
 
 
@@ -74,7 +74,5 @@ async def start_communities():
 
 
 # We use a discrete event loop to enable quick simulations.
-loop = DiscreteLoop()
-set_event_loop(loop)
-
+set_event_loop_policy(DiscreteEventLoopPolicy())
 run(start_communities())

--- a/doc/simulation/simulation_tutorial_2.py
+++ b/doc/simulation/simulation_tutorial_2.py
@@ -1,11 +1,11 @@
 import os
-from asyncio import run, set_event_loop, sleep
+from asyncio import run, set_event_loop_policy, sleep
 
 from pyipv8.ipv8.community import Community
 from pyipv8.ipv8.configuration import Bootstrapper, BootstrapperDefinition, ConfigBuilder, Strategy, WalkerDefinition
 from pyipv8.ipv8_service import IPv8
 from pyipv8.scripts.tracker_service import EndpointServer
-from pyipv8.simulation.discrete_loop import DiscreteLoop
+from pyipv8.simulation.discrete_loop import DiscreteEventLoopPolicy
 from pyipv8.simulation.simulation_endpoint import SimulationEndpoint
 
 
@@ -60,7 +60,5 @@ async def start_communities():
 
 
 # We use a discrete event loop to enable quick simulations.
-loop = DiscreteLoop()
-set_event_loop(loop)
-
+set_event_loop_policy(DiscreteEventLoopPolicy())
 run(start_communities())

--- a/doc/simulation/simulation_tutorial_2.py
+++ b/doc/simulation/simulation_tutorial_2.py
@@ -1,5 +1,5 @@
 import os
-from asyncio import ensure_future, get_event_loop, set_event_loop, sleep
+from asyncio import run, set_event_loop, sleep
 
 from pyipv8.ipv8.community import Community
 from pyipv8.ipv8.configuration import Bootstrapper, BootstrapperDefinition, ConfigBuilder, Strategy, WalkerDefinition
@@ -56,16 +56,11 @@ async def start_communities():
         await instance.start()
         instances.append(instance)
 
-
-async def run_simulation():
-    await start_communities()
     await sleep(120)
-    get_event_loop().stop()
+
 
 # We use a discrete event loop to enable quick simulations.
 loop = DiscreteLoop()
 set_event_loop(loop)
 
-ensure_future(run_simulation())
-
-loop.run_forever()
+run(start_communities())

--- a/ipv8/REST/asyncio_endpoint.py
+++ b/ipv8/REST/asyncio_endpoint.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import collections
 import logging
 import time
-from asyncio import all_tasks, current_task, get_event_loop
+from asyncio import all_tasks, current_task, get_running_loop
 from typing import TYPE_CHECKING, Iterable, cast
 
 from aiohttp import web
@@ -237,7 +237,7 @@ class AsyncioEndpoint(BaseEndpoint[IPv8]):
         if 'enable' not in parameters and 'slow_callback_duration' not in parameters:
             return Response({"success": False, "error": "incorrect parameters"}, status=HTTP_BAD_REQUEST)
 
-        loop = get_event_loop()
+        loop = get_running_loop()
         loop.slow_callback_duration = parameters.get('slow_callback_duration', loop.slow_callback_duration)
 
         if 'enable' in parameters:
@@ -275,7 +275,7 @@ class AsyncioEndpoint(BaseEndpoint[IPv8]):
         """
         Return Asyncio log messages.
         """
-        loop = get_event_loop()
+        loop = get_running_loop()
         messages = cast(Iterable, self.asyncio_log_handler.deque) if self.asyncio_log_handler is not None else []
         return Response({'messages': [{'message': r} for r in messages],
                          'enable': loop.get_debug(),

--- a/ipv8/bootstrapping/udpbroadcast/bootstrapper.py
+++ b/ipv8/bootstrapping/udpbroadcast/bootstrapper.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from asyncio import BaseTransport, DatagramProtocol, get_event_loop
+from asyncio import BaseTransport, DatagramProtocol, get_running_loop
 from binascii import hexlify
 from socket import AF_INET, SO_BROADCAST, SO_REUSEADDR, SOCK_DGRAM, SOL_SOCKET, socket
 from time import time
@@ -41,7 +41,7 @@ class BroadcastBootstrapEndpoint(DatagramProtocol):
         """
         Open the broadcast socket.
         """
-        loop = get_event_loop()
+        loop = get_running_loop()
 
         try:
             self._socket = socket(AF_INET, SOCK_DGRAM)

--- a/ipv8/messaging/anonymization/tunnel.py
+++ b/ipv8/messaging/anonymization/tunnel.py
@@ -5,7 +5,7 @@ import logging
 import socket
 import sys
 import time
-from asyncio import CancelledError, DatagramProtocol, DatagramTransport, Future, ensure_future, gather, get_event_loop
+from asyncio import CancelledError, DatagramProtocol, DatagramTransport, Future, ensure_future, gather, get_running_loop
 from binascii import hexlify
 from collections import deque
 from struct import unpack_from
@@ -201,7 +201,7 @@ class TunnelExitSocket(Tunnel[Peer], DatagramProtocol, TaskManager):
             self.enabled = True
 
             async def create_transport() -> None:
-                self.transport, _ = await get_event_loop().create_datagram_endpoint(lambda: self,
+                self.transport, _ = await get_running_loop().create_datagram_endpoint(lambda: self,
                                                                                     local_addr=('0.0.0.0', 0))
                 # Send any packets that have been waiting while the transport was being created
                 while self.queue:
@@ -248,7 +248,7 @@ class TunnelExitSocket(Tunnel[Peer], DatagramProtocol, TaskManager):
         Using asyncio's getaddrinfo since the aiodns resolver seems to have issues.
         Returns [(family, type, proto, canonname, sockaddr)].
         """
-        infos = await get_event_loop().getaddrinfo(host, 0, family=socket.AF_INET)
+        infos = await get_running_loop().getaddrinfo(host, 0, family=socket.AF_INET)
         return infos[0][-1][0]
 
     def datagram_received(self, data: bytes, source: Address) -> None:

--- a/ipv8/messaging/interfaces/udp/endpoint.py
+++ b/ipv8/messaging/interfaces/udp/endpoint.py
@@ -113,7 +113,7 @@ class UDPEndpoint(Endpoint, asyncio.DatagramProtocol):
         if self._running:
             return True
 
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
 
         for _ in range(10000):
             try:

--- a/ipv8/test/base.py
+++ b/ipv8/test/base.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import inspect
-import logging
 import os
 import shutil
 import sys
@@ -9,7 +8,7 @@ import threading
 import time
 import unittest
 import uuid
-from asyncio import AbstractEventLoop, Task, all_tasks, ensure_future, get_event_loop, iscoroutine, sleep
+from asyncio import AbstractEventLoop, Task, all_tasks, ensure_future, get_running_loop, iscoroutine, sleep
 from contextlib import contextmanager
 from functools import partial
 from typing import TYPE_CHECKING, Callable, Coroutine, Type, cast
@@ -24,12 +23,6 @@ from .mocking.ipv8 import MockIPv8
 if TYPE_CHECKING:
     from ..peerdiscovery.network import Network
     from ..types import Address, Endpoint, Overlay, PrivateKey, PublicKey
-
-try:
-    get_event_loop().set_debug(True)
-except RuntimeError:
-    logging.warning("Failed to set debug mode on the main event loop! "
-                    "You may be missing out on asyncio output!")
 
 
 def _on_packet_fragile_cb(self: Community, packet: tuple[Address, bytes], warn_unknown: bool = True) -> None:
@@ -313,7 +306,7 @@ class TestBase(TestCaseClass):
                             print("|", line[:-1].replace('\n', '\n|   '), file=sys.stderr)  # noqa: T201
 
                 try:
-                    tasks = all_tasks(get_event_loop())
+                    tasks = all_tasks(get_running_loop())
                     if tasks:
                         print("Pending tasks:")  # noqa: T201
                         for task in tasks:

--- a/ipv8/test/mocking/endpoint.py
+++ b/ipv8/test/mocking/endpoint.py
@@ -1,5 +1,5 @@
 import random
-from asyncio import get_event_loop
+from asyncio import get_running_loop
 
 from ...messaging.interfaces.endpoint import Endpoint, EndpointListener
 from ...messaging.interfaces.udp.endpoint import UDPv4Address, UDPv6Address
@@ -50,11 +50,11 @@ class MockEndpoint(Endpoint):
         if socket_address in internet:
             # For the unit tests we handle messages in separate asyncio tasks to prevent infinite recursion.
             ep = internet[socket_address]
-            get_event_loop().call_soon(ep.notify_listeners, (self.wan_address, packet))
+            get_running_loop().call_soon(ep.notify_listeners, (self.wan_address, packet))
         else:
             e = AssertionError("Attempted to send data to unregistered address %s" % repr(socket_address))
             if self.SEND_INET_EXCEPTION_TO_LOOP:
-                get_event_loop().create_task(crash_event_loop(e))
+                get_running_loop().create_task(crash_event_loop(e))
             raise e
 
     def open(self):

--- a/ipv8/test/test_taskmanager.py
+++ b/ipv8/test/test_taskmanager.py
@@ -1,4 +1,4 @@
-from asyncio import Future, ensure_future, get_event_loop, sleep
+from asyncio import Future, ensure_future, get_running_loop, sleep
 from contextlib import suppress
 
 from .base import TestBase
@@ -118,7 +118,7 @@ class TestTaskManager(TestBase):
             exception_handler.called = True
         exception_handler.called = False
 
-        get_event_loop().set_exception_handler(exception_handler)
+        get_running_loop().set_exception_handler(exception_handler)
         with suppress(ZeroDivisionError):
             await self.tm.register_task('test', lambda: 1 / 0)
         self.assertTrue(exception_handler.called)
@@ -128,7 +128,7 @@ class TestTaskManager(TestBase):
             exception_handler.called = True
         exception_handler.called = False
 
-        get_event_loop().set_exception_handler(exception_handler)
+        get_running_loop().set_exception_handler(exception_handler)
         with suppress(ZeroDivisionError):
             await self.tm.register_task('test', lambda: 1 / 0, ignore=(ZeroDivisionError,))
         self.assertFalse(exception_handler.called)

--- a/ipv8_service.py
+++ b/ipv8_service.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 import sys
 import time
-from asyncio import CancelledError, Future, ensure_future, gather, get_event_loop, sleep
+from asyncio import CancelledError, Future, ensure_future, gather, sleep
 from base64 import b64decode
 from contextlib import suppress
 from os.path import isfile
@@ -242,7 +242,7 @@ else:
             await base_endpoint.open()
             return TunnelEndpoint(base_endpoint)
 
-        async def stop(self, stop_loop: bool = True) -> None:
+        async def stop(self) -> None:
             """
             Stop all registered IPv8 strategies, unload all registered overlays and close the endpoint.
             """
@@ -254,9 +254,6 @@ else:
                 unload_list = [self.unload_overlay(overlay) for overlay in self.overlays[:]]
                 await gather(*unload_list)
                 self.endpoint.close()
-            if stop_loop:
-                loop = get_event_loop()
-                loop.call_later(0, loop.stop)
 
 
 if __name__ == '__main__':

--- a/simulation/discrete_loop.py
+++ b/simulation/discrete_loop.py
@@ -41,7 +41,19 @@ class DiscreteLoop(asyncio.AbstractEventLoop):
                 raise self._exc
 
     def run_until_complete(self, future):
-        raise NotImplementedError
+        future = asyncio.tasks.ensure_future(future, loop=self)
+        future.add_done_callback(lambda _: self.stop())
+        self.run_forever()
+        return future.result()
+
+    async def shutdown_asyncgens(self):
+        pass
+
+    async def shutdown_default_executor(self, timeout=None):
+        pass
+
+    def set_debug(self, _):
+        pass
 
     def _timer_handle_cancelled(self, handle):
         pass
@@ -92,3 +104,8 @@ class DiscreteLoop(asyncio.AbstractEventLoop):
 
     def create_future(self):
         return asyncio.Future(loop=self)
+
+
+class DiscreteEventLoopPolicy(asyncio.events.BaseDefaultEventLoopPolicy):
+    def _loop_factory(self):
+        return DiscreteLoop()

--- a/simulation/simulation_endpoint.py
+++ b/simulation/simulation_endpoint.py
@@ -1,4 +1,4 @@
-from asyncio import get_event_loop
+from asyncio import get_running_loop
 from collections import defaultdict
 
 from ipv8.test.mocking.endpoint import AutoMockEndpoint
@@ -26,5 +26,5 @@ class SimulationEndpoint(AutoMockEndpoint):
         return self.latencies[to_address]
 
     def send(self, socket_address, packet):
-        get_event_loop().call_later(self.get_link_latency(socket_address), super().send,
-                                    socket_address, packet)
+        get_running_loop().call_later(self.get_link_latency(socket_address), super().send,
+                                      socket_address, packet)

--- a/stresstest/bootstrap_rtt.py
+++ b/stresstest/bootstrap_rtt.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import os
 import time
-from asyncio import ensure_future, get_event_loop
+from asyncio import run
 from random import randint
 from socket import gethostbyname
 from typing import TYPE_CHECKING, cast
@@ -20,6 +20,7 @@ from ipv8.community import Community  # noqa: I001
 from ipv8.configuration import DISPERSY_BOOTSTRAPPER, get_default_configuration
 from ipv8.messaging.interfaces.udp.endpoint import UDPv4Address
 from ipv8.requestcache import NumberCache, RequestCache
+from ipv8.util import create_event_with_signals
 
 from ipv8_service import IPv8, _COMMUNITIES
 
@@ -28,7 +29,7 @@ if TYPE_CHECKING:
     from ipv8.messaging.payload_headers import GlobalTimeDistributionPayload
     from ipv8.types import Address, Peer
 
-INSTANCES = []
+CHECK_QUEUE = []
 RESULTS = {}
 
 CONST_REQUESTS = 10
@@ -46,6 +47,7 @@ class MyCommunity(Community):
         Create a new measuring Community.
         """
         super().__init__(*args, **kwargs)
+        self.event = None
         self.request_cache = RequestCache()
         self.check_queue = []
 
@@ -81,8 +83,8 @@ class MyCommunity(Community):
             packet = self.create_introduction_request(UDPv4Address(*address))
             self.request_cache.add(PingCache(self, hostname, address, time.time()))
             self.endpoint.send(address, packet)
-        else:
-            get_event_loop().stop()
+        elif self.event:
+            self.event.set()
 
     def introduction_response_callback(self,
                                        peer: Peer,
@@ -95,10 +97,14 @@ class MyCommunity(Community):
             cache = self.request_cache.pop("introping", payload.identifier)
             self.finish_ping(cast(PingCache, cache))
 
-    def started(self) -> None:
+    def started(self, event: Event) -> None:
         """
         Perform DNS name resolution and start sending pings.
         """
+        global CHECK_QUEUE
+
+        self.event = event
+
         dnsmap = {}
         for (address, port) in DISPERSY_BOOTSTRAPPER['init']['dns_addresses']:
             try:
@@ -157,6 +163,7 @@ async def start_communities() -> None:
     """
     Start an IPv8 instance for our measuring Community.
     """
+    event = create_event_with_signals()
     configuration = get_default_configuration()
     configuration['keys'] = [{
         'alias': "my peer",
@@ -170,15 +177,15 @@ async def start_communities() -> None:
         'walkers': [],
         'bootstrappers': [DISPERSY_BOOTSTRAPPER],
         'initialize': {},
-        'on_start': [('started', )]
+        'on_start': [('started', event)]
     }]
     ipv8_instance = IPv8(configuration)
     await ipv8_instance.start()
-    INSTANCES.append(ipv8_instance)
+    await event.wait()
+    await ipv8_instance.stop()
 
 
-ensure_future(start_communities())  # noqa: RUF006
-get_event_loop().run_forever()
+run(start_communities())
 
 with open('summary.txt', 'w') as f:
     f.write('HOST_NAME ADDRESS REQUESTS RESPONSES')


### PR DESCRIPTION
Fixes https://github.com/Tribler/py-ipv8/issues/1152.

This PR:
* Adds the `run_forever` function to util.py that allows for the event loop to stay running when using `asyncio.run`
* Removes the `stop_loop` paramater from `IPv8.stop`
* Updates the codebase to stop using `loop.run_forever`/`loop.stop` and rely on `asyncio.run` instead
* Ensures IPv8 is shutdown properly, with the exception of the example code from the docs
* Adds `DiscreteEventLoopPolicy` and `DiscreteLoop.run_until_complete` in order to be able to use `asyncio.run` during the simulations as well

