### PR TITLE
Fixed missing dependency: typing-extensions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pyOpenSSL
 pyasn1
 asynctest; python_version=='3.7'
 marshmallow
+typing-extensions


### PR DESCRIPTION
This PR:

 - Fixes `ModuleNotFoundError: No module named 'typing_extensions'`