### PR TITLE
Updated bootstrappers to be less complex

### DIFF
--- a/ipv8/bootstrapping/bootstrapper_interface.py
+++ b/ipv8/bootstrapping/bootstrapper_interface.py
@@ -22,6 +22,12 @@ class Bootstrapper(ABC):
      - Initializing this module subclass when missing dependencies.
     """
 
+    def __init__(self) -> None:
+        """
+        Create a new ``Bootstrapper``.
+        """
+        self.initialized = False
+
     @abstractmethod
     def initialize(self, overlay: Community) -> Future | Coroutine:
         """

--- a/ipv8/community.py
+++ b/ipv8/community.py
@@ -436,7 +436,7 @@ class Community(EZPackOverlay):
         We don't answer if we are at our peer capacity, triggering peer churn for the other peer. Otherwise,
         we respond with an introduction response.
         """
-        if self.max_peers >= 0 and len(self.get_peers()) > self.max_peers:
+        if 0 <= self.max_peers < len(self.get_peers()):
             self.logger.debug("Dropping introduction request from (%s, %d): too many peers!",
                               peer.address[0], peer.address[1])
             return

--- a/ipv8/peerdiscovery/community.py
+++ b/ipv8/peerdiscovery/community.py
@@ -131,7 +131,7 @@ class DiscoveryCommunity(Community):
         The old logic flow was to first try to unpack the special DiscoveryCommunity intro request and then fall
         back to the actual intro request payload.
         """
-        if self.max_peers >= 0 and len(self.get_peers()) > self.max_peers:
+        if 0 <= self.max_peers < len(self.get_peers()):
             self.logger.debug("Dropping introduction request from (%s, %d): too many peers!",
                               source_address[0], source_address[1])
             return
@@ -194,7 +194,7 @@ class DiscoveryCommunity(Community):
         """
         We received a response to our request for similarity.
         """
-        if self.max_peers >= 0 and len(self.get_peers()) > self.max_peers and node not in self.network.verified_peers:
+        if 0 <= self.max_peers < len(self.get_peers()) and node not in self.network.verified_peers:
             self.logger.debug("Dropping similarity response from (%s, %d): too many peers!",
                               node.address[0], node.address[1])
             return

--- a/ipv8/test/bootstrapping/dispersy/test_bootstrapper.py
+++ b/ipv8/test/bootstrapping/dispersy/test_bootstrapper.py
@@ -28,7 +28,7 @@ class TestDispersyBootstrapper(TestBase):
 
         We don't test network DNS resolution here, which would contact the Internet.
         """
-        result = self.bootstrapper.initialize(self.overlay)
+        result = await self.bootstrapper.initialize(self.overlay)
 
         self.assertIn(self.bootstrap_node.wan_address, self.overlay.network.blacklist)
         self.assertTrue(result)

--- a/ipv8_service.py
+++ b/ipv8_service.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 import sys
 import time
-from asyncio import CancelledError, ensure_future, gather, sleep
+from asyncio import CancelledError, ensure_future, gather, run, sleep
 from base64 import b64decode
 from contextlib import suppress
 from os.path import isfile
@@ -258,4 +258,4 @@ else:
 
 if __name__ == '__main__':
     from scripts.ipv8_plugin import main
-    main(sys.argv[1:])
+    run(main(sys.argv[1:]))


### PR DESCRIPTION
This PR is meant to simplify the bootstrapping process and introduces the following changes:
* DNS addresses are resolved on the threadpool.
* `DispersyBootstrapper.initialize`/`UDPBroadcastBootstrapper.initialize` are now defined as async functions, although implementations may still return a `Future`.
* Bootstrappers are no longer removed and re-added from `Community.bootstrappers` as a way of keeping track of which ones are initialized. It uses `Bootstrapper.initialized` instead.

