### PR TITLE
Fixed ruff violations for the scripts folder

### DIFF
--- a/doc/further-reading/anonymization.rst
+++ b/doc/further-reading/anonymization.rst
@@ -59,7 +59,7 @@ The community can be initialized using the ``TunnelSettings`` class. This class 
 
 * *min_circuits*\ : the minimum amount of circuits to create before ``tunnels_ready()`` gives a value larger than 1.0
 * *max_circuits*\ : the maximum amount of circuits to create
-* *max_relays_or_exits*\ : the maximum amount of circuits, which are not our own, we will partake in
+* *max_joined_circuits*\ : the maximum amount of circuits, which are not our own, we will partake in
 * *max_time*\ : the time after which a circuit will be removed (for security reasons)
 * *max_time_inactive*\ : the time after which an idle circuit is removed
 * *max_traffic*\ : the amount of traffic after which a circuit will be removed (for security reasons)

--- a/ipv8/configuration.py
+++ b/ipv8/configuration.py
@@ -113,7 +113,7 @@ default: dict[Any, Any] = {
                 'settings': {
                     'min_circuits': 1,
                     'max_circuits': 1,
-                    'max_relays_or_exits': 100,
+                    'max_joined_circuits': 100,
                     'max_time': 10 * 60,
                     'max_time_inactive': 20,
                     'max_traffic': 250 * 1024 * 1024,

--- a/ipv8/test/test_configuration.py
+++ b/ipv8/test/test_configuration.py
@@ -3,11 +3,18 @@ import json
 
 import marshmallow
 
-from .base import TestBase
-from ..configuration import (Bootstrapper, BootstrapperDefinition, ConfigBuilder, DISPERSY_BOOTSTRAPPER, Strategy,
-                             WalkerDefinition, get_default_configuration)
+from ..configuration import (
+    DISPERSY_BOOTSTRAPPER,
+    Bootstrapper,
+    BootstrapperDefinition,
+    ConfigBuilder,
+    Strategy,
+    WalkerDefinition,
+    get_default_configuration,
+)
 from ..keyvault.crypto import default_eccrypto
 from ..keyvault.private.libnaclkey import LibNaCLSK
+from .base import TestBase
 
 
 class IPv8ConfigurationSchema(marshmallow.Schema):
@@ -16,21 +23,40 @@ class IPv8ConfigurationSchema(marshmallow.Schema):
     """
 
     class LoggerSchema(marshmallow.Schema):
+        """
+        The expected JSON schema for the logger configuration.
+        """
+
         level = marshmallow.fields.Str()
 
     class InterfaceSchema(marshmallow.Schema):
+        """
+        The expected JSON schema for the interfaces configuration.
+        """
+
         interface = marshmallow.fields.Str()
         ip = marshmallow.fields.Str()
         port = marshmallow.fields.Int()
 
     class KeySchema(marshmallow.Schema):
+        """
+        The expected JSON schema for the keys configuration.
+        """
+
         alias = marshmallow.fields.Str()
         generation = marshmallow.fields.Str()
         file = marshmallow.fields.Str()
 
     class OverlaySchema(marshmallow.Schema):
+        """
+        The expected JSON schema for an overlay's configuration.
+        """
 
         class WalkerSchema(marshmallow.Schema):
+            """
+            The expected JSON schema for walker configuration.
+            """
+
             strategy = marshmallow.fields.Str()
             peers = marshmallow.fields.Int()
             init = marshmallow.fields.Dict()
@@ -52,13 +78,19 @@ class IPv8ConfigurationSchema(marshmallow.Schema):
 
 
 class TestConfiguration(TestBase):
+    """
+    Tests related to IPv8 configuration.
+    """
 
-    def assertDictInDict(self, expected: dict, container: dict):
-        self.assertTrue(any(all(entry.get(key) == expected[key] for key in expected.keys())
+    def assertDictInDict(self, expected: dict, container: dict) -> None:  # noqa: N802
+        """
+        Check if a dictionary exists in another dictionary.
+        """
+        self.assertTrue(any(all(entry.get(key) == expected[key] for key in expected)
                             and len(entry) == len(expected)
                             for entry in container))
 
-    def test_clear_keys(self):
+    def test_clear_keys(self) -> None:
         """
         Check if all keys are cleared when requested.
         """
@@ -66,7 +98,7 @@ class TestConfiguration(TestBase):
 
         self.assertEqual(0, len(builder.config['keys']))
 
-    def test_clear_overlays(self):
+    def test_clear_overlays(self) -> None:
         """
         Check if all overlays are cleared when requested.
         """
@@ -74,7 +106,7 @@ class TestConfiguration(TestBase):
 
         self.assertEqual(0, len(builder.finalize()['overlays']))
 
-    def test_change_port(self):
+    def test_change_port(self) -> None:
         """
         Check if changes to the port are finalized.
         """
@@ -82,7 +114,7 @@ class TestConfiguration(TestBase):
 
         self.assertEqual(1000, builder.finalize()['interfaces'][0]['port'])
 
-    def test_change_address(self):
+    def test_change_address(self) -> None:
         """
         Check if changes to the address are finalized.
         """
@@ -90,7 +122,7 @@ class TestConfiguration(TestBase):
 
         self.assertEqual("1.1.1.1", builder.finalize()['interfaces'][0]['ip'])
 
-    def test_set_illegal_log_level(self):
+    def test_set_illegal_log_level(self) -> None:
         """
         Check if wrong log levels raise an error immediately.
         """
@@ -98,7 +130,7 @@ class TestConfiguration(TestBase):
 
         self.assertRaises(AssertionError, builder.set_log_level, "I don't exist")
 
-    def test_change_log_level(self):
+    def test_change_log_level(self) -> None:
         """
         Check if changes to the log level are finalized.
         """
@@ -106,7 +138,7 @@ class TestConfiguration(TestBase):
 
         self.assertEqual("CRITICAL", builder.finalize()['logger']['level'])
 
-    def test_set_illegal_walk_interval(self):
+    def test_set_illegal_walk_interval(self) -> None:
         """
         Check if negative walk intervals raise an error on finalization.
         """
@@ -114,7 +146,7 @@ class TestConfiguration(TestBase):
 
         self.assertRaises(AssertionError, builder.finalize)
 
-    def test_change_walk_interval(self):
+    def test_change_walk_interval(self) -> None:
         """
         Check if changes to the walk interval are finalized.
         """
@@ -122,7 +154,7 @@ class TestConfiguration(TestBase):
 
         self.assertEqual(3.14, builder.finalize()['walker_interval'])
 
-    def test_add_key_illegal_curve(self):
+    def test_add_key_illegal_curve(self) -> None:
         """
         Check if wrong key curves raise an error immediately.
         """
@@ -130,7 +162,7 @@ class TestConfiguration(TestBase):
 
         self.assertRaises(AssertionError, builder.add_key, "my key", "I don't exist", "some file")
 
-    def test_add_key(self):
+    def test_add_key(self) -> None:
         """
         Check if changes to the keys are finalized.
         """
@@ -146,7 +178,7 @@ class TestConfiguration(TestBase):
         self.assertEqual(1 + len(get_default_configuration()['keys']), len(keys))
         self.assertTrue(any(set(entry.items()) == set(expected.items()) for entry in keys))
 
-    def test_add_key_from_bin(self):
+    def test_add_key_from_bin(self) -> None:
         """
         Check if changes to the keys are finalized in bin mode.
         """
@@ -163,7 +195,7 @@ class TestConfiguration(TestBase):
         self.assertEqual(1 + len(get_default_configuration()['keys']), len(keys))
         self.assertTrue(any(set(entry.items()) == set(expected.items()) for entry in keys))
 
-    def test_add_key_from_bin_file(self):
+    def test_add_key_from_bin_file(self) -> None:
         """
         Check if changes to the keys are finalized in bin mode with a file.
         """
@@ -181,7 +213,7 @@ class TestConfiguration(TestBase):
         self.assertEqual(1 + len(get_default_configuration()['keys']), len(keys))
         self.assertTrue(any(set(entry.items()) == set(expected.items()) for entry in keys))
 
-    def test_add_ephemeral_key(self):
+    def test_add_ephemeral_key(self) -> None:
         """
         Check if ephemeral keys are created correctly.
         """
@@ -196,7 +228,7 @@ class TestConfiguration(TestBase):
         self.assertEqual("", keys[-1]["file"])
         self.assertIsInstance(default_eccrypto.key_from_private_bin(base64.b64decode(keys[-1]["bin"])), LibNaCLSK)
 
-    def test_add_overlay_overwrite(self):
+    def test_add_overlay_overwrite(self) -> None:
         """
         Check if the allow duplicate flag does not introduce duplicates.
         """
@@ -215,7 +247,7 @@ class TestConfiguration(TestBase):
         self.assertEqual(len(get_default_configuration()['overlays']), len(builder.finalize()['overlays']))
         self.assertDictInDict(expected, builder.finalize()['overlays'])
 
-    def test_add_overlay_append(self):
+    def test_add_overlay_append(self) -> None:
         """
         Check if the duplicate overlays are simply appended.
         """
@@ -234,7 +266,7 @@ class TestConfiguration(TestBase):
         self.assertEqual(1 + len(get_default_configuration()['overlays']), len(builder.finalize()['overlays']))
         self.assertDictInDict(expected, builder.finalize()['overlays'])
 
-    def test_add_overlay_complex(self):
+    def test_add_overlay_complex(self) -> None:
         """
         Check if a complex overlay is correctly added.
         """
@@ -270,7 +302,7 @@ class TestConfiguration(TestBase):
 
         self.assertDictInDict(expected, builder.finalize()['overlays'])
 
-    def test_correct_random_churn_strategy(self):
+    def test_correct_random_churn_strategy(self) -> None:
         """
         The DiscoveryCommunity may use the RandomChurn strategy.
         """
@@ -297,7 +329,7 @@ class TestConfiguration(TestBase):
         self.assertEqual(len(get_default_configuration()['overlays']), len(builder.finalize()['overlays']))
         self.assertDictInDict(expected, builder.finalize()['overlays'])
 
-    def test_correct_periodic_similarity_strategy(self):
+    def test_correct_periodic_similarity_strategy(self) -> None:
         """
         The DiscoveryCommunity may use the PeriodicSimilarity strategy.
         """
@@ -324,7 +356,7 @@ class TestConfiguration(TestBase):
         self.assertEqual(len(get_default_configuration()['overlays']), len(builder.finalize()['overlays']))
         self.assertDictInDict(expected, builder.finalize()['overlays'])
 
-    def test_default_configuration(self):
+    def test_default_configuration(self) -> None:
         """
         Check if we can reconstruct the default configuration.
         """
@@ -356,7 +388,7 @@ class TestConfiguration(TestBase):
                                                   {'settings': {
                                                       'min_circuits': 1,
                                                       'max_circuits': 1,
-                                                      'max_relays_or_exits': 100,
+                                                      'max_joined_circuits': 100,
                                                       'max_time': 10 * 60,
                                                       'max_time_inactive': 20,
                                                       'max_traffic': 250 * 1024 * 1024,
@@ -374,7 +406,7 @@ class TestConfiguration(TestBase):
 
         self.assertDictEqual(get_default_configuration(), builder.finalize())
 
-    def test_default_schema(self):
+    def test_default_schema(self) -> None:
         """
         Check if the default configuration is JSON-serializable and follows the expected schema.
         """

--- a/scripts/exitnode_ipv8_only_plugin.py
+++ b/scripts/exitnode_ipv8_only_plugin.py
@@ -18,6 +18,8 @@ Configuring Sentry:
         SETX SENTRY_URL <sentry_url>
     ```
 """
+from __future__ import annotations
+
 import argparse
 import os
 import sys
@@ -31,17 +33,19 @@ try:
 except ImportError:
     import __scriptpath__  # noqa: F401
 
-from ipv8.REST.rest_manager import RESTManager
 from ipv8.configuration import get_default_configuration
 from ipv8.messaging.anonymization.tunnel import PEER_FLAG_EXIT_IPV8
+from ipv8.REST.rest_manager import RESTManager
 from ipv8.util import run_forever
-
 from ipv8_service import IPv8
 
 
 class ExitnodeIPv8Service:
+    """
+    Exit node service that only allows IPv8 community data to be exited.
+    """
 
-    def __init__(self):
+    def __init__(self) -> None:
         """
         Initialize the variables of the IPV8Service and the logger.
         """
@@ -49,7 +53,7 @@ class ExitnodeIPv8Service:
         self.restapi = None
         self.tc_persistence = None
 
-    async def start_ipv8(self, statedir, listen_port, statistics, no_rest_api):
+    async def start_ipv8(self, statedir: str | None, listen_port: int, statistics: bool, no_rest_api: bool) -> None:
         """
         Main method to startup IPv8.
         """
@@ -69,10 +73,10 @@ class ExitnodeIPv8Service:
             if overlay['class'] == 'HiddenTunnelCommunity':
                 overlay['initialize']['settings']['min_circuits'] = 0
                 overlay['initialize']['settings']['max_circuits'] = 0
-                overlay['initialize']['settings']['max_relays_or_exits'] = 1000
+                overlay['initialize']['settings']['max_joined_circuits'] = 1000
                 overlay['initialize']['settings']['peer_flags'] = {PEER_FLAG_EXIT_IPV8}
 
-        print("Starting IPv8")
+        print("Starting IPv8")  # noqa: T201
 
         self.ipv8 = IPv8(configuration, enable_statistics=statistics)
         await self.ipv8.start()
@@ -81,8 +85,11 @@ class ExitnodeIPv8Service:
             self.restapi = RESTManager(self.ipv8)
             await self.restapi.start()
 
-    async def stop_ipv8(self):
-        print("Stopping IPv8")
+    async def stop_ipv8(self) -> None:
+        """
+        Stop IPv8 and its REST API.
+        """
+        print("Stopping IPv8")  # noqa: T201
 
         if self.restapi:
             await self.restapi.stop()
@@ -90,7 +97,10 @@ class ExitnodeIPv8Service:
             await self.ipv8.stop()
 
 
-async def main(argv):
+async def main(argv: list[str]) -> None:
+    """
+    Start an IPv8 exit service with some given commandline arguments.
+    """
     parser = argparse.ArgumentParser(add_help=False, description=('IPv8-only exit node plugin'))
     parser.add_argument('--help', '-h', action='help', default=argparse.SUPPRESS, help='Show this help message and exit')
     parser.add_argument('--listen_port', '-p', default=8090, type=int, help='Use an alternative port')
@@ -112,6 +122,6 @@ if __name__ == "__main__":
         # If no SENTRY_URL is defined, then no reports are sent
         sentry_sdk.init(os.environ.get('SENTRY_URL'), traces_sample_rate=1.0)
     except ImportError:
-        print('sentry-sdk is not installed. To install sentry-sdk run `pip install sentry-sdk`')
+        print('sentry-sdk is not installed. To install sentry-sdk run `pip install sentry-sdk`')  # noqa: T201
 
     run(main(sys.argv[1:]))

--- a/scripts/ipv8_plugin.py
+++ b/scripts/ipv8_plugin.py
@@ -1,6 +1,8 @@
 """
 This script enables to start IPv8 headless.
 """
+from __future__ import annotations
+
 import argparse
 import ssl
 import sys
@@ -15,27 +17,29 @@ except ImportError:
     import __scriptpath__  # noqa: F401
 
 
-from ipv8.REST.rest_manager import RESTManager
 from ipv8.configuration import get_default_configuration
+from ipv8.REST.rest_manager import RESTManager
 from ipv8.util import run_forever
-
 from ipv8_service import IPv8
 
 
 class IPV8Service:
+    """
+    Service to orchestrate an IPv8 instance and a REST API.
+    """
 
-    def __init__(self):
+    def __init__(self) -> None:
         """
-        Initialize the variables of the IPV8ServiceMaker and the logger.
+        Initialize the variables of the IPV8Service.
         """
         self.ipv8 = None
         self.restapi = None
 
-    async def start_ipv8(self, statistics, no_rest_api, api_key, cert_file):
+    async def start_ipv8(self, statistics: bool, no_rest_api: bool, api_key: str | None, cert_file: str) -> None:
         """
         Main method to startup IPv8.
         """
-        print("Starting IPv8")
+        print("Starting IPv8")  # noqa: T201
 
         self.ipv8 = IPv8(get_default_configuration(), enable_statistics=statistics)
         await self.ipv8.start()
@@ -55,8 +59,11 @@ class IPV8Service:
             self.restapi = RESTManager(self.ipv8)
             await self.restapi.start(api_key=api_key, ssl_context=ssl_context)
 
-    async def stop_ipv8(self):
-        print("Stopping IPv8")
+    async def stop_ipv8(self) -> None:
+        """
+        Stop the service.
+        """
+        print("Stopping IPv8")  # noqa: T201
 
         if self.restapi:
             await self.restapi.stop()
@@ -64,7 +71,10 @@ class IPV8Service:
             await self.ipv8.stop()
 
 
-async def main(argv):
+async def main(argv: list[str]) -> None:
+    """
+    Create a service to run IPv8 and a REST API from some given commandline arguments.
+    """
     parser = argparse.ArgumentParser(description='Starts IPv8 as a service')
     parser.add_argument('--statistics', '-s', action='store_true', help='Enable IPv8 overlay statistics')
     parser.add_argument('--no-rest-api', '-a', action='store_true', help='Autonomous: disable the REST api')

--- a/scripts/tracker_plugin.py
+++ b/scripts/tracker_plugin.py
@@ -15,12 +15,15 @@ try:
 except ImportError:
     import __scriptpath__  # noqa: F401
 
-from ipv8.util import run_forever
-
 from tracker_service import TrackerService
 
+from ipv8.util import run_forever
 
-async def main():
+
+async def main() -> None:
+    """
+    Start a tracker service with some given commandline arguments.
+    """
     parser = argparse.ArgumentParser(add_help=False,
                                      description='IPv8 tracker plugin')
     parser.add_argument('--help', '-h', action='help',

--- a/scripts/tracker_service.py
+++ b/scripts/tracker_service.py
@@ -1,12 +1,15 @@
 """
-Common classes for tracker_plugin.py and tracker_reporter_plugin.py scripts
+Common classes for tracker_plugin.py and tracker_reporter_plugin.py scripts.
 """
+from __future__ import annotations
+
 import os
 import random
 import ssl
 import time
 import traceback
 from binascii import hexlify
+from typing import TYPE_CHECKING
 
 from aiohttp import web
 
@@ -19,8 +22,6 @@ except ImportError:
     import __scriptpath__  # noqa: F401
 
 
-from ipv8.REST.base_endpoint import Response
-from ipv8.REST.rest_manager import ApiKeyMiddleware
 from ipv8.community import Community
 from ipv8.keyvault.crypto import default_eccrypto
 from ipv8.messaging.interfaces.udp.endpoint import UDPEndpoint, UDPv4LANAddress
@@ -29,14 +30,33 @@ from ipv8.peer import Peer
 from ipv8.peerdiscovery.churn import RandomChurn
 from ipv8.peerdiscovery.network import Network
 from ipv8.requestcache import NumberCache, RequestCache
+from ipv8.REST.base_endpoint import Response
+from ipv8.REST.rest_manager import ApiKeyMiddleware
+
+if TYPE_CHECKING:
+    from aiohttp.abc import Request
+
+    from ipv8.types import Address, Endpoint, Overlay
 
 
 class TrackerChurn(RandomChurn):
-    def __init__(self, *args, max_peers=100, **kwargs):
-        super().__init__(*args, **kwargs)
+    """
+    Strategy to get rid of unresponsive of superfluous peers.
+    """
+
+    def __init__(self, overlay: Overlay, sample_size: int = 8,  # noqa: PLR0913
+                 ping_interval: float = 10.0, inactive_time: float = 27.5, drop_time: float = 57.5,
+                 max_peers: int = 100) -> None:
+        """
+        Initialize a new churn strategy with a maximum peer count.
+        """
+        super().__init__(overlay, sample_size, ping_interval, inactive_time, drop_time)
         self.max_peers = max_peers
 
-    def take_step(self):
+    def take_step(self) -> None:
+        """
+        Inspect our peers and remove some if necessary.
+        """
         super().take_step()
         if len(self.overlay.network.verified_peers) > self.max_peers:
             to_remove = sorted(self.overlay.network.verified_peers, key=lambda p: p.creation_time)[:-self.max_peers]
@@ -45,19 +65,34 @@ class TrackerChurn(RandomChurn):
 
 
 class TrackerPing(NumberCache):
+    """
+    Cache to store the state of a liveness ping.
+    """
+
     name = "tracker-ping"
 
-    def __init__(self, request_cache, identifier, network, peer, service):
+    def __init__(self, request_cache: RequestCache, identifier: int, network: Network,  # noqa: PLR0913
+                 peer: Peer, service: bytes) -> None:
+        """
+        Create a new cache for the given peer and service.
+        """
         super().__init__(request_cache, TrackerPing.name, identifier)
         self.network = network
         self.peer = peer
         self.service = service
 
     @property
-    def timeout_delay(self):
+    def timeout_delay(self) -> float:
+        """
+        Consider a peer unreachable after 5 seconds.
+        """
         return 5.0
 
-    def on_timeout(self):
+    def on_timeout(self) -> None:
+        """
+        If a peer is unreachable for some service, don't remove it immediately as it may still be available for
+        other services.
+        """
         services = self.network.get_services_for_peer(self.peer)
         services.discard(self.service)
         if not services:
@@ -69,9 +104,13 @@ class EndpointServer(Community):
     Make some small modifications to the Community to allow it a dynamic prefix.
     We will also only answer introduction requests.
     """
+
     community_id = os.urandom(20)
 
-    def __init__(self, endpoint):
+    def __init__(self, endpoint: Endpoint) -> None:
+        """
+        Create a new endpoint server.
+        """
         my_peer = Peer(default_eccrypto.generate_key("very-low"))
         self.signature_length = default_eccrypto.get_signature_length(my_peer.public_key)
         super().__init__(my_peer, endpoint, Network())
@@ -80,7 +119,11 @@ class EndpointServer(Community):
         self.churn_strategy = TrackerChurn(self)
         self.churn_task = self.register_task("churn", self.churn_strategy.take_step, interval=10)
 
-    def on_packet(self, packet, warn_unknown=False):
+    def on_packet(self, packet: tuple[Address, bytes], warn_unknown: bool = False) -> None:
+        """
+        A modified packet handler that only handles introduction requests and responses and disregards the community
+        id of this Community class.
+        """
         source_address, data = packet
         try:
             probable_peer = self.network.get_verified_by_address(source_address)
@@ -95,7 +138,10 @@ class EndpointServer(Community):
         except Exception:
             traceback.print_exc()
 
-    def on_generic_introduction_request(self, source_address, data, prefix):
+    def on_generic_introduction_request(self, source_address: Address, data: bytes, prefix: bytes) -> None:
+        """
+        Handle introduction requests without assuming a community id (prefix).
+        """
         auth, dist, payload = self._ez_unpack_auth(IntroductionRequestPayload, data)
         peer = Peer(auth.public_key_bin, source_address)
         peer.address = UDPv4LANAddress(*payload.source_lan_address)
@@ -107,19 +153,18 @@ class EndpointServer(Community):
         self.network.add_verified_peer(peer)
         self.network.discover_services(peer, [service_id, ])
 
-        intro_peers = [p for p in self.network.get_peers_for_service(service_id)
-                       if not p == peer]
-        if intro_peers:
-            intro_peer = random.choice(intro_peers)
-        else:
-            intro_peer = None
+        intro_peers = [p for p in self.network.get_peers_for_service(service_id) if p != peer]
+        intro_peer = random.choice(intro_peers) if intro_peers else None
 
         packet = self.create_introduction_response(
             payload.destination_address, peer.address, payload.identifier,
             introduction=intro_peer, prefix=prefix)
         self.endpoint.send(peer.address, packet)
 
-    def send_ping(self, peer):
+    def send_ping(self, peer: Peer) -> None:
+        """
+        Send a ping to a peer to check if it is still live and looking for other peers.
+        """
         service = random.choice(tuple(self.network.get_services_for_peer(peer)))
         prefix = b'\x00' + self.version + service
         packet = self.create_introduction_request(peer.address, prefix=prefix)
@@ -127,7 +172,12 @@ class EndpointServer(Community):
         self.request_cache.add(cache)
         self.endpoint.send(peer.address, packet)
 
-    def on_generic_introduction_response(self, source_address, data, prefix):
+    def on_generic_introduction_response(self, source_address: Address, data: bytes, prefix: bytes) -> None:
+        """
+        Callback for when a peer responds with an introduction response to our ping requests.
+
+        If the peer IS responsive but flags that it already has too many peers, remove it.
+        """
         auth, dist, payload = self._ez_unpack_auth(IntroductionResponsePayload, data)
         if not self.request_cache.has('tracker-ping', payload.identifier):
             return
@@ -140,27 +190,33 @@ class EndpointServer(Community):
             if not services:
                 self.network.remove_peer(peer)
 
-    def on_peer_introduction_request(self, peer, source_address, service_id):
+    def on_peer_introduction_request(self, peer: Peer, source_address: Address, service_id: bytes) -> None:
         """
-        A hook to collect anonymized statistics about total peer count
+        A hook to collect anonymized statistics about total peer count.
         """
 
-    def get_peer_for_introduction(self, exclude=None, new_style=False):
+    def get_peer_for_introduction(self, exclude: Peer | None = None, new_style: bool = False) -> None:
         """
         We explicitly provide create_introduction_response with a peer.
         If on_generic_introduction_request provides None, this method should not suggest a peer.
         More so as the get_peer_for_introduction peer would be for the DiscoveryCommunity.
         """
-        return None
+        return
 
-    async def unload(self):
+    async def unload(self) -> None:
+        """
+        Shutdown the request cache.
+        """
         await self.request_cache.shutdown()
         await super().unload()
 
 
 class TrackerService:
+    """
+    The main service that manages a tracker/bootstrap server instance.
+    """
 
-    def __init__(self):
+    def __init__(self) -> None:
         """
         Initialize the variables of the TrackerServiceMaker and the logger.
         """
@@ -168,26 +224,32 @@ class TrackerService:
         self.overlay = None
         self.site = None
 
-    def create_endpoint_server(self):
+    def create_endpoint_server(self) -> EndpointServer:
+        """
+        Instantiate our reporting Community.
+        """
         return EndpointServer(self.endpoint)
 
-    async def start_tracker(self, listen_port):
+    async def start_tracker(self, listen_port: int) -> None:
         """
-        Main method to startup the tracker.
+        Main method to start up the tracker.
         """
         self.endpoint = UDPEndpoint(listen_port)
         await self.endpoint.open()
         self.overlay = self.create_endpoint_server()
 
-        print("Started tracker")
+        print("Started tracker")  # noqa: T201
 
-    async def start_api(self, listen_port, api_key, cert_file):
+    async def start_api(self, listen_port: int, api_key: str | None, cert_file: str) -> None:
+        """
+        Start the REST API.
+        """
         ssl_context = None
         if cert_file:
             ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
             ssl_context.load_cert_chain(cert_file)
 
-        async def get_services(_):
+        async def get_services(_: Request) -> Response:
             services = set.union(*self.overlay.network.services_per_peer.values()) \
                 if self.overlay.network.services_per_peer else set()
             return Response({
@@ -202,16 +264,19 @@ class TrackerService:
         self.site = web.TCPSite(runner, '0.0.0.0', listen_port, ssl_context=ssl_context)
         await self.site.start()
 
-        print("Started API server")
+        print("Started API server")  # noqa: T201
 
-    async def shutdown(self):
+    async def shutdown(self) -> None:
+        """
+        Shut down the tracker and its REST API.
+        """
         if self.site:
             await self.site.stop()
-            print("Stopped API server")
+            print("Stopped API server")  # noqa: T201
 
         if self.endpoint:
             self.endpoint.close()
 
         if self.overlay:
             await self.overlay.unload()
-            print("Stopped tracker")
+            print("Stopped tracker")  # noqa: T201


### PR DESCRIPTION
This PR:

 - Fixes the remaining `ruff` violations in the `scripts` folder.
 - Updates references to `max_relays_or_exits` by replacing them with the appropriate `max_joined_circuits` (fix ported from #1144).
