### PR TITLE
Fixed ruff violations for REST folder

### DIFF
--- a/ipv8/REST/asyncio_endpoint.py
+++ b/ipv8/REST/asyncio_endpoint.py
@@ -1,63 +1,94 @@
+from __future__ import annotations
+
 import collections
 import logging
 import time
 from asyncio import all_tasks, current_task, get_event_loop
+from typing import TYPE_CHECKING, Iterable, cast
 
 from aiohttp import web
-
 from aiohttp_apispec import docs, json_schema
-
 from marshmallow.fields import Boolean, Float, Integer, String
 
-from .base_endpoint import BaseEndpoint, HTTP_BAD_REQUEST, HTTP_NOT_FOUND, Response
-from .schema import DefaultResponseSchema, schema
 from ..peerdiscovery.discovery import DiscoveryStrategy
+from ..types import IPv8
+from .base_endpoint import HTTP_BAD_REQUEST, HTTP_NOT_FOUND, BaseEndpoint, Response
+from .schema import DefaultResponseSchema, schema
+
+if TYPE_CHECKING:
+    from aiohttp.abc import Request
 
 
 class DequeLogHandler(logging.Handler):
+    """
+    Log handler that stores the past log records.
+    """
 
-    def __init__(self, maxlen=50):
+    def __init__(self, maxlen: int = 50) -> None:
+        """
+        Create a new handler that stores up to the given length of log messages.
+        """
         super().__init__()
-        self.deque = collections.deque(maxlen=maxlen)
+        self.deque: collections.deque[str] = collections.deque(maxlen=maxlen)
 
-    def emit(self, record):
+    def emit(self, record: logging.LogRecord) -> None:
+        """
+        Callback for when a log record is written.
+        """
         self.deque.append(self.format(record))
 
 
 class DriftMeasurementStrategy(DiscoveryStrategy):
+    """
+    Strategy to measure how far off the invocation time of strategies is from the IPv8 tick rate.
+    """
 
-    def __init__(self, core_update_rate):
+    def __init__(self, core_update_rate: float) -> None:
+        """
+        Create a new measurement strategy that compares to the given expected update rate (in seconds).
+        """
         super().__init__(None)
         self.last_measurement = time.time()
-        self.history = collections.deque(maxlen=100)
+        self.history: collections.deque[tuple[float, float]] = collections.deque(maxlen=100)
         self.core_update_rate = core_update_rate
-        self.overlay = type('FakeOverlay', (object,), {'get_peers': lambda: []})
 
-    def take_step(self):
+    def take_step(self) -> None:
+        """
+        Measure the time since our last invocation and compare it to the expected update rate.
+        """
         with self.walk_lock:
             this_time = time.time()
             self.history.append((this_time, max(0.0, this_time - self.last_measurement - self.core_update_rate)))
             self.last_measurement = this_time
 
 
-class AsyncioEndpoint(BaseEndpoint):
+class AsyncioEndpoint(BaseEndpoint[IPv8]):
     """
     This endpoint helps with the monitoring of the Asyncio thread.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
+        """
+        Create new unregistered and uninitialized REST endpoint.
+        """
         super().__init__()
-        self.strategy = None
-        self.asyncio_log_handler = None
+        self.strategy: DriftMeasurementStrategy | None = None
+        self.asyncio_log_handler: DequeLogHandler | None = None
 
-    def setup_routes(self):
+    def setup_routes(self) -> None:
+        """
+        Register the names to make this endpoint callable.
+        """
         self.app.add_routes([web.get('/drift', self.retrieve_drift),
                              web.put('/drift', self.enable_measurements),
                              web.get('/tasks', self.get_asyncio_tasks),
                              web.put('/debug', self.set_asyncio_debug),
                              web.get('/debug', self.get_asyncio_debug)])
 
-    def enable(self):
+    def enable(self) -> bool:
+        """
+        Create a new measurement strategy and hook it into IPv8.
+        """
         if not self.session:
             return False
         if not self.strategy:
@@ -67,7 +98,10 @@ class AsyncioEndpoint(BaseEndpoint):
             return True
         return True
 
-    def disable(self):
+    def disable(self) -> bool:
+        """
+        Destroy the previously registered measurement strategy.
+        """
         if not self.session:
             return False
         if self.strategy:
@@ -95,7 +129,10 @@ class AsyncioEndpoint(BaseEndpoint):
             }
         }
     )
-    async def retrieve_drift(self, _):
+    async def retrieve_drift(self, _: Request) -> Response:
+        """
+        Calculate the current drift.
+        """
         if self.strategy is None:
             return Response({"success": False, "error": "Core drift disabled."}, status=HTTP_NOT_FOUND)
         with self.strategy.walk_lock:
@@ -118,7 +155,10 @@ class AsyncioEndpoint(BaseEndpoint):
     @json_schema(schema(EnableDriftRequest={
         'enable*': (Boolean, 'Whether to enable or disable measuring.'),
     }))
-    async def enable_measurements(self, request):
+    async def enable_measurements(self, request: Request) -> Response:
+        """
+        Enable or disable drift measurements.
+        """
         parameters = await request.json()
         if 'enable' not in parameters:
             return Response({"error": "incorrect parameters"}, status=HTTP_BAD_REQUEST)
@@ -126,8 +166,7 @@ class AsyncioEndpoint(BaseEndpoint):
         status = self.enable() if parameters.get('enable') else self.disable()
         if status:
             return Response({"success": True})
-        else:
-            return Response({"success": False, "error": "Session not initialized."})
+        return Response({"success": False, "error": "Session not initialized."})
 
     @docs(
         tags=["Asyncio"],
@@ -147,7 +186,10 @@ class AsyncioEndpoint(BaseEndpoint):
             }
         }
     )
-    async def get_asyncio_tasks(self, _):
+    async def get_asyncio_tasks(self, _: Request) -> Response:
+        """
+        Return all currently running Asyncio tasks.
+        """
         current = current_task()
         tasks = []
         for task in all_tasks():
@@ -163,8 +205,9 @@ class AsyncioEndpoint(BaseEndpoint):
                 # Only TaskManager tasks have a start_time attribute
                 cls, tsk = name.split(":")
                 task_dict.update({"name": tsk, "taskmanager": cls, "start_time": task.start_time})
-                if task.interval:
-                    task_dict["interval"] = task.interval
+                interval = getattr(task, "interval", None)
+                if interval is not None:
+                    task_dict["interval"] = interval
             tasks.append(task_dict)
         return Response({"tasks": tasks})
 
@@ -186,7 +229,10 @@ class AsyncioEndpoint(BaseEndpoint):
         'enable': (Boolean, 'Whether to enable or disable asyncio debug mode.'),
         'slow_callback_duration': (Integer, 'Time threshold above which tasks will be logged.'),
     }))
-    async def set_asyncio_debug(self, request):
+    async def set_asyncio_debug(self, request: Request) -> Response:
+        """
+        Set asyncio debug options.
+        """
         parameters = await request.json()
         if 'enable' not in parameters and 'slow_callback_duration' not in parameters:
             return Response({"success": False, "error": "incorrect parameters"}, status=HTTP_BAD_REQUEST)
@@ -199,10 +245,10 @@ class AsyncioEndpoint(BaseEndpoint):
             loop.set_debug(enable)
 
             # Add/remove asyncio log handler
-            if enable and not self.asyncio_log_handler:
+            if enable and self.asyncio_log_handler is None:
                 self.asyncio_log_handler = DequeLogHandler()
                 logging.getLogger('asyncio').addHandler(self.asyncio_log_handler)
-            if not enable and self.asyncio_log_handler:
+            if not enable and self.asyncio_log_handler is not None:
                 logging.getLogger('asyncio').removeHandler(self.asyncio_log_handler)
                 self.asyncio_log_handler = None
 
@@ -225,9 +271,12 @@ class AsyncioEndpoint(BaseEndpoint):
             }
         }
     )
-    async def get_asyncio_debug(self, _):
+    async def get_asyncio_debug(self, _: Request) -> Response:
+        """
+        Return Asyncio log messages.
+        """
         loop = get_event_loop()
-        messages = self.asyncio_log_handler.deque if self.asyncio_log_handler else []
+        messages = cast(Iterable, self.asyncio_log_handler.deque) if self.asyncio_log_handler is not None else []
         return Response({'messages': [{'message': r} for r in messages],
                          'enable': loop.get_debug(),
                          'slow_callback_duration': loop.slow_callback_duration})

--- a/ipv8/REST/base_endpoint.py
+++ b/ipv8/REST/base_endpoint.py
@@ -2,8 +2,11 @@ from __future__ import annotations
 
 import json
 import logging
+from typing import Any, Awaitable, Callable, Generic, Iterable, TypeVar, Union
 
 from aiohttp import web
+from aiohttp.abc import Application, Request, StreamResponse
+from aiohttp.typedefs import Handler, LooseHeaders
 
 HTTP_BAD_REQUEST = 400
 HTTP_UNAUTHORIZED = 401
@@ -14,32 +17,57 @@ HTTP_INTERNAL_SERVER_ERROR = 500
 
 DEFAULT_HEADERS: dict[str, str] = {}
 
+T = TypeVar('T')
+MiddleWaresType = Iterable[Union[Callable[[Request, Handler], Awaitable[StreamResponse]],
+                                 Callable[[Application, Handler], Awaitable[Handler]]]]
 
-class BaseEndpoint:
 
-    def __init__(self, middlewares=()):
+class BaseEndpoint(Generic[T]):
+    """
+    Base class for all REST endpoints.
+    """
+
+    def __init__(self, middlewares: MiddleWaresType = ()) -> None:
+        """
+        Create new unregistered and uninitialized REST endpoint.
+        """
         self._logger = logging.getLogger(self.__class__.__name__)
         self.app = web.Application(middlewares=middlewares)
-        self.session = None
-        self.endpoints = {}
+        self.session: T | None = None
+        self.endpoints: dict[str, BaseEndpoint] = {}
         self.setup_routes()
 
-    def setup_routes(self):
-        pass
+    def setup_routes(self) -> None:
+        """
+        Register the names to make this endpoint callable.
+        """
 
-    def initialize(self, session):
+    def initialize(self, session: T) -> None:
+        """
+        Initialize this endpoint for the given session instance.
+        """
         self.session = session
         for endpoint in self.endpoints.values():
             endpoint.initialize(session)
 
-    def add_endpoint(self, prefix, endpoint):
+    def add_endpoint(self, prefix: str, endpoint: BaseEndpoint) -> None:
+        """
+        Add a new child endpoint to this endpoint.
+        """
         self.endpoints[prefix] = endpoint
         self.app.add_subapp(prefix, endpoint.app)
 
 
 class Response(web.Response):
+    """
+    A convenience class to auto-encode response bodies in JSON format.
+    """
 
-    def __init__(self, body=None, headers=None, content_type=None, status=200, **kwargs):
+    def __init__(self, body: Any = None, headers: LooseHeaders | None = None,  # noqa: ANN401
+                 content_type: str | None = None, status: int = 200, **kwargs) -> None:
+        """
+        Create the response.
+        """
         if isinstance(body, (dict, list)):
             body = json.dumps(body)
             content_type = 'application/json'

--- a/ipv8/REST/rest_manager.py
+++ b/ipv8/REST/rest_manager.py
@@ -1,25 +1,46 @@
+from __future__ import annotations
+
 import logging
+from typing import TYPE_CHECKING, cast
 
 from aiohttp import web
-
 from aiohttp_apispec import AiohttpApiSpec
 
-from .base_endpoint import HTTP_INTERNAL_SERVER_ERROR, HTTP_UNAUTHORIZED, Response
+from .base_endpoint import HTTP_INTERNAL_SERVER_ERROR, HTTP_UNAUTHORIZED, BaseEndpoint, Response
 from .root_endpoint import RootEndpoint
+
+if TYPE_CHECKING:
+    from aiohttp.abc import Request
+    from aiohttp.connector import SSLContext
+    from aiohttp.typedefs import Handler
+    from aiohttp.web_response import StreamResponse
+    from aiohttp.web_runner import BaseRunner
 
 
 @web.middleware
 class ApiKeyMiddleware:
-    def __init__(self, api_key):
+    """
+    Middleware to check for authorized REST access.
+    """
+
+    def __init__(self, api_key: str | None) -> None:
+        """
+        Create new middleware for the given API key.
+        """
         self.api_key = api_key
 
-    async def __call__(self, request, handler):
+    async def __call__(self, request: Request, handler: Handler) -> StreamResponse | Response:
+        """
+        Intercept requests that are not authorized.
+        """
         if self.authenticate(request):
             return await handler(request)
-        else:
-            return Response({'error': 'Unauthorized access'}, status=HTTP_UNAUTHORIZED)
+        return Response({'error': 'Unauthorized access'}, status=HTTP_UNAUTHORIZED)
 
-    def authenticate(self, request):
+    def authenticate(self, request: Request) -> bool:
+        """
+        Check if the given request is authorized.
+        """
         if request.path.startswith('/docs') or request.path.startswith('/static'):
             return True
         # The api key can either be in the headers or as part of the url query
@@ -28,7 +49,10 @@ class ApiKeyMiddleware:
 
 
 @web.middleware
-async def cors_middleware(request, handler):
+async def cors_middleware(request: Request, handler: Handler) -> Response | StreamResponse:
+    """
+    Cross-origin resource sharing middleware.
+    """
     preflight_cors = request.method == "OPTIONS" and 'Access-Control-Request-Method' in request.headers
     if not preflight_cors:
         return await handler(request)
@@ -43,7 +67,10 @@ async def cors_middleware(request, handler):
 
 
 @web.middleware
-async def error_middleware(request, handler):
+async def error_middleware(request: Request, handler: Handler) -> Response | StreamResponse:
+    """
+    Middleware to catch call errors when handling requests.
+    """
     try:
         response = await handler(request)
     except Exception as e:
@@ -64,14 +91,18 @@ class RESTManager:
     This class is responsible for managing the startup and closing of the HTTP API.
     """
 
-    def __init__(self, session, root_endpoint_class=None):
+    def __init__(self, session: object, root_endpoint_class: type[BaseEndpoint] | None = None) -> None:
+        """
+        Create a new manager to orchestrate REST requests and responses.
+        """
         self._logger = logging.getLogger(self.__class__.__name__)
         self.session = session
-        self.site = None
-        self.root_endpoint = None
+        self.site: web.TCPSite | None = None
+        self.root_endpoint: BaseEndpoint | None = None
         self._root_endpoint_class = root_endpoint_class or RootEndpoint
 
-    async def start(self, port=8085, host='127.0.0.1', api_key=None, ssl_context=None):
+    async def start(self, port: int = 8085, host: str = '127.0.0.1', api_key: str | None = None,
+                    ssl_context: SSLContext | None = None) -> None:
         """
         Starts the HTTP API with the listen port as specified in the session configuration.
         """
@@ -103,13 +134,20 @@ class RESTManager:
         await runner.setup()
         await self.start_site(runner, host, port, ssl_context)
 
-    async def start_site(self, runner, host, port, ssl_context):
+    async def start_site(self, runner: BaseRunner, host: str | None, port: int | None,
+                         ssl_context: SSLContext | None) -> None:
+        """
+        Create and start the internal TCP-based site.
+        """
         # If localhost is used as hostname, it will randomly either use 127.0.0.1 or ::1
         self.site = web.TCPSite(runner, host, port, ssl_context=ssl_context)
         await self.site.start()
 
-    async def stop(self):
+    async def stop(self) -> None:
         """
         Stop the HTTP API and return when the server has shut down.
         """
+        if self.site is None:
+            return
+        self.site = cast(web.TCPSite, self.site)
         await self.site.stop()

--- a/ipv8/REST/root_endpoint.py
+++ b/ipv8/REST/root_endpoint.py
@@ -16,7 +16,10 @@ class RootEndpoint(BaseEndpoint):
     It will dispatch requests regarding torrents, channels, settings etc to the right child endpoint.
     """
 
-    def setup_routes(self):
+    def setup_routes(self) -> None:
+        """
+        Register the names to make this endpoint callable.
+        """
         endpoints = {'/asyncio': AsyncioEndpoint,
                      '/attestation': AttestationEndpoint,
                      '/dht': DHTEndpoint,

--- a/ipv8/REST/schema.py
+++ b/ipv8/REST/schema.py
@@ -1,46 +1,44 @@
+from __future__ import annotations
+
+from typing import cast
+
 from marshmallow import Schema
+from marshmallow.base import SchemaABC
 from marshmallow.fields import Boolean, Integer, List, Nested, String
 from marshmallow.schema import SchemaMeta
 
 
 class DefaultResponseSchema(Schema):
+    """
+    Every response contains its sucess status and optionally the error that occurred.
+    """
+
     success = Boolean(description='Indicator of success/failure', required=True)
     error = String(description='Optional field describing any failures that may have occurred', required=False)
 
 
-class TransactionSchema(Schema):
-    down = Integer()
-    total_down = Integer()
-    up = Integer()
-    total_up = Integer()
-
-
-class BlockSchema(Schema):
-    transaction = Nested(TransactionSchema)
-    linked = Nested('BlockSchema')
-    type = String()
-    tx = String()
-    public_key = String()
-    sequence_number = Integer()
-    link_public_key = String()
-    link_sequence_number = Integer()
-    previous_hash = String()
-    signature = String()
-    insert_time = String()
-    block_timestamp = Integer()
-    block_hash = String()
-
-
 class Address(Schema):
+    """
+    The schema for address information.
+    """
+
     ip = String()
     port = Integer()
 
 
 class AddressWithPK(Address):
+    """
+    The schema for addresses that have a public key.
+    """
+
     public_key = String()
 
 
 class OverlayStatisticsSchema(Schema):
+    """
+    The schema for overlay statistics.
+    """
+
     num_up = Integer()
     num_down = Integer()
     bytes_up = Integer()
@@ -49,51 +47,64 @@ class OverlayStatisticsSchema(Schema):
 
 
 class OverlayStrategySchema(Schema):
+    """
+    The schema describing discovery strategies for overlays.
+    """
+
     name = String()
     target_peers = Integer()
 
 
 class OverlaySchema(Schema):
-    id = String()
+    """
+    The schema to describe overlays.
+    """
+
+    id = String()  # noqa: A003
     my_peer = String()
     global_time = Integer()
-    peers = List(Nested(AddressWithPK))
+    peers = List(Nested(cast(SchemaABC, AddressWithPK)))
     overlay_name = String()
     max_peers = Integer()
     is_isolated = Boolean()
-    my_estimated_wan = Nested(Address)
-    my_estimated_lan = Nested(Address)
-    strategies = List(Nested(OverlayStrategySchema))
-    statistics = Nested(OverlayStatisticsSchema)
+    my_estimated_wan = Nested(cast(SchemaABC, Address))
+    my_estimated_lan = Nested(cast(SchemaABC, Address))
+    strategies = List(Nested(cast(SchemaABC, OverlayStrategySchema)))
+    statistics = Nested(cast(SchemaABC, OverlayStatisticsSchema))
 
 
 class DHTValueSchema(Schema):
+    """
+    The schema to describe values in the DHT.
+    """
+
     public_key = String()
     key = String()
     value = String()
 
 
-def schema(**kwargs):
+def schema(**kwargs) -> Schema:
     """
     Create a schema. Mostly useful for creating single-use schemas on-the-fly.
     """
     items = list(kwargs.items())
     if len(items) != 1 or not isinstance(items[0][1], dict):
-        raise RuntimeError('schema required 1 keyword argument of type dict')
+        msg = "schema required 1 keyword argument of type dict"
+        raise RuntimeError(msg)
     name, spec = items[0]
 
-    schema_dict = {}
+    schema_dict: dict[str, Nested | List] = {}
     for key, value in spec.items():
         cls, description = value if isinstance(value, tuple) else (value, None)
         required = key.endswith('*')
-        key = key.rstrip('*')
+        key = key.rstrip('*')  # noqa: PLW2901
         kwargs = {'required': required, 'description': description}
 
         if isinstance(cls, SchemaMeta):
-            schema_dict[key] = Nested(cls, required=required)
+            schema_dict[key] = Nested(cast(SchemaABC, cls), required=required)
         elif isinstance(cls, list) and len(cls) == 1:
             cls = cls[0]
-            schema_dict[key] = List(Nested(cls), **kwargs) if isinstance(cls, SchemaMeta) else List(cls, **kwargs)
+            schema_dict[key] = List(Nested(cast(SchemaABC, cls)), **kwargs) if isinstance(cls, SchemaMeta) else List(cls, **kwargs)
         else:
             schema_dict[key] = cls.__call__(**kwargs) if callable(cls) else cls
-    return type(name, (Schema,), schema_dict)
+    return cast(Schema, type(name, (Schema,), schema_dict))

--- a/ipv8/peerdiscovery/churn.py
+++ b/ipv8/peerdiscovery/churn.py
@@ -2,12 +2,13 @@ from __future__ import annotations
 
 from random import sample
 from time import time
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
+from ..types import Overlay
 from .discovery import DiscoveryStrategy
 
 if TYPE_CHECKING:
-    from ..types import Address, Overlay, Peer
+    from ..types import Address, Peer
 
 
 class RandomChurn(DiscoveryStrategy):
@@ -53,6 +54,7 @@ class RandomChurn(DiscoveryStrategy):
         """
         Select a new (set of) peer(s) to investigate liveness for.
         """
+        self.overlay = cast(Overlay, self.overlay)
         with self.walk_lock:
             # Find an inactive or droppable peer
             sample_size = min(len(self.overlay.network.verified_peers), self.sample_size)

--- a/ipv8/peerdiscovery/community.py
+++ b/ipv8/peerdiscovery/community.py
@@ -43,12 +43,12 @@ class PeriodicSimilarity(DiscoveryStrategy):
         """
         Select a random peer, at most every second, to send a similarity request to.
         """
+        self.overlay = cast(DiscoveryCommunity, self.overlay)
         now = time()
         if (now - self.last_step < 1.0) or not self.overlay.network.verified_peers:
             return
         self.last_step = now
         with self.walk_lock:
-            self.overlay = cast(DiscoveryCommunity, self.overlay)
             self.overlay.send_similarity_request(sample(list(self.overlay.network.verified_peers), 1)[0].address)
 
 

--- a/ipv8_service.py
+++ b/ipv8_service.py
@@ -181,8 +181,7 @@ else:
                         try:
                             # We wrap the take_step into a general except as it is prone to programmer error.
                             # Even ``get_peers()`` may fail (https://github.com/Tribler/py-ipv8/issues/1136).
-                            peer_count = len(strategy.overlay.get_peers())
-                            if (target_peers == -1) or (peer_count < target_peers):
+                            if (target_peers == -1) or (strategy.get_peer_count() < target_peers):
                                 strategy.take_step()
                         except Exception:
                             logging.exception("Exception occurred while trying to walk!\n%s,"


### PR DESCRIPTION
This PR:

 - Fixes the `ruff` violations in the `REST` folder.
 - Fixes the `ruff` violations in `peer.py` (touched due to the previous bullet point).
 - Fixes incorrect types in the `peerdiscovery` folder.
 - Removes the `TransactionSchema` and `BlockSchema` JSON schemas, relating to `TrustChain` (which was moved away from the IPv8 codebase 3 years ago 😃).
 - Updates `DiscoveryStrategy` and `IPv8` to explicitly deal with strategies without overlays.