### PR TITLE
Automated Version Update

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -25,9 +25,9 @@ copyright = '2017-2023, Tribler'  # Do not change manually! Handled by github_in
 author = 'Tribler'
 
 # The short X.Y version
-version = '2.11'  # Do not change manually! Handled by github_increment_version.py
+version = '2.12'  # Do not change manually! Handled by github_increment_version.py
 # The full version, including alpha/beta/rc tags
-release = '2.11.0'  # Do not change manually! Handled by github_increment_version.py
+release = '2.12.0'  # Do not change manually! Handled by github_increment_version.py
 
 
 # -- General configuration ---------------------------------------------------

--- a/ipv8/REST/rest_manager.py
+++ b/ipv8/REST/rest_manager.py
@@ -115,7 +115,7 @@ class RESTManager:
         aiohttp_apispec = AiohttpApiSpec(
             app=self.root_endpoint.app,
             title="IPv8 REST API documentation",
-            version="v2.11",  # Do not change manually! Handled by github_increment_version.py
+            version="v2.12",  # Do not change manually! Handled by github_increment_version.py
             url="/docs/swagger.json",
             swagger_path="/docs",
         )

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     description='The Python implementation of the IPV8 library',
     long_description=long_description,
     long_description_content_type='text/markdown',
-    version='2.11.0',  # Do not change manually! Handled by github_increment_version.py
+    version='2.12.0',  # Do not change manually! Handled by github_increment_version.py
     url='https://github.com/Tribler/py-ipv8',
     package_data={'': ['*.*']},
     packages=find_packages(),


### PR DESCRIPTION
Suggested release message
---
Tag version: 2.12
Release title: IPv8 v2.12.2003 release
Body:
Includes the first 2003 commits (+103 since v2.11) for IPv8, containing:

 - Added ruff configuration file
 - Added typed request cache add/get/pop
 - Fixed ReadTheDocs configuration build.os
 - Fixed Sphinx deprecations and dependency versions
 - Fixed TestBase hanging when event loop missing
 - Fixed crypto related issues in TunnelCommunity
 - Fixed doc validation not running as __main__
 - Fixed example lines in testbase_tutorial
 - Fixed line numbers in docs
 - Fixed ruff violations 
 - Removed simulation code
 - Updated DiscoveryCommunity payloads to use ipv4 instead of 4SH
 - Updated DiscoveryStrategy to be a generic of its overlay
 - Updated IPv8 scripts to use asyncio.run
 - Updated LAN discovery to run on a different thread
 - Updated `MockRestIPv8` to not use real socket
 - Updated `TestIdentityEndpoint` to not use real files
 - Updated `test_load_key` to not use a real db file
 - Updated bootstrappers to be less complex
 - Updated codebase with pyupgrade
 - Updated dht community to use DHTValue type
 - Updated mid to always be the hash of the public key
 - Updated overlay basics doc to use PeerObserver
 - Updated overlays to use a settings parameter
 - Updated readme test instructions
 - Updated the ruff rules to allow more args and ignore pandas violations