### PR TITLE
Added typed request cache add/get/pop

### DIFF
--- a/stresstest/bootstrap_introductions.py
+++ b/stresstest/bootstrap_introductions.py
@@ -37,7 +37,7 @@ class MyCommunity(Community):
 
     community_id = community_id
 
-    def __init__(self, my_peer: Peer, endpoint: Endpoint, network: Network,  # noqa: PLR0913
+    def __init__(self, my_peer: Peer, endpoint: Endpoint, network: Network,
                  max_peers: int = DEFAULT_MAX_PEERS, anonymize: bool = False) -> None:
         """
         Create a new community for testing.


### PR DESCRIPTION
Related to #1175

This PR:

 - Adds overloaded versions of `RequestCache`'s `.add()`, `.get()`, and `pop()` that return the given class type.
 - Updates the simple cases where this new functionality can be used.
 - Removes all of the superfluous `typing.cast()` calls where the code was updated.

Pro:
 - We don't have to cast everywhere.

Con:
 - We have to mix-in `CacheWithName` for all caches that have a name. Thanks @xoriole for suggesting the `NumberCacheWithName` and `RandomNumberCacheWithName` shortcuts.

Ideally, I would've like to have `CacheTypeVar` bound to `NumberCache` and to implement the `CacheWithName` protocol. This is a construction that the `PyCharm` type checker recognizes but `mypy` unfortunately doesn't.