### PR TITLE
Fixed mock IPv6 address generation

### DIFF
--- a/.github/workflows/pr-comment-validate.yml
+++ b/.github/workflows/pr-comment-validate.yml
@@ -22,3 +22,8 @@ jobs:
           python-version: ${{ matrix.version }}
       - run: python -m pip install -r requirements.txt
       - run: python run_all_tests.py -a
+        env:
+          TEST_IPV8_WITH_IPV6: 0
+      - run: python run_all_tests.py -a
+        env:
+          TEST_IPV8_WITH_IPV6: 1

--- a/ipv8/test/mocking/endpoint.py
+++ b/ipv8/test/mocking/endpoint.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import ipaddress
 import os
 import random
 from asyncio import get_running_loop
@@ -173,7 +174,10 @@ class AutoMockEndpoint(MockEndpoint):
         b7 = random.randint(0, 65535)
         port = random.randint(0, 65535)
 
-        return UDPv6Address(f"{b0:02x}:{b1:02x}:{b2:02x}:{b3:02x}:{b4:02x}:{b5:02x}:{b6:02x}:{b7:02x}", port)
+        exploded_ip = f"{b0:02x}:{b1:02x}:{b2:02x}:{b3:02x}:{b4:02x}:{b5:02x}:{b6:02x}:{b7:02x}"
+        # Our tests assume that the valid (exploded) ip is formatted using `ip_address`.
+        # You will get random failures if you fail to normalize (see https://github.com/Tribler/py-ipv8/issues/1243).
+        return UDPv6Address(str(ipaddress.ip_address(exploded_ip)), port)
 
     def _is_lan(self, address: Address) -> bool:
         """


### PR DESCRIPTION
Fixes #1238
Fixes #1243

This PR:

 - Fixes `AutoMockEndpoint._generate_address` generating IPv6 addresses that do not work with our test setup.
 - Updates the validation tests to also run tests with IPv6.
