### PR TITLE
Removed overwrite dataclass construction

### DIFF
--- a/doc/basics/overlay_tutorial_5.py
+++ b/doc/basics/overlay_tutorial_5.py
@@ -1,17 +1,13 @@
 import os
 from asyncio import run
-from dataclasses import dataclass
 
 from ipv8.community import Community, CommunitySettings
 from ipv8.configuration import ConfigBuilder, Strategy, WalkerDefinition, default_bootstrap_defs
 from ipv8.lazy_community import lazy_wrapper
-from ipv8.messaging.payload_dataclass import overwrite_dataclass
+from ipv8.messaging.payload_dataclass import dataclass
 from ipv8.types import Peer
 from ipv8.util import run_forever
 from ipv8_service import IPv8
-
-# Enhance normal dataclasses for IPv8 (see the serialization documentation)
-dataclass = overwrite_dataclass(dataclass)
 
 
 @dataclass(msg_id=1)  # The value 1 identifies this message and must be unique per community

--- a/doc/basics/testbase_tutorial.rst
+++ b/doc/basics/testbase_tutorial.rst
@@ -206,28 +206,28 @@ In the following example peer 0 first sends message 1 and then sends message 2 t
 The following construction asserts this:
 
 .. literalinclude:: testbase_tutorial_2.py
-   :lines: 68-71
+   :lines: 65-68
    :dedent: 4
 
 Sometimes, you can't be sure in what order messages are sent.
 In these cases you can use ``ordered=False``:
 
 .. literalinclude:: testbase_tutorial_2.py
-   :lines: 74-80
+   :lines: 71-77
    :dedent: 4
 
 In other cases, your overlay may be sending messages which you cannot control and/or which you don't care about.
 In these cases you can set a filter to only include the messages you want:
 
 .. literalinclude:: testbase_tutorial_2.py
-   :lines: 83-88
+   :lines: 80-85
    :dedent: 4
 
 It may also be helpful to inspect the contents of each payload.
 You can simply use the return value of the assert function to perform further inspection:
 
 .. literalinclude:: testbase_tutorial_2.py
-   :lines: 91-98
+   :lines: 88-95
    :dedent: 4
 
 If you want to use ``assertReceivedBy()``, make sure that:

--- a/doc/basics/testbase_tutorial_2.py
+++ b/doc/basics/testbase_tutorial_2.py
@@ -1,15 +1,12 @@
 import os
 import unittest
-from dataclasses import dataclass
 from random import random, shuffle
 
 from ipv8.community import Community, CommunitySettings
 from ipv8.lazy_community import lazy_wrapper, lazy_wrapper_unsigned
-from ipv8.messaging.payload_dataclass import overwrite_dataclass
+from ipv8.messaging.payload_dataclass import dataclass
 from ipv8.test.base import TestBase
 from ipv8.types import Peer
-
-dataclass = overwrite_dataclass(dataclass)
 
 
 @dataclass(msg_id=1)

--- a/doc/reference/serialization.rst
+++ b/doc/reference/serialization.rst
@@ -38,14 +38,14 @@ If the ``dataclass`` had used normal ``int`` types, these would have been two si
 Each instance will have two fields: ``field1`` and ``field2`` corresponding to the integer and short.
 
 .. literalinclude:: serialization_1.py
-   :lines: 13-65
+   :lines: 9-61
 
 
 To show some of the differences, let's check out the output of the following script using these definitions:
 
 
 .. literalinclude:: serialization_1.py
-   :lines: 68-79
+   :lines: 64-75
 
 
 .. code-block:: bash
@@ -192,7 +192,7 @@ This method involves implementing the methods ``fix_pack_<your field name>`` and
 Check out the following example:
 
 .. literalinclude:: serialization_4.py
-   :lines: 14-39
+   :lines: 11-36
 
 In both classes we create a message with a single field ``dictionary``.
 To pack this field, we use ``json.dumps()`` to create a string representation of the dictionary.
@@ -247,9 +247,9 @@ You can specify them by using the ``"payload"`` datatype and setting the ``Paylo
 For a ``VariablePayload`` this looks like the following example.
 
 .. literalinclude:: serialization_7.py
-   :lines: 9-16
+   :lines: 5-12
 
 For dataclass payloads this nesting is supported by simply specifying nested classes as follows.
 
 .. literalinclude:: serialization_7.py
-   :lines: 19-28
+   :lines: 15-24

--- a/doc/reference/serialization_1.py
+++ b/doc/reference/serialization_1.py
@@ -1,13 +1,9 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
-
 from ipv8.messaging.lazy_payload import VariablePayload, vp_compile
 from ipv8.messaging.payload import Payload
-from ipv8.messaging.payload_dataclass import overwrite_dataclass, type_from_format
+from ipv8.messaging.payload_dataclass import dataclass, type_from_format
 from ipv8.messaging.serialization import Serializable
-
-dataclass = overwrite_dataclass(dataclass)
 
 
 class MySerializable(Serializable):

--- a/doc/reference/serialization_4.py
+++ b/doc/reference/serialization_4.py
@@ -1,14 +1,11 @@
 from __future__ import annotations
 
 import json
-from dataclasses import dataclass
 from typing import cast
 
 from ipv8.messaging.lazy_payload import VariablePayload, vp_compile
-from ipv8.messaging.payload_dataclass import overwrite_dataclass
+from ipv8.messaging.payload_dataclass import dataclass
 from ipv8.messaging.serialization import default_serializer
-
-dataclass = overwrite_dataclass(dataclass)
 
 
 @vp_compile

--- a/doc/reference/serialization_7.py
+++ b/doc/reference/serialization_7.py
@@ -1,9 +1,5 @@
-from dataclasses import dataclass
-
 from ipv8.messaging.lazy_payload import VariablePayload
-from ipv8.messaging.payload_dataclass import overwrite_dataclass
-
-dataclass = overwrite_dataclass(dataclass)
+from ipv8.messaging.payload_dataclass import dataclass
 
 
 class A(VariablePayload):

--- a/ipv8/messaging/payload_dataclass.py
+++ b/ipv8/messaging/payload_dataclass.py
@@ -67,31 +67,4 @@ def dataclass(cls: type | None = None, *,  # noqa: PLR0913
     return vp_compile(DataClassPayload)
 
 
-def overwrite_dataclass(old_dataclass):  # noqa: ANN001, ANN201
-    """
-    Overwrite the dataclass function.
-
-    In order to get type hinting you have to do the following:
-
-    .. code-block:: python
-
-        from dataclasses import dataclass
-        from ipv8.messaging.payload_dataclass import dataclass
-
-    Linters don't like this. Instead, you can use this function to have a linter friendly alternative:
-
-    .. code-block:: python
-
-        from dataclasses import dataclass
-        from ipv8.messaging.payload_dataclass import overwrite_dataclass
-
-        dataclass = overwrite_dataclass(dataclass)
-
-    :param old_dataclass: the dataclass.dataclass definition.
-    :returns: the new dataclass definition
-    """
-    assert old_dataclass  # Though unused, we reference the variable to placate the linters.
-    return dataclass
-
-
-__all__ = ['overwrite_dataclass', 'type_from_format']
+__all__ = ['dataclass', 'type_from_format']

--- a/ipv8/test/messaging/test_payload_dataclass.py
+++ b/ipv8/test/messaging/test_payload_dataclass.py
@@ -1,14 +1,13 @@
 from __future__ import annotations
 
-from dataclasses import dataclass, is_dataclass
+from dataclasses import dataclass as ogdataclass
+from dataclasses import is_dataclass
 from typing import List, TypeVar
 
-from ...messaging.payload_dataclass import overwrite_dataclass, type_from_format
+from ...messaging.payload_dataclass import dataclass, type_from_format
 from ...messaging.serialization import default_serializer
 from ..base import TestBase
 
-ogdataclass = dataclass
-dataclass = overwrite_dataclass(dataclass)
 varlenH = type_from_format('varlenH')  # noqa: N816
 
 T = TypeVar("T")


### PR DESCRIPTION
Related to #1196

This PR:

 - Removes the (now-useless) `overwrite_dataclass()` function.

