### PR TITLE
Updated the ruff rules to allow more args and ignore pandas violations

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -32,6 +32,7 @@ ignore = [
     "INP001",
     "N818",
     "N999",
+    "PD",
     "PERF203",
     "PLR2004",
     "PT",
@@ -90,8 +91,8 @@ dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 target-version = "py37"
 
 [pylint]
-max-args = 5
-max-returns=8
-max-branches=12
-max-statements=50
+max-args = 6
+max-returns = 8
+max-branches = 12
+max-statements = 50
 

--- a/ipv8/REST/attestation_endpoint.py
+++ b/ipv8/REST/attestation_endpoint.py
@@ -71,7 +71,7 @@ class AttestationEndpoint(BaseEndpoint[IPv8]):
         self.attestation_metadata[(peer, attribute_name)] = metadata
         return future
 
-    def on_attestation_complete(self, for_peer: Peer, attribute_name: str, attribute_hash: bytes,  # noqa: PLR0913
+    def on_attestation_complete(self, for_peer: Peer, attribute_name: str, attribute_hash: bytes,
                                 id_format: str, from_peer: Peer | None = None) -> None:
         """
         Callback for when an attestation has been completed for another peer.
@@ -214,7 +214,7 @@ class AttestationEndpoint(BaseEndpoint[IPv8]):
             return Response([(*k, v[1]) for k, v in self.attestation_requests.items()])
 
         if request.query['type'] == 'outstanding_verify':
-            return Response([(x, y) for x, y in self.verify_requests])
+            return Response(list(self.verify_requests))
 
         if request.query['type'] == 'verification_output':
             formatted_vfo = {}

--- a/ipv8/attestation/communication_manager.py
+++ b/ipv8/attestation/communication_manager.py
@@ -72,7 +72,7 @@ class CommunicationChannel:
         self.attestation_metadata[(peer, attribute_name)] = metadata
         return future
 
-    def on_attestation_complete(self, for_peer: Peer, attribute_name: str, attribute_hash: bytes,  # noqa: PLR0913
+    def on_attestation_complete(self, for_peer: Peer, attribute_name: str, attribute_hash: bytes,
                                 id_format: str, from_peer: Peer | None = None) -> None:
         """
         Callback for when an attestation has been completed for another peer.

--- a/ipv8/attestation/identity/community.py
+++ b/ipv8/attestation/identity/community.py
@@ -195,7 +195,7 @@ class IdentityCommunity(Community):
         else:
             self.logger.warning("Received unsolicited disclosure from %s, dropping!", str(peer))
 
-    def request_attestation_advertisement(self,  # noqa: PLR0913
+    def request_attestation_advertisement(self,
                                           peer: Peer,
                                           attribute_hash: bytes,
                                           name: str,

--- a/ipv8/attestation/identity/manager.py
+++ b/ipv8/attestation/identity/manager.py
@@ -221,7 +221,7 @@ class IdentityManager:
                 self.pseudonyms[public_key_material] = PseudonymManager(self.database, public_key=key)
         return self.pseudonyms[public_key_material]
 
-    def substantiate(self,  # noqa: PLR0913
+    def substantiate(self,
                      public_key: PublicKey,
                      serialized_metadata: bytes,
                      serialized_tokens: bytes,

--- a/ipv8/attestation/tokentree/token.py
+++ b/ipv8/attestation/tokentree/token.py
@@ -21,7 +21,7 @@ class Token(AbstractSignedObject):
     Tokens do not and should not contain a reference to the public key (but are signed by one).
     """
 
-    def __init__(self,  # noqa: PLR0913
+    def __init__(self,
                  previous_token_hash: bytes,
                  content: bytes | None = None,
                  content_hash: bytes | None = None,

--- a/ipv8/attestation/wallet/caches.py
+++ b/ipv8/attestation/wallet/caches.py
@@ -99,7 +99,7 @@ class ReceiveAttestationRequestCache(PeerCache):
     Stores one-time key for this attribute attestation.
     """
 
-    def __init__(self, community: AttestationCommunity, mid: bytes, key: Any,  # noqa: ANN401, PLR0913
+    def __init__(self, community: AttestationCommunity, mid: bytes, key: Any,  # noqa: ANN401
                  name: str, id_format: str) -> None:
         """
         Create a new cache for a pending attestation transfer reception.
@@ -121,7 +121,7 @@ class ProvingAttestationCache(HashCache):
     Pending attestation verification, stores expected relmap, hashed challenges and completion callback.
     """
 
-    def __init__(self, community: AttestationCommunity, cache_hash: bytes, id_format: str,  # noqa: PLR0913
+    def __init__(self, community: AttestationCommunity, cache_hash: bytes, id_format: str,
                  public_key: Any | None =None,  # noqa: ANN401
                  on_complete: Callable[[bytes, dict], None] = lambda x, y: None) -> None:
         """
@@ -154,7 +154,7 @@ class PendingChallengeCache(HashCache):
     Single pending challenge for a ProvingAttestationCache.
     """
 
-    def __init__(self, community: AttestationCommunity, cache_hash: bytes,  # noqa: PLR0913
+    def __init__(self, community: AttestationCommunity, cache_hash: bytes,
                  proving_cache: ProvingAttestationCache, id_format: str, honesty_check: int = -1) -> None:
         """
         Create a new cache for a pending challenge.

--- a/ipv8/attestation/wallet/community.py
+++ b/ipv8/attestation/wallet/community.py
@@ -254,7 +254,7 @@ class AttestationCommunity(Community):
         self.database.insert_attestation(unserialized, attestation_hash, secret_key, id_format)
         self.attestation_request_complete_callback(self.my_peer, name, attestation_hash, id_format, peer)
 
-    def verify_attestation_values(self, socket_address: Address, attestation_hash: bytes,  # noqa: PLR0913
+    def verify_attestation_values(self, socket_address: Address, attestation_hash: bytes,
                                   values: list[bytes], callback: Callable[[bytes, list[float]], None],
                                   id_format: str) -> None:
         """

--- a/ipv8/attestation/wallet/irmaexact/gabi/builder.py
+++ b/ipv8/attestation/wallet/irmaexact/gabi/builder.py
@@ -105,7 +105,7 @@ def challengeContributions(pl: list, publicKeys: list[PublicKey], context: int, 
     return contributions
 
 
-def Verify(pl: list, publicKeys: list[PublicKey], context: int, nonce: int, issig: bool,  # noqa: PLR0913
+def Verify(pl: list, publicKeys: list[PublicKey], context: int, nonce: int, issig: bool,
            keyshareServers: list | None = None) -> bool:
     """
     Verify a list of proofs for a list of public keys.
@@ -181,7 +181,7 @@ class IssueCommitmentMessage:
     JWT commitment information.
     """
 
-    def __init__(self, U: int | None, Proofs: list[ProofU] | None, Nonce2: int,  # noqa: PLR0913
+    def __init__(self, U: int | None, Proofs: list[ProofU] | None, Nonce2: int,
                  ProofPjwt: None = None, ProofPjwts: None = None) -> None:
         """
         Create a new issued commitment message container.

--- a/ipv8/attestation/wallet/irmaexact/gabi/keys.py
+++ b/ipv8/attestation/wallet/irmaexact/gabi/keys.py
@@ -29,7 +29,7 @@ class BaseParameters:
     Algorithm parameters for Gabi.
     """
 
-    def __init__(self, LePrime: int, Lh: int, Lm: int, Ln: int, Lstatzk: int) -> None:  # noqa: PLR0913
+    def __init__(self, LePrime: int, Lh: int, Lm: int, Ln: int, Lstatzk: int) -> None:
         """
         Create new base parameters.
         """

--- a/ipv8/attestation/wallet/primitives/boneh.py
+++ b/ipv8/attestation/wallet/primitives/boneh.py
@@ -26,7 +26,7 @@ def generate_prime(n: int) -> int:
     return p
 
 
-def bilinear_group(n: int, p: int, g1x: int, g1y: int, g2x: int, g2y: int) -> FP2Value:  # noqa: PLR0913
+def bilinear_group(n: int, p: int, g1x: int, g1y: int, g2x: int, g2y: int) -> FP2Value:
     """
     Generate a bilinear group for two generators.
     """

--- a/ipv8/attestation/wallet/primitives/structs.py
+++ b/ipv8/attestation/wallet/primitives/structs.py
@@ -124,7 +124,7 @@ class BonehPrivateKey(BonehPublicKey):
 
     FIELDS = 7
 
-    def __init__(self, p: int, g: FP2Value, h: FP2Value, n: int, t1: int) -> None:  # noqa: PLR0913
+    def __init__(self, p: int, g: FP2Value, h: FP2Value, n: int, t1: int) -> None:
         """
         Create a new private key container.
         """

--- a/ipv8/community.py
+++ b/ipv8/community.py
@@ -58,7 +58,7 @@ class Community(EZPackOverlay):
     version = b'\x02'
     community_id: bytes
 
-    def __init__(self, my_peer: Peer, endpoint: Endpoint, network: Network,  # noqa: PLR0913
+    def __init__(self, my_peer: Peer, endpoint: Endpoint, network: Network,
                  max_peers: int = DEFAULT_MAX_PEERS, anonymize: bool = False) -> None:
         """
         Create a new (still inert) community.
@@ -382,7 +382,7 @@ class Community(EZPackOverlay):
 
         return self._ez_pack(self._prefix, payload.msg_id, [auth, dist, payload])
 
-    def create_puncture_request(self, lan_walker: Address, wan_walker: Address, identifier: int,  # noqa: PLR0913
+    def create_puncture_request(self, lan_walker: Address, wan_walker: Address, identifier: int,
                                 prefix: bytes | None = None, new_style: bool = False) -> bytes:
         """
         Create a request for another peer to puncture a given LAN/WAN address pair.

--- a/ipv8/dht/community.py
+++ b/ipv8/dht/community.py
@@ -237,7 +237,7 @@ class DHTCommunity(Community):
 
     community_id = unhexlify('8d0be1845d74d175f178197cad001591d04d73cc')
 
-    def __init__(self, my_peer: Peer, endpoint: Endpoint, network: Network,  # noqa: PLR0913
+    def __init__(self, my_peer: Peer, endpoint: Endpoint, network: Network,
                  max_peers: int = DEFAULT_MAX_PEERS, anonymize: bool = False) -> None:
         """
         Create a new DHT overlay, ignoring the given network instance.
@@ -516,7 +516,7 @@ class DHTCommunity(Community):
         node = self.get_requesting_node(peer)
         if not node:
             return
-        if any(len(value) > MAX_ENTRY_SIZE for value in payload.values):  # noqa: PD011
+        if any(len(value) > MAX_ENTRY_SIZE for value in payload.values):
             self.logger.warning('Maximum length of value exceeded, dropping packet.')
             return
         if len(payload.values) > MAX_VALUES_IN_STORE:
@@ -537,7 +537,7 @@ class DHTCommunity(Community):
         # To prevent over-caching, the expiration time of an entry depends on the number
         # of nodes that are closer than us.
         max_age = MAX_ENTRY_AGE // 2 ** max(0, num_closer - TARGET_NODES + 1)
-        for value in payload.values:  # noqa: PD011
+        for value in payload.values:
             self.add_value(payload.target, value, self.get_storage(node), max_age)
 
         self.ez_send(peer, StoreResponsePayload(payload.identifier))
@@ -590,7 +590,7 @@ class DHTCommunity(Community):
             return crawl.nodes
 
         cache_candidate = crawl.cache_candidate
-        values = crawl.values  # noqa: PD011
+        values = crawl.values
 
         if cache_candidate and values:
             # Store the key-value pair on the most recently visited node that
@@ -707,7 +707,7 @@ class DHTCommunity(Community):
         if cast(List[bool], cache.params)[0]:
             cache.future.set_result({'nodes': payload.nodes})
         else:
-            cache.future.set_result({'values': payload.values} if payload.values  # noqa: PD011
+            cache.future.set_result({'values': payload.values} if payload.values
                                     else {'nodes': payload.nodes})
 
     async def node_maintenance(self) -> None:

--- a/ipv8/dht/discovery.py
+++ b/ipv8/dht/discovery.py
@@ -30,7 +30,7 @@ class DHTDiscoveryCommunity(DHTCommunity):
     Community for discovering peers that are behind NAT.
     """
 
-    def __init__(self, my_peer: Peer, endpoint: Endpoint, network: Network,  # noqa: PLR0913
+    def __init__(self, my_peer: Peer, endpoint: Endpoint, network: Network,
                  max_peers: int = DEFAULT_MAX_PEERS, anonymize: bool = False) -> None:
         """
         Create a new dht-based discovery community.

--- a/ipv8/dht/storage.py
+++ b/ipv8/dht/storage.py
@@ -60,7 +60,7 @@ class Storage:
         """
         self.items: dict[bytes, list[Value]] = defaultdict(list)
 
-    def put(self, key: bytes, data: bytes,  # noqa: PLR0913
+    def put(self, key: bytes, data: bytes,
             id_: bytes | None = None, max_age: float = 86400, version: int = 0) -> None:
         """
         Store the given data under a certain key.

--- a/ipv8/messaging/anonymization/caches.py
+++ b/ipv8/messaging/anonymization/caches.py
@@ -50,7 +50,7 @@ class CreatedRequestCache(NumberCache):
     Used to track outstanding created messages.
     """
 
-    def __init__(self, community: TunnelCommunity, circuit_id: int, candidate: Peer,  # noqa: PLR0913
+    def __init__(self, community: TunnelCommunity, circuit_id: int, candidate: Peer,
                  candidates: dict[bytes, Peer], timeout: float) -> None:
         """
         Create a new cache.

--- a/ipv8/messaging/anonymization/community.py
+++ b/ipv8/messaging/anonymization/community.py
@@ -319,7 +319,7 @@ class TunnelCommunity(Community):
                 and (exit_flags is None or set(exit_flags) <= set(c.exit_flags))
                 and (hops is None or hops == c.goal_hops)]
 
-    def create_circuit(self, goal_hops: int, ctype: str = CIRCUIT_TYPE_DATA,  # noqa: PLR0913
+    def create_circuit(self, goal_hops: int, ctype: str = CIRCUIT_TYPE_DATA,
                        exit_flags: Collection[int] | None = None, required_exit: Peer | None = None,
                        info_hash: bytes | None = None) -> Circuit | None:
         """
@@ -566,7 +566,7 @@ class TunnelCommunity(Community):
         if tunnel_obj:
             tunnel_obj.bytes_up += packet_len
 
-    def send_data(self, peer: Address | Peer, circuit_id: int, dest_address: Address,  # noqa: PLR0913
+    def send_data(self, peer: Address | Peer, circuit_id: int, dest_address: Address,
                   source_address: Address, data: bytes) -> None:
         """
         Pack the given binary data and forward it to the given peer.

--- a/ipv8/messaging/anonymization/pex.py
+++ b/ipv8/messaging/anonymization/pex.py
@@ -28,7 +28,7 @@ class PexCommunity(Community):
     New on-the-fly overlay for the PEX protocol.
     """
 
-    def __init__(self, my_peer: Peer, endpoint: Endpoint, network: Network,  # noqa: PLR0913
+    def __init__(self, my_peer: Peer, endpoint: Endpoint, network: Network,
                  max_peers: int = DEFAULT_MAX_PEERS, anonymize: bool = False, **kwargs) -> None:
         """
         Create a new PEX community by deriving the community id from the given SHA-1 hash.

--- a/ipv8/messaging/anonymization/tunnel.py
+++ b/ipv8/messaging/anonymization/tunnel.py
@@ -306,7 +306,7 @@ class Circuit(Tunnel[Optional[Peer]]):
     A peer-to-peer encrypted communication channel, consisting of 0 or more hops (intermediate peers).
     """
 
-    def __init__(self, circuit_id: int , goal_hops: int = 0, ctype: str = CIRCUIT_TYPE_DATA,  # noqa: PLR0913
+    def __init__(self, circuit_id: int , goal_hops: int = 0, ctype: str = CIRCUIT_TYPE_DATA,
                  required_exit: Peer | None = None, info_hash: bytes | None = None) -> None:
         """
         Create a new circuit instance.

--- a/ipv8/messaging/anonymization/utils.py
+++ b/ipv8/messaging/anonymization/utils.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
     from .community import TunnelCommunity
 
 
-async def run_speed_test(tc: TunnelCommunity, circuit: Circuit, request_size: int, response_size: int,  # noqa: PLR0913
+async def run_speed_test(tc: TunnelCommunity, circuit: Circuit, request_size: int, response_size: int,
                          num_requests: int, window: int = 50) -> dict[str, int | float]:
     """
     Test a circuit's speed.

--- a/ipv8/messaging/interfaces/lan_addresses/windows/GetAdaptersAddresses.py
+++ b/ipv8/messaging/interfaces/lan_addresses/windows/GetAdaptersAddresses.py
@@ -79,7 +79,7 @@ if typing.TYPE_CHECKING:
                 ...  # incomplete
 
             class _GetAdaptersAddresses(typing.Protocol, typing.SupportsInt):  # noqa: PYI046
-                def __call__(self, Family: c_ulong, Flags: c_ulong, Reserved: int,  # noqa: PLR0913
+                def __call__(self, Family: c_ulong, Flags: c_ulong, Reserved: int,
                              AdapterAddresses: _Pointer, SizePointer: _Pointer) -> int:
                     ...
 

--- a/ipv8/peerdiscovery/churn.py
+++ b/ipv8/peerdiscovery/churn.py
@@ -16,7 +16,7 @@ class RandomChurn(DiscoveryStrategy):
     Select random peers, ping them if inactive, remove them if unresponsive.
     """
 
-    def __init__(self, overlay: Overlay, sample_size: int = 8,  # noqa: PLR0913
+    def __init__(self, overlay: Overlay, sample_size: int = 8,
                  ping_interval: float = 10.0, inactive_time: float = 27.5, drop_time: float = 57.5) -> None:
         """
         Random peer removal strategy.

--- a/ipv8/peerdiscovery/community.py
+++ b/ipv8/peerdiscovery/community.py
@@ -97,7 +97,7 @@ class DiscoveryCommunity(Community):
     version = b'\x02'
     community_id = unhexlify('7e313685c1912a141279f8248fc8db5899c5df5a')
 
-    def __init__(self, my_peer: Peer, endpoint: Endpoint, network: Network,  # noqa: PLR0913
+    def __init__(self, my_peer: Peer, endpoint: Endpoint, network: Network,
                  max_peers: int = DEFAULT_MAX_PEERS, anonymize: bool = False) -> None:
         """
         Create a new community with similarity and ping functionality.

--- a/ipv8/peerdiscovery/discovery.py
+++ b/ipv8/peerdiscovery/discovery.py
@@ -42,7 +42,7 @@ class RandomWalk(DiscoveryStrategy):
     Walk randomly through the network.
     """
 
-    def __init__(self, overlay: Overlay, timeout: float = 3.0,  # noqa: PLR0913
+    def __init__(self, overlay: Overlay, timeout: float = 3.0,
                  window_size: int = 5, reset_chance: int = 50, target_interval: int = 0) -> None:
         """
         Create a new walk strategy.

--- a/ipv8/peerdiscovery/payload.py
+++ b/ipv8/peerdiscovery/payload.py
@@ -18,7 +18,7 @@ class SimilarityRequestPayload(Payload):
     msg_id = 1
     format_list = ['H', '4SH', '4SH', 'bits', 'raw']
 
-    def __init__(self, identifier: int, lan_address: Address, wan_address: Address,  # noqa: PLR0913
+    def __init__(self, identifier: int, lan_address: Address, wan_address: Address,
                  connection_type: str, preference_list: list[bytes]) -> None:
         """
         Create a new similarity request payload.

--- a/ipv8/taskmanager.py
+++ b/ipv8/taskmanager.py
@@ -94,7 +94,7 @@ class TaskManager:
         old_task.add_done_callback(cancel_cb)
         return new_task
 
-    def register_task(self, name: Hashable, task: Callable | Coroutine | Future,  # noqa: C901, PLR0913
+    def register_task(self, name: Hashable, task: Callable | Coroutine | Future,  # noqa: C901
                       *args: Any, delay: float | None = None,  # noqa: ANN401
                       interval: float | None = None, ignore: Sequence[type | BaseException] = ()) -> Future:
         """

--- a/ipv8/test/test_community.py
+++ b/ipv8/test/test_community.py
@@ -43,7 +43,7 @@ class OldCommunity(Community):
         """
         return super().create_puncture(lan_walker, wan_walker, identifier)
 
-    def create_puncture_request(self, lan_walker: Address, wan_walker: Address, identifier: int,  # noqa: PLR0913
+    def create_puncture_request(self, lan_walker: Address, wan_walker: Address, identifier: int,
                                 prefix: bytes | None = None, new_style: bool = False) -> bytes:
         """
         Make sure all sent puncture requests are flagged as old style.


### PR DESCRIPTION
Related to #1175

This PR:

 - Updates the `ruff` exceptions to ignore `pandas` related errors.
 - Updates the `ruff` rules to allow 6 arguments in calls (functions/methods).
