### PR TITLE
Updated DiscoveryStrategy to be a generic of its overlay

### DIFF
--- a/ipv8/messaging/anonymization/hidden_services.py
+++ b/ipv8/messaging/anonymization/hidden_services.py
@@ -163,7 +163,7 @@ class HiddenTunnelCommunity(TunnelCommunity):
                 break
 
             # Issue as many requests as possible in parallel
-            ips = random.sample(not_tried, min(len(not_tried), max_requests - len(tried)))
+            ips = random.sample(list(not_tried), min(len(not_tried), max_requests - len(tried)))
             responses = await gather(*[swarm.lookup(ip) for ip in ips], return_exceptions=True)
 
             # Collect responses

--- a/ipv8/peerdiscovery/churn.py
+++ b/ipv8/peerdiscovery/churn.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
     from ..types import Address, Peer
 
 
-class RandomChurn(DiscoveryStrategy):
+class RandomChurn(DiscoveryStrategy[Overlay]):
     """
     Select random peers, ping them if inactive, remove them if unresponsive.
     """
@@ -54,7 +54,6 @@ class RandomChurn(DiscoveryStrategy):
         """
         Select a new (set of) peer(s) to investigate liveness for.
         """
-        self.overlay = cast(Overlay, self.overlay)
         with self.walk_lock:
             # Find an inactive or droppable peer
             sample_size = min(len(self.overlay.network.verified_peers), self.sample_size)


### PR DESCRIPTION
Related to #1175

This PR:

 - Fixes mypy-signalled Python 3.11 incompatibility in `hidden_services.py`.
 - Updates `DiscoveryStrategy` to be generic for its `overlay` attribute (avoiding casts to `Overlay`).

