### PR TITLE
Fixed the GitHub validate action

### DIFF
--- a/.github/workflows/pr-comment-validate.yml
+++ b/.github/workflows/pr-comment-validate.yml
@@ -13,6 +13,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/setup-python@v4
-        with:
+      - with:
           python-version: ${{ matrix.version }}
         run: python --version


### PR DESCRIPTION
Related #1056


```
Error:  .github#L1
a step cannot have both the `uses` and `run` keys
```

See also https://github.com/Tribler/py-ipv8/actions/runs/6492024002

This PR:

 - Fixes the PR validate action by separating the `run` and `uses` keys.

Note that this is PR `2/?`, without any guarantees on the upper limit needed to get this running.