### PR TITLE
Fixed issue with serializing nested payloads that use raw

### DIFF
--- a/ipv8/messaging/serialization.py
+++ b/ipv8/messaging/serialization.py
@@ -106,10 +106,12 @@ class NestedPayload(Packer):
         :param args: a list of one Serializable class to unpack to
         :return: the new offset
         """
+        size, = unpack_from('>H', data, offset)
+        offset += 2
         serializable_class = args[0]
-        unpacked, offset = self.serializer.unpack_serializable(serializable_class, data, offset=offset + 2)
+        unpacked, _ = self.serializer.unpack_serializable(serializable_class, data[offset:offset + size])
         unpack_list.append(unpacked)
-        return offset
+        return offset + size
 
 
 class Bits(Packer):

--- a/ipv8/messaging/serialization.py
+++ b/ipv8/messaging/serialization.py
@@ -400,6 +400,7 @@ class Serializer:
             'varlenBx2': VarLen('>B', 2),
             'varlenH': VarLen('>H'),
             'varlenHutf8': VarLenUtf8('>H'),
+            'varlenIutf8': VarLenUtf8('>I'),
             'varlenHx20': VarLen('>H', 20),
             'varlenH-list': ListOf(VarLen('>H')),
             'varlenI': VarLen('>I'),


### PR DESCRIPTION
This PR fixes raw support for `NestedPayload`.