### PR TITLE
Fixed wrong hypen location in GitHub validate PR action

### DIFF
--- a/.github/workflows/pr-comment-validate.yml
+++ b/.github/workflows/pr-comment-validate.yml
@@ -13,6 +13,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/setup-python@v4
-      - with:
+        with:
           python-version: ${{ matrix.version }}
-        run: python --version
+      - run: python --version


### PR DESCRIPTION
Related to #1056

New error:

```
      - uses: actions/setup-python@v4
      - with:
          python-version: ${{ matrix.version }}
        run: python --version
>>
Invalid workflow file: .github/workflows/pr-comment-validate.yml#L18
The workflow is not valid. .github/workflows/pr-comment-validate.yml (Line: 18, Col: 9): Unexpected value 'run' .github/workflows/pr-comment-validate.yml (Line: 16, Col: 9): Required property is missing: uses
```

Previous error:

```
      - uses: actions/setup-python@v4
        with:
          python-version: ${{ matrix.version }}
        run: python --version
>>
Error: .github#L1
a step cannot have both the `uses` and `run` keys
```

This PR:

 - Fixed previous PR making the `with` of the `uses` a new step instead of the `run` (oops).

Documentation referenced: https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#example-expanding-configurations

Note that this is PR 3/?, without any guarantees on the upper limit needed to get this running.