### PR TITLE
Added IPv6 support to TunnelCommunity

### DIFF
--- a/ipv8/messaging/anonymization/payload.py
+++ b/ipv8/messaging/anonymization/payload.py
@@ -96,7 +96,7 @@ class ExtendPayload(CellablePayload):
 
     msg_id = 4
     names = ['circuit_id', 'identifier', 'node_public_key', 'key', 'node_addr']
-    format_list = ['I', 'H', 'varlenH', 'varlenH', 'ipv4']
+    format_list = ['I', 'H', 'varlenH', 'varlenH', 'ip_address']
 
     circuit_id: int
     identifier: int
@@ -217,7 +217,7 @@ class RendezvousEstablishedPayload(CellablePayload):
 
     msg_id = 12
     names = ['circuit_id', 'identifier', 'rendezvous_point_addr']
-    format_list = ['I', 'H', 'ipv4']
+    format_list = ['I', 'H', 'ip_address']
 
     circuit_id: int
     identifier: int
@@ -307,7 +307,7 @@ class IntroductionInfo(VariablePayload):
     """
 
     names = ['address', 'key', 'seeder_pk', 'source']
-    format_list = ['ipv4', 'varlenH', 'varlenH', 'B']
+    format_list = ['ip_address', 'varlenH', 'varlenH', 'B']
 
     address: Address
     key: bytes
@@ -338,7 +338,7 @@ class RendezvousInfo(VariablePayload):
     """
 
     names = ['address', 'key', 'cookie']
-    format_list = ['ipv4', 'varlenH', '20s']
+    format_list = ['ip_address', 'varlenH', '20s']
 
     address: Address
     key: bytes

--- a/ipv8/messaging/interfaces/endpoint.py
+++ b/ipv8/messaging/interfaces/endpoint.py
@@ -256,8 +256,7 @@ class EndpointListener(metaclass=abc.ABCMeta):
         Chooses the most likely Interface instance out of INTERFACES to use as our LAN address.
         """
         for address in addresses:
-            if (not (self.is_ipv6_listener and not self._is_ipv6_address(address))
-                    and not (not self.is_ipv6_listener and self._is_ipv6_address(address))):
+            if self.is_ipv6_listener == self._is_ipv6_address(address):
                 return address
 
         return "127.0.0.1"

--- a/ipv8/test/REST/test_isolation_endpoint.py
+++ b/ipv8/test/REST/test_isolation_endpoint.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
+import unittest
 from typing import TYPE_CHECKING, cast
 
 from ...bootstrapping.dispersy.bootstrapper import DispersyBootstrapper
 from ...configuration import DISPERSY_BOOTSTRAPPER
 from ...messaging.anonymization.community import TunnelCommunity
 from ..mocking.community import MockCommunity
-from ..mocking.endpoint import MockEndpoint, MockEndpointListener
+from ..mocking.endpoint import AutoMockEndpoint, MockEndpoint, MockEndpointListener
 from ..REST.rest_base import RESTTestBase
 
 if TYPE_CHECKING:
@@ -101,6 +102,7 @@ class TestIsolationEndpoint(RESTTestBase):
 
         self.assertFalse(response["success"])
 
+    @unittest.skipIf(AutoMockEndpoint.IPV6_ADDRESSES, "IPv6 not supported")
     async def test_add_bootstrap(self) -> None:
         """
         Check if bootstrap nodes are correctly added.
@@ -117,6 +119,7 @@ class TestIsolationEndpoint(RESTTestBase):
         self.assertIn(TestIsolationEndpoint.FAKE_BOOTSTRAP_ADDRESS, self.ipv8.network.blacklist)
         self.assertLessEqual(1, len(self.fake_endpoint_listener.received_packets))
 
+    @unittest.skipIf(AutoMockEndpoint.IPV6_ADDRESSES, "IPv6 not supported")
     async def test_add_exit(self) -> None:
         """
         Check if exit nodes are correctly added.

--- a/ipv8/test/bootstrapping/dispersy/test_bootstrapper.py
+++ b/ipv8/test/bootstrapping/dispersy/test_bootstrapper.py
@@ -1,9 +1,12 @@
+import unittest
+
 from ....bootstrapping.dispersy.bootstrapper import DispersyBootstrapper
 from ...base import TestBase
 from ...mocking.community import MockCommunity
 from ...mocking.endpoint import AutoMockEndpoint, MockEndpointListener
 
 
+@unittest.skipIf(AutoMockEndpoint.IPV6_ADDRESSES, "IPv6 not supported")
 class TestDispersyBootstrapper(TestBase):
     """
     Tests related to Dispersy-style bootstrapping.

--- a/ipv8/test/mocking/endpoint.py
+++ b/ipv8/test/mocking/endpoint.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import random
 from asyncio import get_running_loop
 from typing import TYPE_CHECKING
@@ -142,7 +143,7 @@ class AutoMockEndpoint(MockEndpoint):
     Randomly generate LAN + WAN addresses that are globally unique and register them in the "internet" dictionary.
     """
 
-    ADDRESS_TYPE = "UDPv4Address"
+    IPV6_ADDRESSES = bool(int(os.environ.get("TEST_IPV8_WITH_IPV6", 0)))
 
     def __init__(self) -> None:
         """
@@ -153,7 +154,7 @@ class AutoMockEndpoint(MockEndpoint):
         self._port = 0
 
     def _generate_address(self) -> UDPv4Address | UDPv6Address:
-        if self.ADDRESS_TYPE == "UDPv4Address":
+        if not self.IPV6_ADDRESSES:
             b0 = random.randint(0, 255)
             b1 = random.randint(0, 255)
             b2 = random.randint(0, 255)
@@ -162,20 +163,17 @@ class AutoMockEndpoint(MockEndpoint):
 
             return UDPv4Address('%d.%d.%d.%d' % (b0, b1, b2, b3), port)
 
-        if self.ADDRESS_TYPE == "UDPv6Address":
-            b0 = random.randint(0, 65535)
-            b1 = random.randint(0, 65535)
-            b2 = random.randint(0, 65535)
-            b3 = random.randint(0, 65535)
-            b4 = random.randint(0, 65535)
-            b5 = random.randint(0, 65535)
-            b6 = random.randint(0, 65535)
-            b7 = random.randint(0, 65535)
-            port = random.randint(0, 65535)
+        b0 = random.randint(0, 65535)
+        b1 = random.randint(0, 65535)
+        b2 = random.randint(0, 65535)
+        b3 = random.randint(0, 65535)
+        b4 = random.randint(0, 65535)
+        b5 = random.randint(0, 65535)
+        b6 = random.randint(0, 65535)
+        b7 = random.randint(0, 65535)
+        port = random.randint(0, 65535)
 
-            return UDPv6Address(f"{b0:02x}:{b1:02x}:{b2:02x}:{b3:02x}:{b4:02x}:{b5:02x}:{b6:02x}:{b7:02x}", port)
-
-        raise RuntimeError("Illegal address type specified: " + repr(self.ADDRESS_TYPE))
+        return UDPv6Address(f"{b0:02x}:{b1:02x}:{b2:02x}:{b3:02x}:{b4:02x}:{b5:02x}:{b6:02x}:{b7:02x}", port)
 
     def _is_lan(self, address: Address) -> bool:
         """

--- a/ipv8/test/peerdiscovery/test_community.py
+++ b/ipv8/test/peerdiscovery/test_community.py
@@ -1,4 +1,5 @@
 import os
+import unittest
 from functools import reduce
 from typing import cast
 
@@ -10,6 +11,7 @@ from ..mocking.community import MockCommunity
 from ..mocking.endpoint import AutoMockEndpoint
 
 
+@unittest.skipIf(AutoMockEndpoint.IPV6_ADDRESSES, "IPv6 not supported")
 class TestDiscoveryCommunity(TestBase):
     """
     Tests related to the DiscoveryCommunity.

--- a/ipv8/test/test_community.py
+++ b/ipv8/test/test_community.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import unittest
 from typing import TYPE_CHECKING
 
 from ..bootstrapping.dispersy.bootstrapper import DispersyBootstrapper
@@ -102,6 +103,7 @@ class TestCommunityCompatibility(TestBase):
         self.overlay(from_i).walk_to(self.address(to_i))
         await self.deliver_messages()
 
+    @unittest.skipIf(AutoMockEndpoint.IPV6_ADDRESSES, "IPv6 not supported")
     async def test_introduce_old(self) -> None:
         """
         Check that no new-style messages are going to the old-style peer.


### PR DESCRIPTION
This PR adds IPv6 support to the `TunnelCommunity` and finally closes https://github.com/Tribler/py-ipv8/issues/615. This change will break compatibility with old versions.

Note that when running the unittests in IPv6 mode, we're skipping the tests for `DiscoveryCommunity`/`DispersyBootstrapper` and the old-style introduction requests, since they can't support IPv6.

Also note that I've changed `Address.pack` to work on all types of addresses (namedtuple or not). The reason behind this is that a lot of addresses are still just regular tuples (e.g., `my_estimated_lan`).