### PR TITLE
Added Python 3.12 support

### DIFF
--- a/.github/workflows/pr-comment-validate.yml
+++ b/.github/workflows/pr-comment-validate.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]  # macos-latest not tested due to crashing.
-        version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/create_test_coverage_report.py
+++ b/create_test_coverage_report.py
@@ -3,7 +3,6 @@ import os
 import pathlib
 import shutil
 import sys
-from distutils.version import LooseVersion
 from io import StringIO
 from unittest import TextTestRunner, defaultTestLoader
 from unittest.suite import TestSuite
@@ -12,6 +11,7 @@ import coverage
 from coverage.files import abs_file, relative_filename
 from coverage.python import PythonFileReporter
 from coverage.results import Analysis
+from packaging.version import Version
 
 from run_all_tests import find_all_test_class_names
 
@@ -75,9 +75,9 @@ print("Aggregating package stats")  # noqa: T201
 total_numbers = {}  # Package name -> (Numbers: package coverage stats, dict: files per coverage bin)
 for filename in cov.get_data().measured_files():
     file_reporter = PythonFileReporter(filename, cov)
-    if LooseVersion(coverage.__version__) < LooseVersion("5"):
+    if Version(coverage.__version__) < Version("5"):
         analysis = Analysis(cov.get_data(), file_reporter)
-    elif LooseVersion(coverage.__version__) < LooseVersion("6"):
+    elif Version(coverage.__version__) < Version("6"):
         analysis = Analysis(cov.get_data(), file_reporter, abs_file)
     else:
         analysis = Analysis(cov.get_data(), 0, file_reporter, abs_file)

--- a/distutils_forwardport.py
+++ b/distutils_forwardport.py
@@ -1,0 +1,86 @@
+"""
+Forward port to support a small subset of distutils functionality for our upstream dependencies.
+"""
+from __future__ import annotations
+
+try:
+    # Check if we need to fix anything
+    from distutils import version
+except ImportError:
+    import sys
+
+    import packaging.version
+
+
+    class LooseVersion(packaging.version.Version):
+        """
+        Forward port of LooseVersion (mostly equal to Version).
+        """
+
+        @property
+        def version(self) -> tuple[int, ...]:
+            """
+            Get a tuple of the release version ints.
+            """
+            return self.release
+
+        @property
+        def vstring(self) -> str:
+            """
+            Forward port of str(self).
+            """
+            return str(self)
+
+        def __lt__(self, other: str | "_BaseVersion") -> bool:  # type: ignore[name-defined]  # noqa: F821,UP037
+            """
+            Less than: we add support for comparison with str.
+            """
+            if isinstance(other, str):
+                return self < LooseVersion(other)
+            return super().__lt__(other)
+
+        def __le__(self, other: str | "_BaseVersion") -> bool:  # type: ignore[name-defined]  # noqa: F821,UP037
+            """
+            Less than or equal: we add support for comparison with str.
+            """
+            if isinstance(other, str):
+                return self <= LooseVersion(other)
+            return super().__le__(other)
+
+        def __eq__(self, other: object) -> bool:
+            """
+            Equals: we add support for comparison with str.
+            """
+            if isinstance(other, str):
+                return self == LooseVersion(other)
+            return super().__eq__(other)
+
+        def __ge__(self, other: str | "_BaseVersion") -> bool:  # type: ignore[name-defined]  # noqa: F821,UP037
+            """
+            Greater than or equal: we add support for comparison with str.
+            """
+            if isinstance(other, str):
+                return self >= LooseVersion(other)
+            return super().__ge__(other)
+
+        def __gt__(self, other: str | "_BaseVersion") -> bool:  # type: ignore[name-defined]  # noqa: F821,UP037
+            """
+            Greater than: we add support for comparison with str.
+            """
+            if isinstance(other, str):
+                return self > LooseVersion(other)
+            return super().__gt__(other)
+
+        def __ne__(self, other: object) -> bool:
+            """
+            Not equal: we add support for comparison with str.
+            """
+            if isinstance(other, str):
+                return self != LooseVersion(other)
+            return super().__ne__(other)
+
+
+    packaging.version.LooseVersion = LooseVersion  # type: ignore[attr-defined]
+    sys.modules["distutils.version"] = packaging.version
+    sys.modules["distutils"] = sys.modules[LooseVersion.__module__]
+    version = packaging.version  # type: ignore[misc]

--- a/github_increment_version.py
+++ b/github_increment_version.py
@@ -10,10 +10,10 @@ import ast
 import datetime
 import getpass
 import sys
-from distutils.version import LooseVersion
 from typing import cast
 
 from github import Github, InputGitTreeElement
+from packaging.version import Version
 
 
 def parse_setup() -> tuple[str, ast.Expr]:
@@ -129,9 +129,9 @@ def modify_setup(file_contents: str, setup_expression: ast.Expr) -> tuple[str, s
             lineno = keyword.value.lineno
             coloffset = keyword.value.col_offset
             old_version = cast(ast.Name, keyword.value).s
-            version = LooseVersion(old_version)
+            version = Version(old_version)
 
-            new_vstring = version.version
+            new_vstring = str(version)
             old_version_tag = '.'.join(str(s) for s in new_vstring[:2])
             new_vstring[1] += 1
             new_version = '.'.join(str(s) for s in new_vstring)

--- a/ipv8/REST/base_endpoint.py
+++ b/ipv8/REST/base_endpoint.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import Any, Awaitable, Callable, Generic, Iterable, TypeVar, Union
+from typing import Any, Awaitable, Callable, Generic, Iterable, TypeVar
 
 from aiohttp import web
-from aiohttp.abc import Application, Request, StreamResponse
+from aiohttp.abc import Request, StreamResponse
 from aiohttp.typedefs import Handler, LooseHeaders
 
 HTTP_BAD_REQUEST = 400
@@ -18,8 +18,7 @@ HTTP_INTERNAL_SERVER_ERROR = 500
 DEFAULT_HEADERS: dict[str, str] = {}
 
 T = TypeVar('T')
-MiddleWaresType = Iterable[Union[Callable[[Request, Handler], Awaitable[StreamResponse]],
-                                 Callable[[Application, Handler], Awaitable[Handler]]]]
+MiddleWaresType = Iterable[Callable[[Request, Handler], Awaitable[StreamResponse]]]
 
 
 class BaseEndpoint(Generic[T]):

--- a/ipv8/messaging/payload_dataclass.py
+++ b/ipv8/messaging/payload_dataclass.py
@@ -12,7 +12,7 @@ def type_from_format(fmt: str) -> TypeVar:
     """
     Convert a Serializer format directive to a type usable with @dataclass.
     """
-    out = object.__new__(TypeVar)
+    out = TypeVar.__new__(TypeVar, fmt)  # type: ignore[call-arg]
     TypeVar.__init__(out, fmt)
     return out
 

--- a/ipv8/test/REST/rest_base.py
+++ b/ipv8/test/REST/rest_base.py
@@ -138,6 +138,16 @@ class MockedSite(web.TCPSite):
         self._server = self._runner.server
         await web.BaseSite.start(self)
 
+    async def stop(self) -> None:
+        """
+        The `wait_for` implementation of our super does not work.
+
+        Instead, we perform our own light-weight shutdown.
+        """
+        self._runner._check_site(self)  # noqa: SLF001
+        await self._runner.shutdown()
+        self._runner._unreg_site(self)  # noqa: SLF001
+
 
 class MockedRESTManager(RESTManager):
     """

--- a/ipv8/test/REST/test_attestation_endpoint.py
+++ b/ipv8/test/REST/test_attestation_endpoint.py
@@ -4,6 +4,8 @@ from asyncio import sleep
 from base64 import b64encode
 from typing import Collection, Sequence
 
+import distutils_forwardport  # noqa: F401
+
 from ...attestation.identity.community import IdentityCommunity, IdentitySettings
 from ...attestation.identity.manager import IdentityManager
 from ...attestation.wallet.community import AttestationCommunity, AttestationSettings

--- a/ipv8/test/REST/test_identity_endpoint.py
+++ b/ipv8/test/REST/test_identity_endpoint.py
@@ -5,6 +5,8 @@ import json
 import urllib.parse
 from typing import TYPE_CHECKING, Any, cast
 
+import distutils_forwardport  # noqa: F401
+
 from ...attestation.communication_manager import CommunicationChannel, CommunicationManager, PseudonymFolderManager
 from ...attestation.default_identity_formats import FORMATS
 from ...attestation.identity.community import IdentityCommunity, IdentitySettings

--- a/ipv8/test/REST/test_isolation_endpoint.py
+++ b/ipv8/test/REST/test_isolation_endpoint.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import unittest
 from typing import TYPE_CHECKING, cast
 
+import distutils_forwardport  # noqa: F401
+
 from ...bootstrapping.dispersy.bootstrapper import DispersyBootstrapper
 from ...configuration import DISPERSY_BOOTSTRAPPER
 from ...messaging.anonymization.community import TunnelCommunity

--- a/ipv8/test/REST/test_network_endpoint.py
+++ b/ipv8/test/REST/test_network_endpoint.py
@@ -1,6 +1,8 @@
 import base64
 import random
 
+import distutils_forwardport  # noqa: F401
+
 from ...keyvault.crypto import default_eccrypto
 from ...peer import Peer
 from ..REST.rest_base import RESTTestBase

--- a/ipv8/test/REST/test_overlays_endpoint.py
+++ b/ipv8/test/REST/test_overlays_endpoint.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import binascii
 
+import distutils_forwardport  # noqa: F401
+
 from ...keyvault.crypto import default_eccrypto
 from ...messaging.interfaces.statistics_endpoint import StatisticsEndpoint
 from ...peer import Peer

--- a/ipv8_service.py
+++ b/ipv8_service.py
@@ -11,6 +11,8 @@ from threading import RLock
 from traceback import format_exception
 from typing import Any, Awaitable, Generator
 
+import distutils_forwardport  # noqa: F401
+
 if hasattr(sys.modules['__main__'], "IPv8"):
     sys.modules[__name__] = sys.modules['__main__']
 else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,11 @@
 cryptography
 libnacl
-aiohttp
+aiohttp==3.8.6; python_version<'3.11'
+aiohttp>=3.9.0b0; python_version>='3.11'
 aiohttp_apispec
 pyOpenSSL
 pyasn1
 asynctest; python_version=='3.7'
 marshmallow
 typing-extensions
+packaging

--- a/run_all_tests.py
+++ b/run_all_tests.py
@@ -17,6 +17,8 @@ from concurrent.futures import ProcessPoolExecutor
 from typing import TYPE_CHECKING, Generator, TextIO, cast
 from unittest import TestCase
 
+import distutils_forwardport  # noqa: F401
+
 if TYPE_CHECKING:
     import types
 
@@ -267,8 +269,8 @@ def install_libsodium() -> None:
         web_response = connection.getresponse().read().decode()
 
         # Extract the latest version
-        result = sorted(re.findall("libsodium-[0-9]*\.[0-9]*\.[0-9]*-stable-msvc.zip\"",  # noqa: W605
-                                   web_response))[-1][:-1]
+        result = sorted(re.findall(r"libsodium-[0-9]*\.[0-9]*\.[0-9]*-stable-msvc.zip\"",
+                                    web_response))[-1][:-1]
 
         connection.request("GET", f"/libsodium/releases/{result}", headers={})
         pathlib.Path("libsodium.zip").write_bytes(connection.getresponse().read())

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Topic :: Scientific/Engineering",
         "Topic :: Software Development :: Libraries :: Python Modules",
         "Topic :: System :: Distributed Computing",


### PR DESCRIPTION
Fixes #1231

This PR:

 - Adds Python 3.12 support (small fixes described in #1231).

Notes:
 - According to `aiohttp` logging, `3.9.0b0` works with Python 3.8 or higher. In my testing, this turned out to be Python 3.11 or higher.
 - The `import distutils_forwardport` workaround is required in all files that can serve as a main entrypoint for tests that (indirectly) use `apispec`. Once `apispec` is updated, and no longer uses `distutils`, it should be safe to remove this.
 - This PR was tested locally on Python 3.12 for Windows.