### PR TITLE
Updated overlay basics doc to use PeerObserver

### DIFF
--- a/doc/basics/overlay_tutorial.rst
+++ b/doc/basics/overlay_tutorial.rst
@@ -78,7 +78,7 @@ Printing the known peers
 ------------------------
 
 Like every DHT-based network overlay framework, IPv8 needs some time to find peers.
-We will now modify ``main.py`` again to print the current amount of peers:
+We will now modify ``main.py`` again to print the current number of peers:
 
 .. literalinclude:: overlay_tutorial_4.py
 
@@ -87,14 +87,8 @@ Running this should yield something like the following output:
 .. code-block:: bash
 
    $ python main.py 
-   I am: Peer<0.0.0.0:0, /zWXEA/4wFeGEKTZ8fckwUwLk3Y=> 
-   I know: []
-   I am: Peer<0.0.0.0:0, VVsH+LxamOUVUkV/5rjemqYMO8w=> 
-   I know: []
-   I am: Peer<0.0.0.0:0, /zWXEA/4wFeGEKTZ8fckwUwLk3Y=> 
-   I know: ['Peer<10.0.2.15:8091, VVsH+LxamOUVUkV/5rjemqYMO8w=>']
-   I am: Peer<0.0.0.0:0, VVsH+LxamOUVUkV/5rjemqYMO8w=> 
-   I know: ['Peer<10.0.2.15:8090, /zWXEA/4wFeGEKTZ8fckwUwLk3Y=>']
+   I am: Peer<0.0.0.0:0:8090, dxGFpQ4awTMz826HOVCB5OoiPPI=> I found: Peer<0.0.0.0:0:8091, YfHrKJR4O72/k/FBYYxMIQwOb1U=>
+   I am: Peer<0.0.0.0:0:8091, YfHrKJR4O72/k/FBYYxMIQwOb1U=> I found: Peer<0.0.0.0:0:8090, dxGFpQ4awTMz826HOVCB5OoiPPI=>
 
 .. warning::
    You should never use the ``address`` of a ``Peer`` as its identifier.

--- a/doc/basics/overlay_tutorial_3.py
+++ b/doc/basics/overlay_tutorial_3.py
@@ -2,7 +2,8 @@ import os
 from asyncio import ensure_future, get_event_loop
 
 from pyipv8.ipv8.community import Community
-from pyipv8.ipv8.configuration import ConfigBuilder, Strategy, WalkerDefinition, default_bootstrap_defs
+from pyipv8.ipv8.configuration import (ConfigBuilder, Strategy, WalkerDefinition,
+                                       default_bootstrap_defs)
 from pyipv8.ipv8_service import IPv8
 
 
@@ -27,10 +28,12 @@ async def start_communities():
         # RandomWalk strategy, until we find 10 peers.
         # We do not provide additional startup arguments or a function to run
         # once the overlay has been initialized.
-        builder.add_overlay("MyCommunity", "my peer", [WalkerDefinition(Strategy.RandomWalk, 10, {'timeout': 3.0})],
+        builder.add_overlay("MyCommunity", "my peer",
+                            [WalkerDefinition(Strategy.RandomWalk,
+                                              10, {'timeout': 3.0})],
                             default_bootstrap_defs, {}, [])
-        ipv8 = IPv8(builder.finalize(), extra_communities={'MyCommunity': MyCommunity})
-        await ipv8.start()
+        await IPv8(builder.finalize(),
+                   extra_communities={'MyCommunity': MyCommunity}).start()
 
 
 ensure_future(start_communities())

--- a/doc/basics/overlay_tutorial_4.py
+++ b/doc/basics/overlay_tutorial_4.py
@@ -2,21 +2,24 @@ import os
 from asyncio import ensure_future, get_event_loop
 
 from pyipv8.ipv8.community import Community
-from pyipv8.ipv8.configuration import ConfigBuilder, Strategy, WalkerDefinition, default_bootstrap_defs
+from pyipv8.ipv8.configuration import (ConfigBuilder, Strategy, WalkerDefinition,
+                                       default_bootstrap_defs)
+from pyipv8.ipv8.peerdiscovery.network import PeerObserver
+from pyipv8.ipv8.types import Peer
 from pyipv8.ipv8_service import IPv8
 
 
-class MyCommunity(Community):
+class MyCommunity(Community, PeerObserver):
     community_id = os.urandom(20)
 
-    def started(self):
-        async def print_peers():
-            print("I am:", self.my_peer, "\nI know:", [str(p) for p in self.get_peers()])
+    def on_peer_added(self, peer: Peer) -> None:
+        print("I am:", self.my_peer, "I found:", peer)
 
-        # We register a asyncio task with this overlay.
-        # This makes sure that the task ends when this overlay is unloaded.
-        # We call the 'print_peers' function every 5.0 seconds, starting now.
-        self.register_task("print_peers", print_peers, interval=5.0, delay=0)
+    def on_peer_removed(self, peer: Peer) -> None:
+        pass
+
+    def started(self):
+        self.network.add_peer_observer(self)
 
 
 async def start_communities():
@@ -26,9 +29,12 @@ async def start_communities():
         # We provide the 'started' function to the 'on_start'.
         # We will call the overlay's 'started' function without any
         # arguments once IPv8 is initialized.
-        builder.add_overlay("MyCommunity", "my peer", [WalkerDefinition(Strategy.RandomWalk, 10, {'timeout': 3.0})],
+        builder.add_overlay("MyCommunity", "my peer",
+                            [WalkerDefinition(Strategy.RandomWalk,
+                                              10, {'timeout': 3.0})],
                             default_bootstrap_defs, {}, [('started',)])
-        await IPv8(builder.finalize(), extra_communities={'MyCommunity': MyCommunity}).start()
+        await IPv8(builder.finalize(),
+                   extra_communities={'MyCommunity': MyCommunity}).start()
 
 
 ensure_future(start_communities())


### PR DESCRIPTION
Fixes #1161

This PR:

 - Updates `overlay_tutorial.rst` to show the new `PeerObserver` functionality.
 - Updates the `overlay_tutorial_*.py` files to fit within the ReadTheDocs page width.

