### PR TITLE
Fixed Sphinx deprecations and dependency versions

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -72,7 +72,7 @@ master_doc = 'index'
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -99,7 +99,7 @@ html_theme = 'sphinx_rtd_theme'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = []
 
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.
@@ -192,7 +192,7 @@ epub_exclude_files = ['search.html']
 # -- Options for intersphinx extension ---------------------------------------
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'https://docs.python.org/': None}
+intersphinx_mapping = {'python': ('https://docs.python.org/3', None)}
 
 # -- Options for todo extension ----------------------------------------------
 

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,1 +1,3 @@
+astroid>=3.0.0
 sphinx-autoapi
+sphinx-rtd-theme>=1.3.0


### PR DESCRIPTION
Fixes #1205 (again)

This PR:

 - Fixes requirements in `doc/requirements.txt` to work with `Sphinx==7.1.2`.
 - Updates deprecations in `doc/conf.py`.

Locally verified with:

```
astroid==3.0.0
Sphinx==7.1.2
sphinx-autoapi==3.0.0
sphinx-rtd-theme==1.3.0
```

This _should_ now work.