### PR TITLE
Updated aiohttp version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 cryptography
 libnacl
-aiohttp==3.8.6; python_version<'3.11'
-aiohttp>=3.9.0b0; python_version>='3.11'
+aiohttp==3.8.6; python_version=='3.7'
+aiohttp>=3.9.1; python_version>'3.7'
 aiohttp_apispec>=3.0.0b1
 pyOpenSSL
 pyasn1


### PR DESCRIPTION
Fixes #1249

This PR:

 - Updates the minimum version of `aiohttp` to be `>=3.9.1` for all non-end-of-life Python versions (Python versions >3.7).


