### PR TITLE
Fixed spelling and grammar instance in index.rst

### DIFF
--- a/.github/workflows/pr-comment-validate.yml
+++ b/.github/workflows/pr-comment-validate.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: refs/pull/${{ github.event.issue.number }}/head
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.version }}

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -8,7 +8,7 @@ The documentation will explain the concepts behind IPv8, the architecture, and g
 Why does IPv8 exist?
 ====================
 
-Problems with the very fabric of The Internet, IPv4, are mounting. The approach of IPv6, Mobile IP, and IPSec is hampered by fundamental architectural problems. One solution is moving the intelligence up to a higher layer in the protocol stack and towards the end points. Our endpoints are not dependent on any central infrastructure. Our architecture is academically pure and fully decentralized; to the point of obsession. IPv8 is based on the principle of self-governance. Like Bitcoin and BitTorrent our IPv8 overlays are permissionless and requires no server upkeep costs. 
+Problems with the very fabric of The Internet, IPv4, are mounting. The approach of IPv6, Mobile IP, and IPSec is hampered by fundamental architectural problems. One solution is moving the intelligence up to a higher layer in the protocol stack and towards the end points. Our endpoints are not dependent on any central infrastructure. Our architecture is academically pure and fully decentralized; to the point of obsession. IPv8 is based on the principle of self-governance. Like Bitcoin and BitTorrent, our IPv8 overlays are permissionless and require no server upkeep costs. 
 
 IPv8 aims to help restore the original Internet; for free; owned by nobody; for everyone.
 

--- a/run_all_tests.py
+++ b/run_all_tests.py
@@ -170,7 +170,7 @@ def task_test(*test_names: str) -> tuple[bool, int, float, list[tuple[str, str, 
         # If we made it here, there is only one option if the import fails and that is a local path dll.
         import libnacl  # noqa: F401
     except:
-        os.add_dll_directory(os.path.dirname(__file__))
+        os.add_dll_directory(os.path.dirname(__file__) or '.')
 
     print_stream = io.StringIO()
     output_stream = CustomLinePrint(print_stream, "OUT")
@@ -293,7 +293,7 @@ def windows_missing_libsodium() -> bool:
         return False
 
     # Try to find it in the local directory. This is where we'll download it anyway.
-    os.add_dll_directory(os.path.dirname(__file__))
+    os.add_dll_directory(os.path.dirname(__file__) or '.')
     try:
         import libnacl  # noqa: F401, F811
         return False


### PR DESCRIPTION
This PR:

 - Adds a fallback to the `"."` directory if `run_all_tests.py` is run from the `""` directory.
 - Fixes spelling and grammar instance in index.rst
 - Fixes the validation matrix still not using the PR head (this time using [this](https://github.com/actions/checkout/pull/1248/files) solution).
 
 This PR is mainly to test the recent validation Action fixes.

