### PR TITLE
Updated LAN discovery to run on a different thread

### DIFF
--- a/ipv8/messaging/interfaces/lan_addresses/interfaces.py
+++ b/ipv8/messaging/interfaces/lan_addresses/interfaces.py
@@ -13,52 +13,49 @@ try:
 except ImportError:
     netifaces = None
 BLACKLIST = {"127.0.0.1", "127.0.1.1", "0.0.0.0", "255.255.255.255", "::1"}
+VERBOSE = False
 
 
-@lru_cache(maxsize=2)  # One copy of verbose and one copy of non-verbose providers.
-def get_providers(verbose: bool = False) -> list[AddressProvider]:
+@lru_cache(maxsize=1)
+def get_providers() -> list[AddressProvider]:
     """
     Construct the ``AddressProvider``s that are applicable for this platform.
-
-    :param verbose: Log any errors that are encountered while fetching addresses.
     """
     providers: list[AddressProvider] = []
     if netifaces is not None:
         # Netifaces is faster but archived since 2021 and unsupported >= Python 3.11
-        with conditional_import_shield(Platform.ANY, verbose):
+        with conditional_import_shield(Platform.ANY, VERBOSE):
             from .any_os.netifaces import Netifaces
-            providers.append(Netifaces(verbose))
+            providers.append(Netifaces(VERBOSE))
     else:
         # Attempt to mimic netifaces with (slower) ctypes and other OS calls.
-        with conditional_import_shield(Platform.ANY, verbose):
+        with conditional_import_shield(Platform.ANY, VERBOSE):
             from .any_os.getaddrinfo import SocketGetAddrInfo
-            providers.append(SocketGetAddrInfo(verbose))
-        with conditional_import_shield(Platform.ANY, verbose):
+            providers.append(SocketGetAddrInfo(VERBOSE))
+        with conditional_import_shield(Platform.ANY, VERBOSE):
             from .any_os.testnet1 import TestNet1
-            providers.append(TestNet1(verbose))
-        with conditional_import_shield(Platform.WINDOWS, verbose):
+            providers.append(TestNet1(VERBOSE))
+        with conditional_import_shield(Platform.WINDOWS, VERBOSE):
             from .windows.GetAdaptersAddresses import GetAdaptersAddresses
-            providers.append(GetAdaptersAddresses(verbose))
-        with conditional_import_shield(Platform.LINUX, verbose):
+            providers.append(GetAdaptersAddresses(VERBOSE))
+        with conditional_import_shield(Platform.LINUX, VERBOSE):
             from .unix.getifaddrs import GetIfAddrs
-            providers.append(GetIfAddrs(verbose))
-        with conditional_import_shield(Platform.LINUX, verbose):
+            providers.append(GetIfAddrs(VERBOSE))
+        with conditional_import_shield(Platform.LINUX, VERBOSE):
             from .unix.ioctl import Ioctl
-            providers.append(Ioctl(verbose))
+            providers.append(Ioctl(VERBOSE))
     return providers
 
 
-def get_lan_addresses(verbose: bool = False) -> list[str]:
+def get_lan_addresses() -> list[str]:
     """
     Attempt to find the LAN addresses of this machine using whatever means available.
-
-    :param verbose: Log any errors that are encountered while fetching addresses.
     """
     votes: dict[str, int] = {}
-    for provider in get_providers(verbose):
+    for provider in get_providers():
         for found in (provider.get_addresses_buffered() - BLACKLIST):
             votes[found] = votes.get(found, 0) + 1
     return sorted(votes.keys(), key=lambda key: votes[key], reverse=True)
 
 
-__all__ = ["get_lan_addresses"]
+__all__ = ["get_lan_addresses", "get_providers"]

--- a/ipv8/test/test_community.py
+++ b/ipv8/test/test_community.py
@@ -169,12 +169,14 @@ class TestCommunityBootstrapping(TestBase):
         # Initialize bootstrapper and get the bootstrapping task
         community.bootstrap()
         tasks = community.get_tasks()
+        bootstrap_task = tasks[1]
         # Unload the Community after the bootstrapping task has completed.
-        await tasks[0]
+        await bootstrap_task
         await community.unload()
 
-        self.assertEqual(1, len(tasks), msg="Precondition failed. Only the bootstrap task should be running!")
-        self.assertFalse(tasks[0].cancelled())
+        self.assertEqual(2, len(tasks),
+                         msg="Precondition failed. Only the bootstrap/LAN discovery tasks should be running!")
+        self.assertFalse(bootstrap_task.cancelled())
 
     async def test_cancel_bootstrap(self) -> None:
         """
@@ -186,8 +188,10 @@ class TestCommunityBootstrapping(TestBase):
         # Initialize bootstrapper and get the bootstrapping task
         community.bootstrap()
         tasks = community.get_tasks()
+        bootstrap_task = tasks[1]
         # Cancel the bootstrapping task before it can complete.
         await community.unload()
 
-        self.assertEqual(1, len(tasks), msg="Precondition failed. Only the bootstrap task should be running!")
-        self.assertTrue(tasks[0].cancelled())
+        self.assertEqual(2, len(tasks),
+                         msg="Precondition failed. Only the bootstrap/LAN discovery tasks should be running!")
+        self.assertTrue(bootstrap_task.cancelled())


### PR DESCRIPTION
This PR fixes https://github.com/Tribler/py-ipv8/issues/1188 by letting all communities periodically run a LAN discovery task using the threadpool. The `AddressProvider.addresses_ts` tries to avoid concurrent/frequent runs.

Note that blocking is still possible for the first call to `discover_addresses` (e.g., when `EndpointListener.__init__` calls `my_estimated_lan`). Although this may only be a problem when adding communities at runtime (which is what we do in Tribler). Alternatively, we could remove the first 2 lines from `get_addresses_buffered` and be unaware of our LAN address until one of the discovery tasks completes.

I removed `verbose` kwarg in interfaces.py because with this PR we can't use `lru_cache(maxsize=2)` anymore. Allowing the cache to be larger than 1 means we don't have a single timestamp for each `AddressProvider` anymore. For debugging purposes I added a global `VERBOSE` variable. I'm not seeing a need to change the verbosity at runtime, so hopefully this will do.