### PR TITLE
Fixed ruff violations for the irmaexact folder

### DIFF
--- a/ipv8/attestation/wallet/irmaexact/__init__.py
+++ b/ipv8/attestation/wallet/irmaexact/__init__.py
@@ -2,7 +2,10 @@ import os
 from functools import reduce
 
 
-def secure_randint(bitspace):
+def secure_randint(bitspace: int) -> int:
+    """
+    Generate an integer in a given bitspace using the OS rng.
+    """
     delbits = 8 - (bitspace % 8)
     bytez = os.urandom(bitspace // 8)
     if delbits > 0:

--- a/ipv8/attestation/wallet/irmaexact/algorithm.py
+++ b/ipv8/attestation/wallet/irmaexact/algorithm.py
@@ -1,61 +1,104 @@
+from __future__ import annotations
+
 import binascii
 import json
 import os
+from typing import Any, cast
 
+from ...identity_formats import Attestation, IdentityAlgorithm
+from ..primitives.structs import ipack, iunpack
 from .gabi.attributes import make_attribute_list
 from .gabi.keys import DefaultSystemParameters
-from .gabi.proofs import createChallenge
+from .gabi.proofs import ProofD, createChallenge
 from .wrappers import challenge_response, serialize_proof_d, unserialize_proof_d
-from ..primitives.structs import ipack, iunpack
-from ...identity_formats import Attestation, IdentityAlgorithm
+
+# ruff: noqa: N803,N806
 
 
 class IRMAAttestation(Attestation):
+    """
+    IPv8 wrapper for IRMA-based attestations.
+    """
 
-    def __init__(self, sign_date, proofd, z=None):
+    def __init__(self, sign_date: int, proofd: ProofD, z: int | None = None) -> None:
+        """
+        Create a new IPv8 attestation for the given diclosure proof and Z value.
+        """
         self.sign_date = sign_date
         self.proofd = proofd
         self.z = z
 
-    def serialize(self):
+    def serialize(self) -> bytes:
+        """
+        Make this attestation transferrable.
+        """
         return ipack(self.sign_date) + serialize_proof_d(self.proofd)
 
-    def serialize_private(self, PK):
+    def serialize_private(self, PK: None) -> bytes:
+        """
+        We don't use a base key for serialization.
+        """
         return ipack(self.z) + ipack(self.sign_date) + serialize_proof_d(self.proofd)
 
     @classmethod
-    def unserialize(cls, s, id_format):
+    def unserialize(cls: type[IRMAAttestation], s: bytes, id_format: str) -> IRMAAttestation:  # noqa: ARG003
+        """
+        Read an attestation from its serialized form.
+        """
         sign_date, rem = iunpack(s)
         return IRMAAttestation(sign_date, unserialize_proof_d(rem))
 
     @classmethod
-    def unserialize_private(cls, SK, s, id_format):
+    def unserialize_private(cls: type[IRMAAttestation], SK: None,  # noqa: ARG003
+                            s: bytes, id_format: str) -> IRMAAttestation:  # noqa: ARG003
+        """
+        Read the secret part of an attestation from its serialized form.
+        """
         z, rem = iunpack(s)
         sign_date, rem = iunpack(rem)
         return IRMAAttestation(sign_date, unserialize_proof_d(rem), z)
 
 
 class KeyStub:
+    """
+    We don't use an IPv8 key for this algorithm.
+    """
 
-    def public_key(self):
+    def public_key(self) -> KeyStub:
+        """
+        The public part of this key.
+        """
         return self
 
-    def serialize(self):
+    def serialize(self) -> bytes:
+        """
+        The serialized form of this key.
+        """
         return b''
 
     @classmethod
-    def unserialize(cls, s):
+    def unserialize(cls: type[KeyStub], s: bytes) -> KeyStub:  # noqa: ARG003
+        """
+        Load the key from the given bytes.
+        """
         return KeyStub()
 
 
 class IRMAExactAlgorithm(IdentityAlgorithm):
+    """
+    IPv8 wrapper around the IRMA business logic.
+    """
 
-    def __init__(self, id_format, formats):
+    def __init__(self, id_format: str, formats: dict[str, dict[str, Any]]) -> None:
+        """
+        Create a new IRMA wrapper.
+        """
         super().__init__(id_format, formats)
 
         # Check algorithm match
         if formats[id_format]["algorithm"] != "irmaexact":
-            raise RuntimeError("Identity format linked to wrong algorithm")
+            msg = "Identity format linked to wrong algorithm"
+            raise RuntimeError(msg)
 
         self.issuer_pk = formats[self.id_format]["issuer_pk"]
         self.attribute_order = formats[self.id_format]["order"]
@@ -70,25 +113,43 @@ class IRMAExactAlgorithm(IdentityAlgorithm):
         self.system_parameters = DefaultSystemParameters[1024]
         self.challenge_count = 8
 
-    def generate_secret_key(self):
+    def generate_secret_key(self) -> KeyStub:
+        """
+        Generate a fake secret key, we need none.
+        """
         return KeyStub()
 
-    def load_secret_key(self, serialized):
+    def load_secret_key(self, serialized: bytes) -> KeyStub:
+        """
+        Load a fake secret key, we need none.
+        """
         return KeyStub()
 
-    def load_public_key(self, serialized):
+    def load_public_key(self, serialized: bytes) -> KeyStub:
+        """
+        Load a fake public key, we need none.
+        """
         return KeyStub()
 
-    def get_attestation_class(self):
+    def get_attestation_class(self) -> type[IRMAAttestation]:
+        """
+        Get our class.
+        """
         return IRMAAttestation
 
-    def attest(self, PK, value):
+    def attest(self, PK: KeyStub, value: str) -> IRMAAttestation:
+        """
+        Not implemented.
+        """
         raise NotImplementedError("Only import_blob is supported (now) for IRMA.")
 
-    def certainty(self, value, aggregate):
+    def certainty(self, value: str, aggregate: dict) -> float:
+        """
+        Get the certainty that the given value is equal to the attestation in the aggregate.
+        """
         value_json = {"attributes": json.loads(value)}
         value_json.update(self.base_meta)
-        attestation = aggregate['attestation']
+        attestation = cast(IRMAAttestation, aggregate['attestation'])
         attr_ints, sign_date = make_attribute_list(value_json, self.attribute_order,
                                                    (self.validity, attestation.sign_date))
         reconstructed_attr_map = {}
@@ -112,26 +173,48 @@ class IRMAExactAlgorithm(IdentityAlgorithm):
 
         return 0.0 if failure else (verified / self.challenge_count)
 
-    def create_challenges(self, PK, attestation):
+    def create_challenges(self, PK: KeyStub, attestation: IRMAAttestation) -> list[bytes]:
+        """
+        Generate the raw messages to be sent over the Internet as challenges.
+        """
         return [ipack(int(binascii.hexlify(os.urandom(32)), 16) % self.issuer_pk.N)
                 for _ in range(self.challenge_count)]
 
-    def create_challenge_response(self, SK, attestation, challenge):
-        return challenge_response(attestation.proofd, attestation.z, challenge)
+    def create_challenge_response(self, SK: KeyStub, attestation: IRMAAttestation, challenge: bytes) -> bytes:
+        """
+        Create a response to a given challenge to our attestation.
+        """
+        return challenge_response(attestation.proofd, cast(int, attestation.z), challenge)
 
-    def create_certainty_aggregate(self, attestation):
+    def create_certainty_aggregate(self, attestation: IRMAAttestation) -> dict:
+        """
+        Create the aggregation dictionary (just one key with the attestation).
+        """
         return {'attestation': attestation}
 
-    def create_honesty_challenge(self, PK, value):
-        raise NotImplementedError()
+    def create_honesty_challenge(self, PK: KeyStub, value: bytes) -> bytes:
+        """
+        Not implemented.
+        """
+        raise NotImplementedError
 
-    def process_honesty_challenge(self, value, response):
-        raise NotImplementedError()
+    def process_honesty_challenge(self, value: bytes, response: bytes) -> bool:
+        """
+        Not implemented.
+        """
+        raise NotImplementedError
 
-    def process_challenge_response(self, aggregate, challenge, response):
+    def process_challenge_response(self, aggregate: dict,
+                                   challenge: bytes, response: bytes) -> None:
+        """
+        Process the response to our challenge.
+        """
         aggregate[challenge] = response
 
-    def import_blob(self, blob):
+    def import_blob(self, blob: bytes) -> tuple[bytes, None]:
+        """
+        Import raw data needed to construct an attestation for this algorithm.
+        """
         blob_json = json.loads(blob)
 
         sign_date = blob_json["sign_date"]

--- a/ipv8/attestation/wallet/irmaexact/gabi/attributes.py
+++ b/ipv8/attestation/wallet/irmaexact/gabi/attributes.py
@@ -5,21 +5,32 @@ All rights reserved.
 This source code has been ported from https://github.com/privacybydesign/irmago
 The authors of this file are not -in any way- affiliated with the original authors or organizations.
 """
+from __future__ import annotations
+
 import binascii
 import calendar
 import datetime
 import hashlib
 import time
+from typing import Any
 
 from .....util import int2byte
+
+# ruff: noqa: N801,N802,N803,N806,N816
 
 ExpiryFactor = 60 * 60 * 24 * 7
 metadataLength = 1 + 3 + 2 + 2 + 16
 
 
 class metadataField:
+    """
+    Metadata position information.
+    """
 
-    def __init__(self, length, offset):
+    def __init__(self, length: int, offset: int) -> None:
+        """
+        Create a new metadata field descriptor.
+        """
         self.length = length
         self.offset = offset
 
@@ -31,20 +42,32 @@ keyCounterField = metadataField(2, 6)
 credentialID = metadataField(16, 8)
 
 
-def int_to_str(n):
+def int_to_str(n: int) -> bytes:
+    """
+    Covert an integer of unbounded size to bytes.
+    """
     hexInt = hex(n).lstrip('0x').rstrip('L')
     if (len(hexInt) % 2) == 1:
         hexInt = '0' + hexInt
     return binascii.unhexlify(hexInt)
 
 
-def shortToByte(x):
+def shortToByte(x: int) -> bytes:
+    """
+    Convert a short (stored in a Python int type) to bytes.
+    """
     return int_to_str(x)[-2:]
 
 
 class MetadataAttribute:
+    """
+    Metadata values.
+    """
 
-    def __init__(self, version):
+    def __init__(self, version: bytes) -> None:
+        """
+        Create a new empty metadata container.
+        """
         self.Int = 0
         self.pk = None
         self.Conf = None
@@ -54,13 +77,19 @@ class MetadataAttribute:
         self.setKeyCounter(0)
         self.setExpiryDate()
 
-    def Bytes(self):
+    def Bytes(self) -> bytes:
+        """
+        Convert this metadata to bytes.
+        """
         bytez = int_to_str(self.Int)
         if len(bytez) < metadataLength:
             bytez += b'\x00' * (metadataLength - len(bytez))
         return bytez
 
-    def setField(self, field, value):
+    def setField(self, field: metadataField, value: bytes) -> None:
+        """
+        Set a given metadata field position to a given value.
+        """
         bytez_array = [int2byte(c) if isinstance(c, int) else c for c in self.Bytes()]
         startindex = field.length - len(value)
         for i in range(field.length):
@@ -71,47 +100,73 @@ class MetadataAttribute:
 
         self.Int = int(binascii.hexlify(b''.join(bytez_array)), 16)
 
-    def field(self, field):
+    def field(self, field: metadataField) -> bytes:
+        """
+        Retrieve the value of a given field.
+        """
         return self.Bytes()[field.offset:field.offset + field.length]
 
-    def setSigningDate(self, timestamp=None):
+    def setSigningDate(self, timestamp: int | None = None) -> None:
+        """
+        Set the date of signing in the metadata.
+
+        Note that the timestamp is a short in units of ``ExpiryFactor``.
+        """
         if timestamp:
             self.setField(signingDateField, shortToByte(timestamp))
         else:
             self.setField(signingDateField, shortToByte(int(time.time() / ExpiryFactor)))
 
-    def setKeyCounter(self, i):
+    def setKeyCounter(self, i: int) -> None:
+        """
+        Set the key counter field to a given value.
+        """
         self.setField(keyCounterField, shortToByte(i))
 
-    def SigningDate(self):
+    def SigningDate(self) -> int:
+        """
+        Get the signing date in seconds since the epoch (like ``int(time.time())``).
+        """
         bytez_array = [int2byte(c) if isinstance(c, int) else c for c in self.field(signingDateField)]
         bytez_array = bytez_array[1:]
-        timestamp = int(binascii.hexlify(b''.join(bytez_array)), 16) * ExpiryFactor
-        return timestamp
+        return int(binascii.hexlify(b''.join(bytez_array)), 16) * ExpiryFactor
 
-    def setValidityDuration(self, weeks):
+    def setValidityDuration(self, weeks: int) -> None:
+        """
+        Set the value of the validity duration field (in weeks).
+        """
         self.setField(validityField, shortToByte(weeks))
 
-    def setExpiryDate(self):
-        expiry = datetime.datetime.now()
+    def setExpiryDate(self) -> None:
+        """
+        Set the default validity duration.
+        """
+        expiry = datetime.datetime.now()  # noqa: DTZ005
         month = expiry.month - 1 + 6
         year = expiry.year + month // 12
         month = month % 12 + 1
         day = min(expiry.day, calendar.monthrange(year, month)[1])
-        expiry = time.mktime(datetime.date(year, month, day).timetuple())
+        fexpiry = time.mktime(datetime.date(year, month, day).timetuple())
+        signing = self.SigningDate()
+        self.setValidityDuration(int((fexpiry - signing) / ExpiryFactor))
+
+    def setExpiryDateFromTimestamp(self, expiry: float) -> None:
+        """
+        Set the validity duration from a given expiry timestamp (like ``time.time()``).
+        """
         signing = self.SigningDate()
         self.setValidityDuration(int((expiry - signing) / ExpiryFactor))
 
-    def setExpiryDateFromTimestamp(self, expiry):
-        signing = self.SigningDate()
-        self.setValidityDuration(int((expiry - signing) / ExpiryFactor))
-
-    def setCredentialTypeIdentifier(self, the_id):
+    def setCredentialTypeIdentifier(self, the_id: bytes) -> None:
+        """
+        Set the credential type field.
+        """
         bytez = hashlib.sha256(the_id).digest()
         self.setField(credentialID, bytez[:16])
 
 
-def make_attribute_list(cr, attribute_order=None, validity_signing=None):
+def make_attribute_list(cr: dict[str, Any], attribute_order: list[str] | None = None,
+                        validity_signing: tuple[int, int | None] | None = None) -> tuple[list[int], int]:
     """
     cr =
         {
@@ -119,7 +174,7 @@ def make_attribute_list(cr, attribute_order=None, validity_signing=None):
             u'credential': u'pbdf.nijmegen.address',
             u'keyCounter': 0,
             u'validity': 1570123936
-        }
+        }.
 
     :param attribute_order: the order in which to handle the keys
     :type attribute_order: list

--- a/ipv8/attestation/wallet/irmaexact/gabi/proofs.py
+++ b/ipv8/attestation/wallet/irmaexact/gabi/proofs.py
@@ -5,26 +5,44 @@ All rights reserved.
 This source code has been ported from https://github.com/privacybydesign/gabi
 The authors of this file are not -in any way- affiliated with the original authors or organizations.
 """
-from cryptography.hazmat.primitives.asymmetric.rsa import _modinv  # type:ignore
+from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
+from cryptography.hazmat.primitives.asymmetric.rsa import _modinv
 from pyasn1.codec.ber.encoder import encode
 from pyasn1.type import univ
 
 from ...primitives.attestation import sha256_as_int
 from ...primitives.value import FP2Value
 
+if TYPE_CHECKING:
+    from .keys import CLSignature, PublicKey
+
+# ruff: noqa: N802,N803,N806,N815
+
 
 class Record(univ.SequenceOf):
+    """
+    PyASN1 container for records (of integers).
+    """
+
     componentType = univ.Integer()
 
 
-def custom_asn1_marshal(values):
+def custom_asn1_marshal(values: list[int]) -> bytes:
+    """
+    Use ASN1 marshalling with universal integer encoding.
+    """
     return encode(values, asn1Spec=Record())
 
 
-def hashCommit(values, issig):
-    tmp = [True] if issig else []
-    tmp = tmp + [len(values)] + values
+def hashCommit(values: list[int], issig: bool) -> int:
+    """
+    Hash a list of values.
+    """
+    tmp = [1] if issig else []
+    tmp = [*tmp, len(values), *values]
     r = custom_asn1_marshal(tmp)
     if issig:
         indx = r.find(b'\x02\x01\x01')
@@ -32,66 +50,115 @@ def hashCommit(values, issig):
     return sha256_as_int(r)
 
 
-def createChallenge(context, nonce, contributions, issig):
-    return hashCommit([context] + contributions + [nonce], issig)
+def createChallenge(context: int, nonce: int, contributions: list[int], issig: bool) -> int:
+    """
+    Create a challenge for the given contributions.
+    """
+    return hashCommit([context, *contributions, nonce], issig)
 
 
 class ProofU:
+    """
+    A proof of commitment to a value for U.
+    """
 
-    def __init__(self, U, C, VPrimeResponse, SResponse):
+    def __init__(self, U: int, C: int, VPrimeResponse: int, SResponse: int) -> None:
+        """
+        Store the proof information.
+        """
         self.U = U
         self.C = C
         self.VPrimeResponse = VPrimeResponse
         self.SResponse = SResponse
 
-    def MergeProofP(self, proofP, pk):
+    def MergeProofP(self, proofP: ProofP, pk: PublicKey) -> None:
+        """
+        Merge in a partial proof to reconstruct U.
+        """
         self.U = (self.U * proofP.P) % pk.N
         self.SResponse = self.SResponse + proofP.SResponse
 
-    def Verify(self, pk, context, nonce):
+    def Verify(self, pk: PublicKey, context: int, nonce: int) -> bool:
+        """
+        Verify this proof for a given public key.
+        """
         return self.VerifyWithChallenge(pk, createChallenge(context, nonce, self.ChallengeContribution(pk), False))
 
-    def correctResponseSizes(self, pk):
+    def correctResponseSizes(self, pk: PublicKey) -> bool:
+        """
+        Check if our stored responses conform to the format of the given public key.
+        """
         maximum = (1 << (pk.Params.LvPrimeCommit + 1)) - 1
         minimum = -maximum
         return self.VPrimeResponse >= minimum and self.VPrimeResponse <= maximum
 
-    def VerifyWithChallenge(self, pk, reconstructedChallenge):
-        return self.correctResponseSizes(pk) and self.C == reconstructedChallenge
+    def VerifyWithChallenge(self, pk: PublicKey, reconstructedChallenge: int) -> bool:
+        """
+        Check if a given challenge is equal to our challenge.
+        """
+        return self.correctResponseSizes(pk) and reconstructedChallenge == self.C
 
-    def reconstructUcommit(self, pk):
+    def reconstructUcommit(self, pk: PublicKey) -> int:
+        """
+        Construct the value for U from our challenge and responses.
+        """
         Uc = FP2Value(pk.N, self.U).intpow(-self.C)
         Sv = FP2Value(pk.N, pk.S).intpow(self.VPrimeResponse)
         R0s = FP2Value(pk.N, pk.R[0]).intpow(self.SResponse)
         return (Uc * Sv * R0s).a
 
-    def SecretKeyResponse(self):
+    def SecretKeyResponse(self) -> int:
+        """
+        The secret key response.
+        """
         return self.SResponse
 
-    def Challenge(self):
+    def Challenge(self) -> int:
+        """
+        The challenge.
+        """
         return self.C
 
-    def ChallengeContribution(self, pk):
+    def ChallengeContribution(self, pk: PublicKey) -> list[int]:
+        """
+        Get our value for U and our reconstructed value for U, given the public key.
+        """
         return [self.U, self.reconstructUcommit(pk)]
 
 
 class ProofS:
+    """
+    A proof of signature issuance.
+    """
 
-    def __init__(self, C, EResponse):
+    def __init__(self, C: int, EResponse: int) -> None:
+        """
+        Get a proof of issuance.
+        """
         self.C = C
         self.EResponse = EResponse
 
-    def Verify(self, pk, signature, context, nonce):
+    def Verify(self, pk: PublicKey, signature: CLSignature, context: int, nonce: int) -> bool:
+        """
+        Verify the issuance of the signature by a public key.
+        """
         exponent = self.EResponse * signature.E + self.C
         ACommit = FP2Value(pk.N, signature.A).intpow(exponent).a
         Q = FP2Value(pk.N, signature.A).intpow(signature.E).a
         cPrime = hashCommit([context, Q, signature.A, nonce, ACommit], False)
-        return self.C == cPrime
+        return cPrime == self.C
 
 
 class ProofD:
+    """
+    A disclosure proof for identity information.
+    """
 
-    def __init__(self, C, A, EResponse, VResponse, AResponses, ADisclosed):
+    def __init__(self, C: int, A: int, EResponse: int, VResponse: int, AResponses: dict[int, int],  # noqa: PLR0913
+                 ADisclosed: dict[int, int]) -> None:
+        """
+        Create a container for the necessary values.
+        """
         self.C = C
         self.A = A
         self.EResponse = EResponse
@@ -99,10 +166,16 @@ class ProofD:
         self.AResponses = AResponses
         self.ADisclosed = ADisclosed
 
-    def MergeProofP(self, proofP, pk):
+    def MergeProofP(self, proofP: ProofP, pk: PublicKey) -> None:
+        """
+        Merge in a partial proof.
+        """
         self.AResponses[0] += proofP.SResponse
 
-    def correctResponseSizes(self, pk):
+    def correctResponseSizes(self, pk: PublicKey) -> bool:
+        """
+        Check if our responses conform to the public key format.
+        """
         maximum = (1 << (pk.Params.LmCommit + 1)) - 1
         minimum = -maximum
 
@@ -118,14 +191,16 @@ class ProofD:
 
         return True
 
-    def reconstructZ(self, pk):
+    def reconstructZ(self, pk: PublicKey) -> int:
+        """
+        Reconstruct the value of Z using our information.
+        """
         numerator = 1 << (pk.Params.Le - 1)
         numerator = FP2Value(pk.N, self.A).intpow(numerator).a
 
         for i, exp in self.ADisclosed.items():
-            if exp.bit_length() > pk.Params.Lm:
-                exp = sha256_as_int(str(exp))
-            numerator *= FP2Value(pk.N, pk.R[i]).intpow(exp).a
+            short_exp = sha256_as_int(str(exp)) if exp.bit_length() > pk.Params.Lm else exp
+            numerator *= FP2Value(pk.N, pk.R[i]).intpow(short_exp).a
         numerator = numerator % pk.N
 
         known = pk.Z * _modinv(numerator, pk.N)
@@ -135,25 +210,42 @@ class ProofD:
         Rs = 1
         for i, response in self.AResponses.items():
             Rs *= FP2Value(pk.N, pk.R[i]).intpow(response).a
-        Z = (knownC * Ae * Rs * Sv) % pk.N
-        return Z
+        return (knownC * Ae * Rs * Sv) % pk.N
 
-    def Verify(self, pk, context, nonce1, issig):
+    def Verify(self, pk: PublicKey, context: int, nonce1: int, issig: bool) -> bool:
+        """
+        Verify this proof for the given public key.
+        """
         return self.VerifyWithChallenge(pk, createChallenge(context, nonce1, self.ChallengeContribution(pk), issig))
 
-    def VerifyWithChallenge(self, pk, reconstructedChallenge):
-        return self.correctResponseSizes(pk) and self.C == reconstructedChallenge
+    def VerifyWithChallenge(self, pk: PublicKey, reconstructedChallenge: int) -> bool:
+        """
+        Verify that the given challenge matches our challenge value.
+        """
+        return self.correctResponseSizes(pk) and reconstructedChallenge == self.C
 
-    def ChallengeContribution(self, pk):
+    def ChallengeContribution(self, pk: PublicKey) -> list[int]:
+        """
+        Get our A and reconstructed Z.
+        """
         return [self.A, self.reconstructZ(pk)]
 
-    def SecretKeyResponse(self):
+    def SecretKeyResponse(self) -> int:
+        """
+        Get the secret key response value.
+        """
         return self.AResponses[0]
 
-    def Challenge(self):
+    def Challenge(self) -> int:
+        """
+        Get our challenge.
+        """
         return self.C
 
-    def Copy(self):
+    def Copy(self) -> ProofD:
+        """
+        Create an exact copy of this instance.
+        """
         ADisclosed = {}
         for k, v in self.ADisclosed.items():
             ADisclosed[k] = v
@@ -161,15 +253,27 @@ class ProofD:
 
 
 class ProofP:
+    """
+    Partial proof to reconstruct values.
+    """
 
-    def __init__(self, P, C, SResponse):
+    def __init__(self, P: int, C: int, SResponse: int) -> None:
+        """
+        Create new partial proof information.
+        """
         self.P = P
         self.C = C
         self.SResponse = SResponse
 
 
 class ProofPCommitment:
+    """
+    A commitment to a value of P.
+    """
 
-    def __init__(self, P, Pcommit):
+    def __init__(self, P: int, Pcommit: int) -> None:
+        """
+        Create a new container.
+        """
         self.P = P
         self.Pcommit = Pcommit

--- a/ipv8/attestation/wallet/irmaexact/wrappers.py
+++ b/ipv8/attestation/wallet/irmaexact/wrappers.py
@@ -1,8 +1,13 @@
-from .gabi.proofs import ProofD, createChallenge
 from ..primitives.structs import ipack, iunpack
+from .gabi.proofs import ProofD, createChallenge
+
+# ruff: noqa: N803,N806
 
 
-def serialize_proof_d(proof_d):
+def serialize_proof_d(proof_d: ProofD) -> bytes:
+    """
+    Serialize a ProofD value.
+    """
     return (ipack(proof_d.C)
             + ipack(proof_d.A)
             + ipack(proof_d.EResponse)
@@ -10,7 +15,10 @@ def serialize_proof_d(proof_d):
             + ipack(proof_d.AResponses[0]))
 
 
-def unserialize_proof_d(s):
+def unserialize_proof_d(s: bytes) -> ProofD:
+    """
+    Convert bytes to a ProofD.
+    """
     C, rem = iunpack(s)
     A, rem = iunpack(rem)
     EResponse, rem = iunpack(rem)
@@ -19,6 +27,9 @@ def unserialize_proof_d(s):
     return ProofD(C, A, EResponse, VResponse, {0: fa_response}, {})
 
 
-def challenge_response(my_proof_d, Z, challenge):
+def challenge_response(my_proof_d: ProofD, Z: int, challenge: bytes) -> bytes:
+    """
+    Create a challenge to a given ProofD.
+    """
     challenge_verif, _ = iunpack(challenge)
     return ipack(createChallenge(challenge_verif, challenge_verif, [my_proof_d.A, Z], False))


### PR DESCRIPTION
This PR:

 - Fixes the `ruff` issues in the `ipv8/attestation/wallet/irmaexact` folder.

This folder had the vast majority of violations so I'm separating it from the other `ipv8/attestation` fixes. However, some files will need to be revisited after the API's they implement are typed.