### PR TITLE
WIP: Fixed validate job not installing dependencies

### DIFF
--- a/.github/workflows/pr-comment-validate.yml
+++ b/.github/workflows/pr-comment-validate.yml
@@ -16,4 +16,5 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.version }}
+      - run: python -m pip install -r requirements.txt
       - run: python run_all_tests.py -a


### PR DESCRIPTION
Fixes #1222

This PR:

 - Fixes the validation action not installing the IPv8 requirements before launching tests.

