### PR TITLE
Updated overlays to use a settings parameter

### DIFF
--- a/doc/basics/overlay_tutorial_5.py
+++ b/doc/basics/overlay_tutorial_5.py
@@ -2,11 +2,11 @@ import os
 from asyncio import run
 from dataclasses import dataclass
 
-from ipv8.community import Community
+from ipv8.community import Community, CommunitySettings
 from ipv8.configuration import ConfigBuilder, Strategy, WalkerDefinition, default_bootstrap_defs
 from ipv8.lazy_community import lazy_wrapper
 from ipv8.messaging.payload_dataclass import overwrite_dataclass
-from ipv8.types import Endpoint, Network, Peer
+from ipv8.types import Peer
 from ipv8.util import run_forever
 from ipv8_service import IPv8
 
@@ -22,8 +22,8 @@ class MyMessage:
 class MyCommunity(Community):
     community_id = os.urandom(20)
 
-    def __init__(self, my_peer: Peer, endpoint: Endpoint, network: Network) -> None:
-        super().__init__(my_peer, endpoint, network)
+    def __init__(self, settings: CommunitySettings) -> None:
+        super().__init__(settings)
         # Register the message handler for messages (with the identifier "1").
         self.add_message_handler(MyMessage, self.on_message)
         # The Lamport clock this peer maintains.

--- a/doc/basics/requestcache_tutorial_3.py
+++ b/doc/basics/requestcache_tutorial_3.py
@@ -1,12 +1,12 @@
 import os
 from asyncio import run, sleep
 
-from ipv8.community import Community
+from ipv8.community import Community, CommunitySettings
 from ipv8.configuration import ConfigBuilder, Strategy, WalkerDefinition, default_bootstrap_defs
 from ipv8.lazy_community import lazy_wrapper, retrieve_cache
 from ipv8.messaging.lazy_payload import VariablePayload, vp_compile
 from ipv8.requestcache import RandomNumberCacheWithName, RequestCache
-from ipv8.types import Endpoint, Network, Peer
+from ipv8.types import Peer
 from ipv8_service import IPv8
 
 # We'll use this global variable to keep track of the IPv8 instances that finished.
@@ -38,8 +38,8 @@ class MyCache(RandomNumberCacheWithName):
 class MyCommunity(Community):
     community_id = os.urandom(20)
 
-    def __init__(self, my_peer: Peer, endpoint: Endpoint, network: Network) -> None:
-        super().__init__(my_peer, endpoint, network)
+    def __init__(self, settings: CommunitySettings) -> None:
+        super().__init__(settings)
         self.add_message_handler(1, self.on_request)
         self.add_message_handler(2, self.on_response)
 

--- a/doc/basics/tasks_tutorial_6.py
+++ b/doc/basics/tasks_tutorial_6.py
@@ -1,7 +1,7 @@
 import os
 from typing import Any
 
-from ipv8.community import Community
+from ipv8.community import Community, CommunitySettings
 from ipv8.test.base import TestBase
 from ipv8.test.mocking.ipv8 import MockIPv8
 
@@ -9,8 +9,8 @@ from ipv8.test.mocking.ipv8 import MockIPv8
 class MyCommunity(Community):
     community_id = os.urandom(20)
 
-    def __init__(self, *args: Any, **kwargs) -> None:
-        super().__init__(*args, **kwargs)
+    def __init__(self, settings: CommunitySettings) -> None:
+        super().__init__(settings)
         self.register_task("error out :-(", self.error)
 
     def error(self) -> None:

--- a/doc/basics/testbase_tutorial.rst
+++ b/doc/basics/testbase_tutorial.rst
@@ -19,7 +19,7 @@ This tutorial uses the following files in the working directory:
 We will use the following ``community.py`` in this tutorial:
 
 .. literalinclude:: testbase_tutorial_1.py
-   :lines: 3-55
+   :lines: 3-57
 
 You're encouraged to fill ``test_community.py`` yourself as you read through this tutorial.
 
@@ -46,7 +46,7 @@ If you have custom logic in your subclass, please make sure to call your ``super
 Here's an example of custom ``setUp`` and ``tearDown`` methods:
 
 .. literalinclude:: testbase_tutorial_1.py
-   :lines: 58-66
+   :lines: 60-68
 
 Deadlock Detection
 ------------------
@@ -73,7 +73,7 @@ The ``initialize()`` method takes care of initializing your ``Community`` subcla
 It's as easy as this:
 
 .. literalinclude:: testbase_tutorial_1.py
-   :lines: 77-87
+   :lines: 79-89
 
 What happened here?
 First, we instructed ``TestBase`` to create 1 instance of ``MyCommunity`` using ``initialize()``.
@@ -88,14 +88,14 @@ In some cases, you might need to give additional parameters to your ``Community`
 In these cases, you can simply add additional keyword arguments to ``initialize()``.
 
 .. literalinclude:: testbase_tutorial_1.py
-   :lines: 89-97
+   :lines: 91-99
 
 In yet more advanced use cases, you may want to provide your own ``MockIPv8`` instances.
 This will usually be the case if your ``Community`` instance only supports specific keys.
 Commonly, ``Community`` instances may choose to **only** support ``curve25519`` keys, which you can do as follows:
 
 .. literalinclude:: testbase_tutorial_1.py
-   :lines: 68-69
+   :lines: 70-71
 
 Communication
 -------------
@@ -105,13 +105,13 @@ However, these instances are not communicating with each other yet.
 Take note of this code in our ``Community`` instance that stores the last peer that sent us an introduction request:
 
 .. literalinclude:: testbase_tutorial_1.py
-   :lines: 49-52
+   :lines: 51-54
 
 This code simply stores whatever ``Peer`` object last sent us a request.
 We'll create a unit test to test whether this happened:
 
 .. literalinclude:: testbase_tutorial_1.py
-   :lines: 99-112
+   :lines: 101-114
 
 Let's run through this example.
 First we create two instances of ``MyCommunity`` using ``initialize()``.
@@ -142,7 +142,7 @@ The ``introduce_nodes()`` method allows you to send these introductions anyway, 
 (note the absence of ``deliver_messages()``):
 
 .. literalinclude:: testbase_tutorial_1.py
-   :lines: 114-123
+   :lines: 116-125
 
 Using the RequestCache
 ----------------------
@@ -152,7 +152,7 @@ To make it easier to trigger these timeouts in the ``RequestCache``, we use the 
 Here's an example:
 
 .. literalinclude:: testbase_tutorial_1.py
-   :lines: 125-135
+   :lines: 127-137
 
 In this example we use the ``passthrough()`` contextmanager while we invoke a function that adds a cache.
 This causes the timeout of the ``MyCache`` cache we add inside ``add_cache`` to be nullified and instantly fire.
@@ -165,7 +165,7 @@ In these cases you can add a filter to ``passthrough()`` to make it only nullify
 (simply add these classes as arguments to ``passthrough()``):
 
 .. literalinclude:: testbase_tutorial_1.py
-   :lines: 137-147
+   :lines: 139-149
 
 Fragile Packet Handling
 -----------------------
@@ -178,7 +178,7 @@ If you want to enable the general exception handler again, you can either add yo
 For example:
 
 .. literalinclude:: testbase_tutorial_1.py
-   :lines: 71-75
+   :lines: 73-77
 
 Temporary Files
 ---------------
@@ -206,28 +206,28 @@ In the following example peer 0 first sends message 1 and then sends message 2 t
 The following construction asserts this:
 
 .. literalinclude:: testbase_tutorial_2.py
-   :lines: 69-72
+   :lines: 68-71
    :dedent: 4
 
 Sometimes, you can't be sure in what order messages are sent.
 In these cases you can use ``ordered=False``:
 
 .. literalinclude:: testbase_tutorial_2.py
-   :lines: 75-81
+   :lines: 74-80
    :dedent: 4
 
 In other cases, your overlay may be sending messages which you cannot control and/or which you don't care about.
 In these cases you can set a filter to only include the messages you want:
 
 .. literalinclude:: testbase_tutorial_2.py
-   :lines: 84-89
+   :lines: 83-88
    :dedent: 4
 
 It may also be helpful to inspect the contents of each payload.
 You can simply use the return value of the assert function to perform further inspection:
 
 .. literalinclude:: testbase_tutorial_2.py
-   :lines: 92-99
+   :lines: 91-98
    :dedent: 4
 
 If you want to use ``assertReceivedBy()``, make sure that:

--- a/doc/basics/testbase_tutorial_2.py
+++ b/doc/basics/testbase_tutorial_2.py
@@ -3,11 +3,11 @@ import unittest
 from dataclasses import dataclass
 from random import random, shuffle
 
-from ipv8.community import DEFAULT_MAX_PEERS, Community
+from ipv8.community import Community, CommunitySettings
 from ipv8.lazy_community import lazy_wrapper, lazy_wrapper_unsigned
 from ipv8.messaging.payload_dataclass import overwrite_dataclass
 from ipv8.test.base import TestBase
-from ipv8.types import Endpoint, Network, Peer
+from ipv8.types import Peer
 
 dataclass = overwrite_dataclass(dataclass)
 
@@ -30,9 +30,8 @@ class Message3:
 class MyCommunity(Community):
     community_id = os.urandom(20)
 
-    def __init__(self, my_peer: Peer, endpoint: Endpoint, network: Network,
-                 max_peers: int = DEFAULT_MAX_PEERS, anonymize: bool = False) -> None:
-        super().__init__(my_peer, endpoint, network, max_peers, anonymize)
+    def __init__(self, settings: CommunitySettings) -> None:
+        super().__init__(settings)
 
         self.add_message_handler(Message1, self.on_message1)
         self.add_message_handler(Message2, self.on_message2)

--- a/doc/reference/serialization.rst
+++ b/doc/reference/serialization.rst
@@ -155,12 +155,12 @@ In practice, given a ``COMMUNITY_ID`` and the payload definitions ``MyMessagePay
 
 
 .. literalinclude:: serialization_2.py
-   :lines: 25-41
+   :lines: 24-40
 
 It is recommended (but not obligatory) to have single payload messages store the message identifier inside the ``Payload.msg_id`` field, as this improves readability:
 
 .. literalinclude:: serialization_3.py
-   :lines: 33,34,55,58
+   :lines: 32,33,54,57
    :dedent: 4
 
 If you are using the ``@dataclass`` wrapper you can specify the message identifier through an argument instead.
@@ -235,7 +235,7 @@ The following example shows how to use JSON serialization without any IPv8 seria
 Note that we need to do our own signature checks now.
 
 .. literalinclude:: serialization_6.py
-   :lines: 16-47
+   :lines: 16-46
 
 
 Nested Payloads

--- a/doc/reference/serialization_2.py
+++ b/doc/reference/serialization_2.py
@@ -1,7 +1,6 @@
 import os
-from typing import Any
 
-from ipv8.community import Community
+from ipv8.community import Community, CommunitySettings
 from ipv8.lazy_community import lazy_wrapper
 from ipv8.messaging.lazy_payload import VariablePayload, vp_compile
 from ipv8.types import Peer
@@ -25,8 +24,8 @@ COMMUNITY_ID = os.urandom(20)
 class MyCommunity(Community):
     community_id = COMMUNITY_ID
 
-    def __init__(self, *args: Any, **kwargs) -> None:
-        super().__init__(*args, **kwargs)
+    def __init__(self, settings: CommunitySettings) -> None:
+        super().__init__(settings)
 
         self.add_message_handler(1, self.on_message)
 

--- a/doc/reference/serialization_3.py
+++ b/doc/reference/serialization_3.py
@@ -1,7 +1,6 @@
 import os
-from typing import Any
 
-from ipv8.community import Community
+from ipv8.community import Community, CommunitySettings
 from ipv8.lazy_community import lazy_wrapper
 from ipv8.messaging.lazy_payload import VariablePayload, vp_compile
 from ipv8.types import Peer
@@ -27,8 +26,8 @@ COMMUNITY_ID = os.urandom(20)
 class MyCommunity(Community):
     community_id = COMMUNITY_ID
 
-    def __init__(self, *args: Any, **kwargs) -> None:
-        super().__init__(*args, **kwargs)
+    def __init__(self, settings: CommunitySettings) -> None:
+        super().__init__(settings)
 
         self.add_message_handler(MyMessage1, self.on_message1)
         self.add_message_handler(MyMessage2, self.on_message2)

--- a/doc/reference/serialization_5.py
+++ b/doc/reference/serialization_5.py
@@ -4,12 +4,12 @@ import struct
 from asyncio import Event, run
 from typing import Any
 
-from ipv8.community import Community
+from ipv8.community import Community, CommunitySettings
 from ipv8.configuration import ConfigBuilder, Strategy, WalkerDefinition, default_bootstrap_defs
 from ipv8.lazy_community import lazy_wrapper
 from ipv8.messaging.lazy_payload import VariablePayload, vp_compile
 from ipv8.messaging.serialization import Packer, Serializer
-from ipv8.types import Endpoint, Network, Peer
+from ipv8.types import Peer
 from ipv8_service import IPv8
 
 
@@ -49,8 +49,8 @@ class MyCommunity(Community):
 
     community_id = os.urandom(20)
 
-    def __init__(self, my_peer: Peer, endpoint: Endpoint, network: Network) -> None:
-        super().__init__(my_peer, endpoint, network)
+    def __init__(self, settings: CommunitySettings) -> None:
+        super().__init__(settings)
         self.event = None
         self.add_message_handler(Message, self.on_message)
 

--- a/doc/reference/serialization_6.py
+++ b/doc/reference/serialization_6.py
@@ -3,9 +3,9 @@ import os
 from asyncio import Event, run
 from binascii import hexlify, unhexlify
 
-from ipv8.community import Community
+from ipv8.community import Community, CommunitySettings
 from ipv8.configuration import ConfigBuilder, Strategy, WalkerDefinition, default_bootstrap_defs
-from ipv8.types import Address, Endpoint, Network, Peer
+from ipv8.types import Address, Peer
 from ipv8_service import IPv8
 
 
@@ -16,9 +16,8 @@ def to_hex(bstr: bytes) -> str:
 class MyCommunity(Community):
     community_id = os.urandom(20)
 
-    def __init__(self, my_peer: Peer, endpoint: Endpoint,
-                 network: Network) -> None:
-        super().__init__(my_peer, endpoint, network)
+    def __init__(self, settings: CommunitySettings) -> None:
+        super().__init__(settings)
         self.event = None
         self.add_message_handler(1, self.on_message)
 

--- a/ipv8/attestation/communication_manager.py
+++ b/ipv8/attestation/communication_manager.py
@@ -13,7 +13,7 @@ from ..types import IPv8, Peer, PrivateKey
 from ..util import succeed
 from .identity.community import IdentityCommunity, create_community
 from .identity.manager import IdentityManager
-from .wallet.community import AttestationCommunity
+from .wallet.community import AttestationCommunity, AttestationSettings
 
 AttributePointer = Tuple[Peer, str]  # Backward compatibility: Python >= 3.9 can use ``tuple[Peer, str]``
 MetadataDict = Dict[str, str]  # Backward compatibility: Python >= 3.9 can use ``dict[str, str]``
@@ -334,10 +334,10 @@ class CommunicationManager:
                                                       working_directory=self.working_directory,
                                                       anonymize=tunnel_community is not None,
                                                       rendezvous_token=decoded_rendezvous_token)
-            attestation_overlay = AttestationCommunity(identity_overlay.my_peer, identity_overlay.endpoint,
-                                                       identity_overlay.network,
-                                                       working_directory=self.working_directory,
-                                                       anonymize=tunnel_community is not None)
+            settings = AttestationSettings(my_peer=identity_overlay.my_peer, endpoint=identity_overlay.endpoint,
+                                           network=identity_overlay.network, working_directory=self.working_directory,
+                                           anonymize=tunnel_community is not None)
+            attestation_overlay = AttestationCommunity(settings)
             cast(TunnelEndpoint, identity_overlay.endpoint).set_tunnel_community(tunnel_community)
             self.channels[public_key] = CommunicationChannel(attestation_overlay, identity_overlay)
             self.name_to_channel[name] = self.channels[public_key]

--- a/ipv8/dht/community.py
+++ b/ipv8/dht/community.py
@@ -11,7 +11,7 @@ from collections import defaultdict, deque
 from itertools import zip_longest
 from typing import TYPE_CHECKING, Any, Coroutine, Iterator, List, Optional, Sequence, Set, Tuple, cast
 
-from ..community import DEFAULT_MAX_PEERS, Community
+from ..community import Community, CommunitySettings
 from ..lazy_community import lazy_wrapper, lazy_wrapper_wd
 from ..messaging.interfaces.udp.endpoint import UDPv4Address, UDPv6Address
 from ..messaging.serialization import ListOf, Serializer
@@ -44,7 +44,7 @@ if TYPE_CHECKING:
     )
     from ..messaging.payload_headers import GlobalTimeDistributionPayload
     from ..peerdiscovery.discovery import DiscoveryStrategy
-    from ..types import Address, Endpoint, Peer
+    from ..types import Address, Peer
 
 DHTValue = Tuple[bytes, Optional[bytes]]
 
@@ -239,15 +239,14 @@ class DHTCommunity(Community):
 
     community_id = unhexlify('8d0be1845d74d175f178197cad001591d04d73cc')
 
-    def __init__(self, my_peer: Peer, endpoint: Endpoint, network: Network,
-                 max_peers: int = DEFAULT_MAX_PEERS, anonymize: bool = False) -> None:
+    def __init__(self, settings: CommunitySettings) -> None:
         """
         Create a new DHT overlay, ignoring the given network instance.
         """
-        super().__init__(my_peer, endpoint, network, max_peers, anonymize)
+        super().__init__(settings)
         self.network = Network()
         self.network.blacklist_mids.append(self.my_peer.mid)
-        self.network.blacklist.extend(network.blacklist)
+        self.network.blacklist.extend(self.network.blacklist)
 
         self.storages: dict[type[Address], Storage] = {}
         self.routing_tables: dict[type[Address], RoutingTable]  = {}

--- a/ipv8/dht/discovery.py
+++ b/ipv8/dht/discovery.py
@@ -5,7 +5,6 @@ from binascii import hexlify
 from collections import defaultdict
 from typing import TYPE_CHECKING, Callable, List, cast
 
-from ..community import DEFAULT_MAX_PEERS
 from ..lazy_community import lazy_wrapper, lazy_wrapper_wd
 from ..types import Address
 from . import DHTError
@@ -21,8 +20,8 @@ from .payload import (
 from .routing import NODE_STATUS_BAD, Node
 
 if TYPE_CHECKING:
-    from ..peerdiscovery.network import Network
-    from ..types import Endpoint, Peer
+    from ..community import CommunitySettings
+    from ..types import Peer
 
 
 class DHTDiscoveryCommunity(DHTCommunity):
@@ -30,12 +29,11 @@ class DHTDiscoveryCommunity(DHTCommunity):
     Community for discovering peers that are behind NAT.
     """
 
-    def __init__(self, my_peer: Peer, endpoint: Endpoint, network: Network,
-                 max_peers: int = DEFAULT_MAX_PEERS, anonymize: bool = False) -> None:
+    def __init__(self, settings: CommunitySettings) -> None:
         """
         Create a new dht-based discovery community.
         """
-        super().__init__(my_peer, endpoint, network, max_peers, anonymize)
+        super().__init__(settings)
 
         self.store: dict[bytes, list[Node]]  = defaultdict(list)
         self.store_for_me: dict[bytes, list[Node]] = defaultdict(list)

--- a/ipv8/loader.py
+++ b/ipv8/loader.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import abc
 import logging
 import types
-from typing import TYPE_CHECKING, Any, Callable, Iterable, Type, cast
+from typing import TYPE_CHECKING, Any, Callable, Type, cast
 
 from .keyvault.crypto import default_eccrypto
 from .peer import Peer
@@ -66,12 +66,6 @@ class CommunityLauncher:
         """
         Perform cleanup tasks after the community has been loaded.
         """
-
-    def get_args(self, session: object) -> Iterable:
-        """
-        Get the args to load the community with.
-        """
-        return self.community_args
 
     def get_kwargs(self, session: object) -> dict:
         """
@@ -208,9 +202,10 @@ class IPv8CommunityLoader(CommunityLoader):
         self._logger.info("Loading overlay %s", overlay_class)
         walk_strategies = launcher.get_walk_strategies()
         peer = launcher.get_my_peer(ipv8, session)
-        args = launcher.get_args(session)
         kwargs = launcher.get_kwargs(session)
-        overlay = overlay_class(peer, ipv8.endpoint, ipv8.network, *args, **kwargs)
+
+        settings = overlay_class.settings_class(my_peer=peer, endpoint=ipv8.endpoint, network=ipv8.network, **kwargs)
+        overlay = overlay_class(settings)
         bootstrappers = launcher.get_bootstrappers(session)
 
         ipv8.overlays.append(overlay)

--- a/ipv8/messaging/anonymization/endpoint.py
+++ b/ipv8/messaging/anonymization/endpoint.py
@@ -29,7 +29,7 @@ class TunnelEndpoint:
         self.settings: dict[bytes, bool] = {}
         self.send_queue: deque[tuple[Address, bytes]] = deque(maxlen=100)
 
-    def set_tunnel_community(self, tunnel_community: TunnelCommunity, hops: int = 1) -> None:
+    def set_tunnel_community(self, tunnel_community: TunnelCommunity | None, hops: int = 1) -> None:
         """
         Configure this endpoint to create tunnels of a given number of hops over the given community.
         """

--- a/ipv8/messaging/anonymization/pex.py
+++ b/ipv8/messaging/anonymization/pex.py
@@ -5,13 +5,12 @@ import time
 from collections import deque
 from typing import TYPE_CHECKING, List, cast
 
-from ...community import DEFAULT_MAX_PEERS, Community
+from ...community import Community, CommunitySettings
 from ...messaging.anonymization.tunnel import PEER_SOURCE_PEX, IntroductionPoint
 from ...peer import Peer
 
 if TYPE_CHECKING:
-    from ...peerdiscovery.network import Network
-    from ...types import Address, Endpoint
+    from ...types import Address
     from ..payload import (
         IntroductionRequestPayload,
         IntroductionResponsePayload,
@@ -23,20 +22,27 @@ if TYPE_CHECKING:
 PEX_VERSION = 1
 
 
+class PexSettings(CommunitySettings):
+    """
+    Settings for the PexCommunity.
+    """
+
+    info_hash: bytes
+
+
 class PexCommunity(Community):
     """
     New on-the-fly overlay for the PEX protocol.
     """
 
-    def __init__(self, my_peer: Peer, endpoint: Endpoint, network: Network,
-                 max_peers: int = DEFAULT_MAX_PEERS, anonymize: bool = False, **kwargs) -> None:
+    def __init__(self, settings: PexSettings) -> None:
         """
         Create a new PEX community by deriving the community id from the given SHA-1 hash.
         """
-        infohash = kwargs.pop('info_hash')
+        infohash = settings.info_hash
         self.community_id = (int.from_bytes(infohash, 'big') + PEX_VERSION).to_bytes(20, 'big')
         self._prefix = b'\x00' + self.version + self.community_id
-        super().__init__(my_peer, endpoint, network, max_peers, anonymize)
+        super().__init__(settings)
 
         self.intro_points: deque[IntroductionPoint] = deque(maxlen=20)
         self.intro_points_for: list[bytes] = []

--- a/ipv8/peerdiscovery/community.py
+++ b/ipv8/peerdiscovery/community.py
@@ -5,7 +5,7 @@ from random import sample
 from time import time
 from typing import TYPE_CHECKING, Sequence, Union, cast
 
-from ..community import DEFAULT_MAX_PEERS, Community
+from ..community import Community, CommunitySettings
 from ..keyvault.crypto import default_eccrypto
 from ..keyvault.keys import PrivateKey
 from ..lazy_community import PacketDecodingError, lazy_wrapper, lazy_wrapper_unsigned, retrieve_cache
@@ -24,8 +24,7 @@ from .payload import (
 )
 
 if TYPE_CHECKING:
-    from ..types import Address, Endpoint
-    from .network import Network
+    from ..types import Address
 
 
 class PeriodicSimilarity(DiscoveryStrategy):
@@ -97,12 +96,11 @@ class DiscoveryCommunity(Community):
     version = b'\x02'
     community_id = unhexlify('7e313685c1912a141279f8248fc8db5899c5df5a')
 
-    def __init__(self, my_peer: Peer, endpoint: Endpoint, network: Network,
-                 max_peers: int = DEFAULT_MAX_PEERS, anonymize: bool = False) -> None:
+    def __init__(self, settings: CommunitySettings) -> None:
         """
         Create a new community with similarity and ping functionality.
         """
-        super().__init__(my_peer, endpoint, network, max_peers=max_peers, anonymize=anonymize)
+        super().__init__(settings)
 
         self.request_cache = RequestCache()
 

--- a/ipv8/test/REST/test_attestation_endpoint.py
+++ b/ipv8/test/REST/test_attestation_endpoint.py
@@ -4,10 +4,10 @@ from asyncio import sleep
 from base64 import b64encode
 from typing import Collection, Sequence
 
-from ...attestation.identity.community import IdentityCommunity
+from ...attestation.identity.community import IdentityCommunity, IdentitySettings
 from ...attestation.identity.manager import IdentityManager
-from ...attestation.wallet.community import AttestationCommunity
-from ..REST.rest_base import MockRestIPv8, RESTTestBase, partial_cls
+from ...attestation.wallet.community import AttestationCommunity, AttestationSettings
+from ..REST.rest_base import MockRestIPv8, RESTTestBase
 
 
 class TestAttestationEndpoint(RESTTestBase):
@@ -21,8 +21,9 @@ class TestAttestationEndpoint(RESTTestBase):
         """
         super().setUp()
         identity_manager = IdentityManager(":memory:")
-        await self.initialize([partial_cls(AttestationCommunity, working_directory=':memory:'),
-                               partial_cls(IdentityCommunity, identity_manager=identity_manager)], 2)
+        await self.initialize([AttestationCommunity, IdentityCommunity], 2,
+                              settings=[AttestationSettings(working_directory=':memory:'),
+                                        IdentitySettings(identity_manager=identity_manager)])
 
     async def make_outstanding(self, node: MockRestIPv8) -> list[Sequence[str, str, str]]:
         """

--- a/ipv8/test/REST/test_isolation_endpoint.py
+++ b/ipv8/test/REST/test_isolation_endpoint.py
@@ -62,7 +62,7 @@ class TestIsolationEndpoint(RESTTestBase):
         self.fake_endpoint_listener = MockEndpointListener(self.fake_endpoint)
         self.fake_endpoint.add_listener(self.fake_endpoint_listener)
 
-        await self.initialize([], 1)
+        await self.initialize([], 1, [])
         self.ipv8 = self.node(0)
         self.ipv8.overlay = MockTunnelCommunity()
         self.ipv8.overlay.network = self.ipv8.network

--- a/ipv8/test/REST/test_network_endpoint.py
+++ b/ipv8/test/REST/test_network_endpoint.py
@@ -20,7 +20,7 @@ class TestNetworkEndpoint(RESTTestBase):
         Create a single node.
         """
         super().setUp()
-        await self.initialize([], 1)
+        await self.initialize([], 1, [])
         self.ipv8 = self.node(0)
 
     async def test_no_peers(self) -> None:

--- a/ipv8/test/REST/test_overlays_endpoint.py
+++ b/ipv8/test/REST/test_overlays_endpoint.py
@@ -34,7 +34,7 @@ class TestOverlaysEndpoint(RESTTestBase):
         Set up a single node.
         """
         super().setUp()
-        await self.initialize([], 1)
+        await self.initialize([], 1, [])
         self.ipv8 = self.node(0)
 
     def mount_statistics(self, i: int, add_mock_community: bool = True) -> None:

--- a/ipv8/test/attestation/identity/test_identity.py
+++ b/ipv8/test/attestation/identity/test_identity.py
@@ -1,9 +1,15 @@
+from __future__ import annotations
+
 import json
 from asyncio import sleep
+from typing import TYPE_CHECKING
 
-from ....attestation.identity.community import IdentityCommunity
+from ....attestation.identity.community import IdentityCommunity, IdentitySettings
 from ....attestation.identity.manager import IdentityManager
 from ...base import MockIPv8, TestBase
+
+if TYPE_CHECKING:
+    from ....community import CommunitySettings
 
 
 class TestIdentityCommunity(TestBase[IdentityCommunity]):
@@ -20,12 +26,13 @@ class TestIdentityCommunity(TestBase[IdentityCommunity]):
         super().setUp()
         self.initialize(IdentityCommunity, 2)
 
-    def create_node(self) -> MockIPv8:
+    def create_node(self, settings: CommunitySettings | None = None, create_dht: bool = False,
+                    enable_statistics: bool = False) -> MockIPv8:
         """
         Use a memory-based identity manager for each community.
         """
         identity_manager = IdentityManager(":memory:")
-        return MockIPv8("curve25519", IdentityCommunity, identity_manager=identity_manager)
+        return MockIPv8("curve25519", IdentityCommunity, settings=IdentitySettings(identity_manager=identity_manager))
 
     async def test_advertise(self) -> None:
         """

--- a/ipv8/test/base.py
+++ b/ipv8/test/base.py
@@ -22,6 +22,7 @@ from .mocking.endpoint import MockEndpointListener, internet
 from .mocking.ipv8 import MockIPv8
 
 if TYPE_CHECKING:
+    from ..community import CommunitySettings
     from ..peerdiscovery.network import Network
     from ..types import Address, Endpoint, PrivateKey, PublicKey
 
@@ -189,7 +190,8 @@ class TestBase(TestCaseClass, Generic[OT]):
         else:
             self.__call_internal_in_context(self.tearDown)
 
-    def initialize(self, overlay_class: type[Community], node_count: int, *args: object, **kwargs) -> None:
+    def initialize(self, overlay_class: type[Community], node_count: int, settings: CommunitySettings | None = None,
+                   create_dht: bool = False, enable_statistics: bool = False) -> None:
         """
         Spawn a given number of nodes with a particular overlay class and introduce them to each other.
 
@@ -197,7 +199,7 @@ class TestBase(TestCaseClass, Generic[OT]):
                  HOWEVER, custom logic based on introduction requests and responses may therefore be skipped.
         """
         self.overlay_class = overlay_class
-        self.nodes = [self.create_node(*args, **kwargs) for _ in range(node_count)]
+        self.nodes = [self.create_node(settings, create_dht, enable_statistics) for _ in range(node_count)]
 
         # Add nodes to each other.
         for node in self.nodes:
@@ -339,11 +341,12 @@ class TestBase(TestCaseClass, Generic[OT]):
         """
         cls.__testing__ = False
 
-    def create_node(self, *args: object, **kwargs) -> MockIPv8:
+    def create_node(self, settings: CommunitySettings | None = None, create_dht: bool = False,
+                    enable_statistics: bool = False) -> MockIPv8:
         """
         Create a new IPv8-like container to store node related information.
         """
-        return MockIPv8("low", cast(Type[Community], self.overlay_class), *args, **kwargs)
+        return MockIPv8("low", cast(Type[Community], self.overlay_class), settings, create_dht, enable_statistics)
 
     def add_node_to_experiment(self, node: MockIPv8) -> None:
         """

--- a/ipv8/test/messaging/anonymization/test_community.py
+++ b/ipv8/test/messaging/anonymization/test_community.py
@@ -22,6 +22,7 @@ from ...mocking.ipv8 import MockIPv8
 from .mock import MockDHTProvider
 
 if TYPE_CHECKING:
+    from ....community import CommunitySettings
     from ....types import Address, Overlay
 
 
@@ -64,15 +65,16 @@ class TestTunnelCommunity(TestBase[TunnelCommunity]):
 
         return await super().tearDown()
 
-    def create_node(self) -> MockIPv8:
+    def create_node(self, settings: CommunitySettings | None = None, create_dht: bool = False,
+                    enable_statistics: bool = False) -> MockIPv8:
         """
         Initialize a TunnelCommunity without circuits or exit node functionality.
         """
-        settings = TunnelSettings()
-        settings.min_circuits = 0
-        settings.max_circuits = 0
-        settings.remove_tunnel_delay = 0
-        ipv8 = MockIPv8("curve25519", TunnelCommunity, settings=settings)
+        tunnel_settings = TunnelSettings()
+        tunnel_settings.min_circuits = 0
+        tunnel_settings.max_circuits = 0
+        tunnel_settings.remove_tunnel_delay = 0
+        ipv8 = MockIPv8("curve25519", TunnelCommunity, settings=tunnel_settings)
         # Then kill all automated circuit creation
         ipv8.overlay.cancel_all_pending_tasks()
         # Finally, use the proper exitnode and circuit settings for manual creation

--- a/ipv8/test/messaging/anonymization/test_hiddenservices.py
+++ b/ipv8/test/messaging/anonymization/test_hiddenservices.py
@@ -5,8 +5,8 @@ from asyncio import Future, sleep
 from typing import TYPE_CHECKING
 from unittest.mock import Mock
 
-from ....messaging.anonymization.community import CIRCUIT_TYPE_RP_DOWNLOADER, TunnelSettings
-from ....messaging.anonymization.hidden_services import HiddenTunnelCommunity
+from ....messaging.anonymization.community import CIRCUIT_TYPE_RP_DOWNLOADER
+from ....messaging.anonymization.hidden_services import HiddenTunnelCommunity, HiddenTunnelSettings
 from ....messaging.anonymization.payload import TestRequestPayload
 from ....messaging.anonymization.tunnel import (
     CIRCUIT_TYPE_DATA,
@@ -98,15 +98,15 @@ class TestHiddenServices(TestBase[HiddenTunnelCommunity]):
 
         return path
 
-    def create_node(self) -> MockIPv8:
+    def create_node(self, settings: None = None, create_dht: bool = False, enable_statistics: bool = False) -> MockIPv8:
         """
         Initialize a HiddenTunnelCommunity without circuits or exit node functionality.
         """
-        settings = TunnelSettings()
-        settings.min_circuits = 0
-        settings.max_circuits = 0
-        settings.remove_tunnel_delay = 0
-        ipv8 = MockIPv8("curve25519", HiddenTunnelCommunity, settings=settings)
+        tunnel_settings = HiddenTunnelSettings()
+        tunnel_settings.min_circuits = 0
+        tunnel_settings.max_circuits = 0
+        tunnel_settings.remove_tunnel_delay = 0
+        ipv8 = MockIPv8("curve25519", HiddenTunnelCommunity, settings=tunnel_settings)
         ipv8.overlay.ipv8 = ipv8
 
         # Then kill all automated circuit creation

--- a/ipv8/test/messaging/interfaces/lan_addresses/test_addressprovider.py
+++ b/ipv8/test/messaging/interfaces/lan_addresses/test_addressprovider.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import contextlib
 import io
 from asyncio import sleep
+from time import time
 from typing import Set
 
 from .....messaging.interfaces.lan_addresses.addressprovider import AddressProvider
@@ -96,7 +97,8 @@ class TestAddressProvider(TestBase):
         provider = InvocationCountingProvider()
         provider.get_addresses_buffered()
 
-        await sleep(0.02)
+        while time() - provider.addresses_ts <= 0.01:
+            await sleep(0.01)
 
         # 0.01 seconds should have passed, so the addresses should be re-discovered
         provider.discover_addresses(0.01)

--- a/ipv8/test/mocking/community.py
+++ b/ipv8/test/mocking/community.py
@@ -1,3 +1,4 @@
+from ...community import CommunitySettings
 from ...keyvault.crypto import default_eccrypto
 from ...peer import Peer
 from ...peerdiscovery.community import DiscoveryCommunity
@@ -16,9 +17,13 @@ class MockCommunity(DiscoveryCommunity):
         """
         endpoint = AutoMockEndpoint()
         endpoint.open()
-        network = Network()
-        peer = Peer(default_eccrypto.generate_key("very-low"), endpoint.wan_address)
-        super().__init__(peer, endpoint, network)
+
+        settings = CommunitySettings(
+            endpoint=endpoint,
+            network=Network(),
+            my_peer=Peer(default_eccrypto.generate_key("very-low"), endpoint.wan_address)
+        )
+        super().__init__(settings)
         # workaround for race conditions in deliver_messages
         self._use_main_thread = False
         self.my_estimated_lan = endpoint.lan_address

--- a/ipv8/test/test_community.py
+++ b/ipv8/test/test_community.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from ..bootstrapping.dispersy.bootstrapper import DispersyBootstrapper
-from ..community import Community
+from ..community import Community, CommunitySettings
 from ..peer import Peer
 from ..peerdiscovery.network import Network
 from .base import TestBase
@@ -142,14 +142,17 @@ class TestCommunityInit(TestBase):
         """
         Check that attempting to create a Community without an id raises an error.
         """
-        self.assertRaises(RuntimeError, NoIDCommunity, Peer(b'LibNaCLPK:' + b'0' * 32), AutoMockEndpoint(), Network())
+        settings = CommunitySettings(my_peer=Peer(b'LibNaCLPK:' + b'0' * 32), endpoint=AutoMockEndpoint(),
+                                     network=Network())
+        self.assertRaises(RuntimeError, NoIDCommunity, settings)
 
     async def test_init_strange_id(self) -> None:
         """
         Check that attempting to create a Community with an id that is not ```bytes`` raises an error.
         """
-        self.assertRaises(RuntimeError, StrangeIDCommunity, Peer(b'LibNaCLPK:' + b'0' * 32), AutoMockEndpoint(),
-                          Network())
+        settings = CommunitySettings(my_peer=Peer(b'LibNaCLPK:' + b'0' * 32), endpoint=AutoMockEndpoint(),
+                                     network=Network())
+        self.assertRaises(RuntimeError, StrangeIDCommunity, settings)
 
 
 class TestCommunityBootstrapping(TestBase):
@@ -163,7 +166,9 @@ class TestCommunityBootstrapping(TestBase):
         """
         Check if unloading a Community after waiting for bootstrapping results exits cleanly.
         """
-        community = NewCommunity(Peer(b'LibNaCLPK:' + b'0' * 32), AutoMockEndpoint(), Network())
+        settings = CommunitySettings(my_peer=Peer(b'LibNaCLPK:' + b'0' * 32), endpoint=AutoMockEndpoint(),
+                                     network=Network())
+        community = NewCommunity(settings)
         community.bootstrappers = [DispersyBootstrapper([], [])]
 
         # Initialize bootstrapper and get the bootstrapping task
@@ -182,7 +187,9 @@ class TestCommunityBootstrapping(TestBase):
         """
         Check if unloading a Community while waiting for bootstrapping results exits cleanly.
         """
-        community = NewCommunity(Peer(b'LibNaCLPK:' + b'0' * 32), AutoMockEndpoint(), Network())
+        settings = CommunitySettings(my_peer=Peer(b'LibNaCLPK:' + b'0' * 32), endpoint=AutoMockEndpoint(),
+                                     network=Network())
+        community = NewCommunity(settings)
         community.bootstrappers = [DispersyBootstrapper([], [])]
 
         # Initialize bootstrapper and get the bootstrapping task

--- a/ipv8/test/test_loader.py
+++ b/ipv8/test/test_loader.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Iterable
 
 from ..bootstrapping.bootstrapper_interface import Bootstrapper
-from ..community import Community
+from ..community import Community, CommunitySettings
 from ..loader import (
     CommunityLauncher,
     IPv8CommunityLoader,
@@ -20,8 +20,7 @@ from ..peerdiscovery.discovery import DiscoveryStrategy
 from .base import TestBase
 
 if TYPE_CHECKING:
-    from ..peerdiscovery.network import Network
-    from ..types import Address, Endpoint, IPv8, Peer
+    from ..types import Address, IPv8
 
 
 class MockCommunity(Community):
@@ -29,15 +28,14 @@ class MockCommunity(Community):
     Empty community implementation.
     """
 
-    def __init__(self, peer: Peer, endpoint: Endpoint, network: Network, *args: Any, **kw_args) -> None:  # noqa: ANN401
+    def __init__(self, settings: CommunitySettings) -> None:
         """
         Fake creation, simply store all init args.
         """
-        self.peer = peer
-        self.endpoint = endpoint
-        self.network = network
-        self.args = args
-        self.kwargs = kw_args
+        self.peer = settings.my_peer
+        self.endpoint = settings.endpoint
+        self.network = settings.network
+        self.kwargs = {k: v for k, v in settings.__dict__.items() if k not in CommunitySettings().__dict__}
         self.bootstrappers = []
 
 
@@ -446,7 +444,7 @@ class TestCommunityLauncher(TestBase):
             pass
 
         session = MockSession()
-        community = MockCommunity(None, None, None)
+        community = MockCommunity(CommunitySettings(my_peer=None, network=None, endpoint=None))
         DecoratedCommunityLauncher().finalize(None, session, community)
 
         self.assertEqual(community, session.community)

--- a/ipv8_service.py
+++ b/ipv8_service.py
@@ -81,7 +81,7 @@ else:
                      configuration: dict[str, Any],
                      endpoint_override: Endpoint | None = None,
                      enable_statistics: bool = False,
-                     extra_communities: dict[str, Overlay] | None = None) -> None:
+                     extra_communities: dict[str, type[Overlay]] | None = None) -> None:
             """
             Create a new IPv8 instance, that is yet unstarted.
             """
@@ -136,7 +136,9 @@ else:
             for overlay in configuration['overlays']:
                 overlay_class = _COMMUNITIES.get(overlay['class'], (extra_communities or {}).get(overlay['class']))
                 my_peer = self.keys[overlay['key']]
-                overlay_instance = overlay_class(my_peer, self.endpoint, self.network, **overlay['initialize'])
+                settings = overlay_class.settings_class(my_peer=my_peer, endpoint=self.endpoint, network=self.network,
+                                                        **overlay['initialize'])
+                overlay_instance = overlay_class(settings)
                 self.overlays.append(overlay_instance)
                 for walker in overlay['walkers']:
                     strategy_class: type[DiscoveryStrategy]


### PR DESCRIPTION
Fixes #1175

This PR:

 - Updates all `Overlay` instances to take a `settings` object instead of passing individual settings to the `__init__()`.

