### PR TITLE
Fixed line numbers in docs

### DIFF
--- a/doc/basics/requestcache_tutorial.rst
+++ b/doc/basics/requestcache_tutorial.rst
@@ -45,7 +45,7 @@ Both the ``identifier`` fields for the messages and the ``name`` for the cache a
 Please attentively read through this code:
 
 .. literalinclude:: requestcache_tutorial_3.py
-   :lines: 12-93
+   :lines: 12-91
 
 You are encouraged to play around with this code.
 Also, take notice of the fact that this example includes a replay attack (try removing the cache and see what happens).

--- a/doc/basics/tasks_tutorial.rst
+++ b/doc/basics/tasks_tutorial.rst
@@ -74,7 +74,7 @@ Next to simply adding tasks, the ``TaskManager`` also allows you to invoke calls
 The following example will add the value ``1`` to the ``COMPLETED`` list periodically and inject a single value of ``2`` after half a second:
 
 .. literalinclude:: tasks_tutorial_5.py
-   :lines: 8-26
+   :lines: 8-25
 
 This example prints ``[1, 1, 1, 1, 2, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]``.
 

--- a/doc/basics/tasks_tutorial_3.py
+++ b/doc/basics/tasks_tutorial_3.py
@@ -19,6 +19,6 @@ async def main():
     await task_manager.wait_for_tasks()
 
     await task_manager.shutdown_task_manager()
+    print(COMPLETED)
 
 asyncio.run(main())
-print(COMPLETED)

--- a/doc/basics/tasks_tutorial_4.py
+++ b/doc/basics/tasks_tutorial_4.py
@@ -19,6 +19,6 @@ async def main():
     await task_manager.wait_for_tasks()
 
     await task_manager.shutdown_task_manager()
+    print(COMPLETED)
 
 asyncio.run(main())
-print(COMPLETED)

--- a/doc/basics/tasks_tutorial_5.py
+++ b/doc/basics/tasks_tutorial_5.py
@@ -22,6 +22,6 @@ async def main():
     await task_manager.wait_for_tasks()
 
     await task_manager.shutdown_task_manager()
+    print(COMPLETED)
 
 asyncio.run(main())
-print(COMPLETED)

--- a/doc/further-reading/advanced_identity.rst
+++ b/doc/further-reading/advanced_identity.rst
@@ -20,14 +20,14 @@ Enabling anonymization
 In the basic identity tutorial we created the following configuration:
 
 .. literalinclude:: ../basics/identity_tutorial_1.py
-   :lines: 10-15
+   :lines: 11-16
    :dedent: 4
 
 To enable anonymization of all traffic through the identity layer we need to load the anonymization overlay.
 This is done by editing the loaded overlays through ``configuration['overlays']``, as follows:
 
 .. literalinclude:: advanced_identity_1.py
-   :lines: 10-16
+   :lines: 11-17
    :dedent: 4
 
 Inclusion of the ``'HiddenTunnelCommunity'`` overlay automatically enables anonymization of identity traffic.
@@ -44,13 +44,13 @@ Setting a REST API key
 In the basic identity tutorial we started the REST API as follows:
 
 .. literalinclude:: ../basics/identity_tutorial_1.py
-   :lines: 17-21
+   :lines: 18-22
    :dedent: 4
 
 To set a REST API key, we will have to pass it to the ``RESTManager`` constructor, as follows (replacing ``"my secret key"`` with your key):
 
 .. literalinclude:: advanced_identity_1.py
-   :lines: 18-22
+   :lines: 19-23
    :dedent: 4
 
 All requests to the core will then have to use either:
@@ -68,13 +68,13 @@ Using a REST API X509 certificate
 In the basic identity tutorial we started the REST API as follows:
 
 .. literalinclude:: ../basics/identity_tutorial_1.py
-   :lines: 17-21
+   :lines: 18-22
    :dedent: 4
 
 To use a certificate file, we will have to pass it to the ``RESTManager`` constructor, as follows (replacing ``cert_fileX`` with the file path of your certificate file for the particular IPv8 instance):
 
 .. literalinclude:: advanced_identity_2.py
-   :lines: 25-31
+   :lines: 26-32
    :dedent: 4
 
 This can (and should) be combined with an API key.

--- a/stresstest/peer_discovery_defaults.py
+++ b/stresstest/peer_discovery_defaults.py
@@ -66,8 +66,6 @@ async def start_communities() -> None:
 
     create_task(on_timeout(event))
 
-    # Override the Community master peers so we don't interfere with the live network
-    # Also hook in our custom logic for introduction responses
     for community_cls in _COMMUNITIES.values():
         community_cls.community_id = os.urandom(20)
         community_cls.introduction_response_callback = lambda *args, e=event: custom_intro_response_cb(*args, e)


### PR DESCRIPTION
After merging https://github.com/Tribler/py-ipv8/pull/1154 some of the line numbers in the docs were off. This PR fixes this.

