### PR TITLE
Fixed ruff violations for peerdiscovery folder

### DIFF
--- a/ipv8/messaging/serialization.py
+++ b/ipv8/messaging/serialization.py
@@ -555,7 +555,7 @@ class Serializable(metaclass=abc.ABCMeta):
 
     @classmethod
     @abc.abstractmethod
-    def from_unpack_list(cls: type[Serializable], *args: object) -> Serializable:
+    def from_unpack_list(cls: type[Serializable], *args: typing.Any, **kwargs) -> Serializable:  # noqa: ANN401
         """
         Create a new Serializable object from a list of unpacked variables.
         """

--- a/ipv8/peerdiscovery/community.py
+++ b/ipv8/peerdiscovery/community.py
@@ -1,61 +1,106 @@
+from __future__ import annotations
+
 from binascii import unhexlify
 from random import sample
 from time import time
+from typing import TYPE_CHECKING, Iterable, Union, cast
 
-from .churn import DiscoveryStrategy, RandomChurn
-from .payload import (DiscoveryIntroductionRequestPayload, PingPayload, PongPayload, SimilarityRequestPayload,
-                      SimilarityResponsePayload)
-from ..community import Community, DEFAULT_MAX_PEERS
+from ..community import DEFAULT_MAX_PEERS, Community
 from ..keyvault.crypto import default_eccrypto
 from ..lazy_community import PacketDecodingError, lazy_wrapper, lazy_wrapper_unsigned, retrieve_cache
-from ..messaging.payload import IntroductionRequestPayload
+from ..messaging.payload import IntroductionRequestPayload, IntroductionResponsePayload
 from ..messaging.payload_headers import BinMemberAuthenticationPayload, GlobalTimeDistributionPayload
-from ..messaging.serialization import PackError
+from ..messaging.serialization import PackError, Serializable
 from ..peer import Peer
 from ..requestcache import NumberCache, RequestCache
+from .churn import DiscoveryStrategy, RandomChurn
+from .payload import (
+    DiscoveryIntroductionRequestPayload,
+    PingPayload,
+    PongPayload,
+    SimilarityRequestPayload,
+    SimilarityResponsePayload,
+)
+
+if TYPE_CHECKING:
+    from ..types import Address, Endpoint
+    from .network import Network
 
 
 class PeriodicSimilarity(DiscoveryStrategy):
+    """
+    Periodically send a request for similar Communities to a random peer.
+    """
 
-    def __init__(self, overlay):
+    def __init__(self, overlay: DiscoveryCommunity) -> None:
+        """
+        Create a new strategy to regularly send similarity requests.
+        """
         super().__init__(overlay)
-        self.last_step = 0
+        self.last_step: float = 0
 
-    def take_step(self):
+    def take_step(self) -> None:
+        """
+        Select a random peer, at most every second, to send a similarity request to.
+        """
         now = time()
         if (now - self.last_step < 1.0) or not self.overlay.network.verified_peers:
             return
         self.last_step = now
         with self.walk_lock:
+            self.overlay = cast(DiscoveryCommunity, self.overlay)
             self.overlay.send_similarity_request(sample(list(self.overlay.network.verified_peers), 1)[0].address)
 
 
 class PingRequestCache(NumberCache):
+    """
+    Cache for ping measurements to a peer.
+    """
 
     name = "discoverypingcache"
 
-    def __init__(self, request_cache, identifier, peer, start_time):
+    def __init__(self, request_cache: RequestCache, identifier: int, peer: Peer, start_time: float) -> None:
+        """
+        Register a new ping to a peer that was sent at a given time.
+        """
         super().__init__(request_cache, PingRequestCache.name, identifier)
         self.peer = peer
         self.start_time = start_time
 
-    def finish(self):
+    def finish(self) -> None:
+        """
+        Complete the ping measurement by adding it to a peer's pings.
+        """
         self.peer.pings.append(time() - self.start_time)
 
     @property
-    def timeout_delay(self):
+    def timeout_delay(self) -> float:
+        """
+        After 5 seconds, consider the peer unreachable.
+        """
         return 5.0
 
-    def on_timeout(self):
-        pass
+    def on_timeout(self) -> None:
+        """
+        If we can't reach a peer, we assume accidental packet drop. Actually dropping the peer is left to the churn.
+        """
 
 
 class DiscoveryCommunity(Community):
+    """
+    Community for peers to more quickly discover peers in other communities.
+
+    Peers exchange the community ids they are part of with each other.
+    """
 
     version = b'\x02'
     community_id = unhexlify('7e313685c1912a141279f8248fc8db5899c5df5a')
 
-    def __init__(self, my_peer, endpoint, network, max_peers=DEFAULT_MAX_PEERS, anonymize=False):
+    def __init__(self, my_peer: Peer, endpoint: Endpoint, network: Network,  # noqa: PLR0913
+                 max_peers: int = DEFAULT_MAX_PEERS, anonymize: bool = False) -> None:
+        """
+        Create a new community with similarity and ping functionality.
+        """
         super().__init__(my_peer, endpoint, network, max_peers=max_peers, anonymize=anonymize)
 
         self.request_cache = RequestCache()
@@ -65,14 +110,26 @@ class DiscoveryCommunity(Community):
         self.add_message_handler(PingPayload, self.on_ping)
         self.add_message_handler(PongPayload, self.on_pong)
 
-    def get_available_strategies(self):
+    def get_available_strategies(self) -> dict[str, type[DiscoveryStrategy]]:
+        """
+        Expose strategies for periodically checking similarity and unreachable peer churn.
+        """
         return {'PeriodicSimilarity': PeriodicSimilarity, 'RandomChurn': RandomChurn}
 
-    async def unload(self):
+    async def unload(self) -> None:
+        """
+        Unload the pending ping cache and then shut down the pending tasks.
+        """
         await self.request_cache.shutdown()
         await super().unload()
 
-    def on_old_introduction_request(self, source_address, data):
+    def on_old_introduction_request(self, source_address: Address, data: bytes) -> None:
+        """
+        A backward-compatible (2014) introduction request handler.
+
+        The old logic flow was to first try to unpack the special DiscoveryCommunity intro request and then fall
+        back to the actual intro request payload.
+        """
         if self.max_peers >= 0 and len(self.get_peers()) > self.max_peers:
             self.logger.debug("Dropping introduction request from (%s, %d): too many peers!",
                               source_address[0], source_address[1])
@@ -82,6 +139,7 @@ class DiscoveryCommunity(Community):
             auth, dist, payload = self._ez_unpack_auth(DiscoveryIntroductionRequestPayload, data)
         except (PacketDecodingError, PackError):
             auth, dist, payload = self._ez_unpack_auth(IntroductionRequestPayload, data)
+        payload = cast(Union[IntroductionRequestPayload, DiscoveryIntroductionRequestPayload], payload)
 
         peer = Peer(auth.public_key_bin, source_address)
         self.network.add_verified_peer(peer)
@@ -97,17 +155,30 @@ class DiscoveryCommunity(Community):
                                                    introduction=introduction, new_style=False)
         self.endpoint.send(source_address, packet)
 
-    def introduction_response_callback(self, peer, dist, payload):
+    def introduction_response_callback(self, peer: Peer, dist: GlobalTimeDistributionPayload,
+                                       payload: IntroductionResponsePayload) -> None:
+        """
+        If a peer sent us a response, send them a request for similarity.
+        """
         self.send_similarity_request(peer.address)
 
-    def send_similarity_request(self, address):
+    def send_similarity_request(self, address: Address) -> None:
+        """
+        Send a request for similarity with our communities.
+        """
         my_peer_set = {overlay.my_peer for overlay in self.network.service_overlays.values()}
         for peer in my_peer_set:
             packet = self.create_similarity_request(peer)
             self.endpoint.send(address, packet)
 
     @lazy_wrapper(GlobalTimeDistributionPayload, SimilarityRequestPayload)
-    def on_similarity_request(self, node, dist, payload):
+    def on_similarity_request(self, node: Peer, dist: GlobalTimeDistributionPayload,
+                              payload: SimilarityRequestPayload) -> None:
+        """
+        We received a request for similarity (overlap with another peer's communities).
+
+        We update the known community ids for this peer and we send a response that contains our own ids.
+        """
         self.network.discover_services(node, payload.preference_list)
 
         my_peer_set = {overlay.my_peer for overlay in self.network.service_overlays.values()}
@@ -116,7 +187,11 @@ class DiscoveryCommunity(Community):
             self.endpoint.send(node.address, packet)
 
     @lazy_wrapper(GlobalTimeDistributionPayload, SimilarityResponsePayload)
-    def on_similarity_response(self, node, dist, payload):
+    def on_similarity_response(self, node: Peer, dist: GlobalTimeDistributionPayload,
+                               payload: SimilarityResponsePayload) -> None:
+        """
+        We received a response to our request for similarity.
+        """
         if self.max_peers >= 0 and len(self.get_peers()) > self.max_peers and node not in self.network.verified_peers:
             self.logger.debug("Dropping similarity response from (%s, %d): too many peers!",
                               node.address[0], node.address[1])
@@ -126,26 +201,48 @@ class DiscoveryCommunity(Community):
         self.network.discover_services(node, payload.preference_list)
 
     @lazy_wrapper_unsigned(GlobalTimeDistributionPayload, PingPayload)
-    def on_ping(self, source_address, dist, payload):
+    def on_ping(self, source_address: Address, dist: GlobalTimeDistributionPayload, payload: PingPayload) -> None:
+        """
+        We received a ping, send a pong back.
+
+        For backward compatibility, this message is unsigned.
+        """
         packet = self.create_pong(payload.identifier)
         self.endpoint.send(source_address, packet)
 
     @lazy_wrapper_unsigned(GlobalTimeDistributionPayload, PongPayload)
     @retrieve_cache(PingRequestCache)
-    def on_pong(self, source_address, dist, payload, cache):
+    def on_pong(self, source_address: Address, dist: GlobalTimeDistributionPayload, payload: PongPayload,
+                cache: PingRequestCache) -> None:
+        """
+        We got a valid pong to our existing ping (retrieve_cache ensures this), finish the request in the cache handler.
+
+        Note: For backward compatibility, this message is UNSIGNED. The only thing guaranteeing that the response
+              is not faked, is its nonce.
+        """
         cache.finish()
 
-    def get_my_overlays(self, peer):
+    def get_my_overlays(self, peer: Peer) -> list[bytes]:
+        """
+        Get the known community ids that we are a part of.
+        """
         return [service_id for service_id, overlay in self.network.service_overlays.items()
                 if overlay.my_peer == peer]
 
-    def custom_pack(self, peer, msg_num, payloads):
+    def custom_pack(self, peer: Peer, msg_num: int, payloads: Iterable[Serializable]) -> bytes:
+        """
+        You can have different key material for different communities. So, in order for you to cross-communicate,
+        you should sign messages with the key material that is used by a particular community.
+        """
         packet = self._prefix + bytes([msg_num])
         packet += self.serializer.pack_serializable_list(payloads)
         packet += default_eccrypto.create_signature(peer.key, packet)
         return packet
 
-    def create_similarity_request(self, peer):
+    def create_similarity_request(self, peer: Peer) -> bytes:
+        """
+        Create a similarity request message to send to the given peer.
+        """
         global_time = self.claim_global_time()
         payload = SimilarityRequestPayload(global_time,
                                            self.my_estimated_lan,
@@ -157,7 +254,10 @@ class DiscoveryCommunity(Community):
 
         return self.custom_pack(peer, 1, [auth, dist, payload])
 
-    def create_similarity_response(self, identifier, peer):
+    def create_similarity_response(self, identifier: int, peer: Peer) -> bytes:
+        """
+        Create a response message to a similarity request from a given peer.
+        """
         global_time = self.claim_global_time()
         payload = SimilarityResponsePayload(identifier, self.get_my_overlays(peer), [])
         auth = BinMemberAuthenticationPayload(peer.public_key.key_to_bin())
@@ -165,7 +265,10 @@ class DiscoveryCommunity(Community):
 
         return self.custom_pack(peer, 2, [auth, dist, payload])
 
-    def send_ping(self, peer):
+    def send_ping(self, peer: Peer) -> None:
+        """
+        Send a ping message to the given peer.
+        """
         global_time = self.claim_global_time()
         payload = PingPayload(global_time)
         dist = GlobalTimeDistributionPayload(global_time)
@@ -174,7 +277,10 @@ class DiscoveryCommunity(Community):
         self.request_cache.add(PingRequestCache(self.request_cache, global_time, peer, time()))
         self.endpoint.send(peer.address, packet)
 
-    def create_pong(self, identifier):
+    def create_pong(self, identifier: int) -> bytes:
+        """
+        Create a pong message for the given identifier.
+        """
         global_time = self.claim_global_time()
         payload = PongPayload(identifier)
         dist = GlobalTimeDistributionPayload(global_time)

--- a/ipv8/peerdiscovery/payload.py
+++ b/ipv8/peerdiscovery/payload.py
@@ -1,15 +1,28 @@
+from __future__ import annotations
+
 from socket import inet_aton, inet_ntoa
 from struct import pack, unpack
+from typing import TYPE_CHECKING
 
 from ..messaging.payload import IntroductionRequestPayload, Payload, decode_connection_type, encode_connection_type
 
+if TYPE_CHECKING:
+    from ..types import Address
+
 
 class SimilarityRequestPayload(Payload):
+    """
+    Payload to request overlap with our own Community instances.
+    """
 
     msg_id = 1
     format_list = ['H', '4SH', '4SH', 'bits', 'raw']
 
-    def __init__(self, identifier, lan_address, wan_address, connection_type, preference_list):
+    def __init__(self, identifier: int, lan_address: Address, wan_address: Address,  # noqa: PLR0913
+                 connection_type: str, preference_list: list[bytes]) -> None:
+        """
+        Create a new similarity request payload.
+        """
         super().__init__()
         self.identifier = identifier % 65536
         self.preference_list = preference_list
@@ -17,20 +30,27 @@ class SimilarityRequestPayload(Payload):
         self.wan_address = wan_address
         self.connection_type = connection_type
 
-    def to_pack_list(self):
+    def to_pack_list(self) -> list[tuple]:
+        """
+        Pack our values.
+        """
         encoded_connection_type = encode_connection_type(self.connection_type)
-        data = [('H', self.identifier),
+        return [('H', self.identifier),
                 ('4SH', inet_aton(self.lan_address[0]), self.lan_address[1]),
                 ('4SH', inet_aton(self.wan_address[0]), self.wan_address[1]),
                 ('bits', encoded_connection_type[0], encoded_connection_type[1], 0, 0, 0, 0, 0, 0),
                 ('raw', b"".join(self.preference_list))]
 
-        return data
 
     @classmethod
-    def from_unpack_list(cls, identifier, lan_address, wan_address,
-                         connection_type_0, connection_type_1, dflag0, dflag1, dflag2, dflag3, dflag4, dflag5,
-                         preference_list):
+    def from_unpack_list(cls: type[SimilarityRequestPayload], identifier: int,  # noqa: PLR0913
+                         lan_address: tuple[bytes, int], wan_address: tuple[bytes, int],
+                         connection_type_0: int, connection_type_1: int,
+                         dflag0: int, dflag1: int, dflag2: int, dflag3: int, dflag4: int, dflag5: int,  # noqa: ARG003
+                         preference_list: bytes) -> SimilarityRequestPayload:
+        """
+        Unpack a SimilarityRequestPayload.
+        """
         args = [identifier,
                 (inet_ntoa(lan_address[0]), lan_address[1]),
                 (inet_ntoa(wan_address[0]), wan_address[1]),
@@ -41,76 +61,115 @@ class SimilarityRequestPayload(Payload):
 
 
 class SimilarityResponsePayload(Payload):
+    """
+    Payload to respond with overlap with our own Community instances.
+    """
 
     msg_id = 2
     format_list = ['H', 'varlenHx20', 'raw']
 
-    def __init__(self, identifier, preference_list, tb_overlap):
+    def __init__(self, identifier: int, preference_list: list[bytes], tb_overlap: list[tuple[bytes, int]]) -> None:
+        """
+        Create a new similarity response payload.
+        """
         super().__init__()
         self.identifier = identifier % 65536
         self.preference_list = preference_list
         self.tb_overlap = tb_overlap
 
-    def to_pack_list(self):
+    def to_pack_list(self) -> list[tuple]:
+        """
+        Pack our values.
+        """
         encoded_tb_overlap = [pack(">20sI", *tb) for tb in self.tb_overlap]
-        data = [('H', self.identifier),
+        return [('H', self.identifier),
                 ('varlenHx20', b"".join(self.preference_list)),
                 ('raw', b"".join(encoded_tb_overlap))]
 
-        return data
-
     @classmethod
-    def from_unpack_list(cls, identifier, preference_list, tb_overlap):
-        args = [identifier,
-                [preference_list[i:i + 20] for i in range(0, len(preference_list), 20)],
-                [(tb_overlap[i:i + 20], unpack(">I", tb_overlap[i + 20:i + 24])[0])
-                 for i in range(0, len(tb_overlap), 24)]]
-
-        return SimilarityResponsePayload(*args)
+    def from_unpack_list(cls: type[SimilarityResponsePayload], identifier: int,
+                         preference_list: bytes, tb_overlap: bytes) -> SimilarityResponsePayload:
+        """
+        Unpack a SimilarityResponsePayload.
+        """
+        return SimilarityResponsePayload(identifier,
+                                         [preference_list[i:i + 20] for i in range(0, len(preference_list), 20)],
+                                         [(tb_overlap[i:i + 20], unpack(">I", tb_overlap[i + 20:i + 24])[0])
+                                          for i in range(0, len(tb_overlap), 24)])
 
 
 class PingPayload(Payload):
+    """
+    Payload used to ask for a pong.
+    """
 
     msg_id = 3
     format_list = ['H']
 
-    def __init__(self, identifier):
+    def __init__(self, identifier: int) -> None:
+        """
+        Create a new ping with a given nonce.
+        """
         super().__init__()
         self.identifier = identifier % 65536
 
-    def to_pack_list(self):
-        data = [('H', self.identifier), ]
-
-        return data
+    def to_pack_list(self) -> list[tuple]:
+        """
+        Pack our values.
+        """
+        return [('H', self.identifier), ]
 
     @classmethod
-    def from_unpack_list(cls, identifier):
+    def from_unpack_list(cls: type[PingPayload], identifier: int) -> PingPayload:
+        """
+        Unpack a PingPayload.
+        """
         return PingPayload(identifier)
 
 
 class PongPayload(PingPayload):
+    """
+    Payload used to answer a ping.
+    """
+
     msg_id = 4
 
 
 class DiscoveryIntroductionRequestPayload(IntroductionRequestPayload):
+    """
+    Custom introduction request override for Dispersy backward compatibility.
+    """
 
     format_list = ['c20s', '4SH', '4SH', '4SH', 'bits', 'H', 'raw']
 
-    def __init__(self, introduce_to, destination_address, source_lan_address, source_wan_address, advice,
-                 connection_type, identifier, extra_bytes):
+    def __init__(self, introduce_to: bytes, destination_address: Address, source_lan_address: Address,  # noqa: PLR0913
+                 source_wan_address: Address, advice: int, connection_type: str, identifier: int,
+                 extra_bytes: bytes) -> None:
+        """
+        Create a new introduction request.
+        """
         super().__init__(destination_address, source_lan_address, source_wan_address, advice, connection_type,
                          identifier, extra_bytes)
         self.introduce_to = introduce_to
 
-    def to_pack_list(self):
+    def to_pack_list(self) -> list[tuple]:
+        """
+        Pack our values.
+        """
         data = super().to_pack_list()
         data.insert(0, ('c20s', b'Y', self.introduce_to))
         return data
 
     @classmethod
-    def from_unpack_list(cls, introduce_to, destination_address, source_lan_address, source_wan_address,
-                         connection_type_0, connection_type_1, dflag0, dflag1, dflag2, tunnel, _, advice,
-                         identifier, extra_bytes):
+    def from_unpack_list(cls: type[DiscoveryIntroductionRequestPayload],  # type: ignore[override]  # noqa: PLR0913
+                         introduce_to: bytes,
+                         destination_address: tuple[bytes, int], source_lan_address: tuple[bytes, int],
+                         source_wan_address: tuple[bytes, int], connection_type_0: int, connection_type_1: int,
+                         dflag0: int, dflag1: int, dflag2: int, tunnel: int, _: int, advice: int,  # noqa: ARG003
+                         identifier: int, extra_bytes: bytes) -> DiscoveryIntroductionRequestPayload:
+        """
+        Unpack a DiscoveryIntroductionRequestPayload.
+        """
         args = [introduce_to[1:],
                 (inet_ntoa(destination_address[0]), destination_address[1]),
                 (inet_ntoa(source_lan_address[0]), source_lan_address[1]),


### PR DESCRIPTION
This PR:

 - Fixes a "wrong" type for `Serializable.from_unpack_list`, which was too narrow.
 - Fixes the `ruff` violations in the `peerdiscovery` folder.
 
