### PR TITLE
Updated IPv8 exit node script to use RustEndpoint

### DIFF
--- a/ipv8/attestation/wallet/primitives/cryptography_wrapper.py
+++ b/ipv8/attestation/wallet/primitives/cryptography_wrapper.py
@@ -28,7 +28,8 @@ def generate_safe_prime(bit_length: int, backend: Backend = default_backend()) -
     out = int(backend._ffi.string(generated_hex), 16)
     # Cleanup the memory
     backend._lib.OPENSSL_free(generated_hex)
-    backend._lib.BN_clear_free(generated)
+    backend._lib.BN_set_word(generated, 0)
+    backend._lib.BN_free(generated)
     return out
 
 
@@ -59,5 +60,6 @@ def is_prime(number: int, backend: Backend = default_backend()) -> bool:  # noqa
         raise RuntimeError(msg)
     result = backend._lib.BN_is_prime_ex(generated, backend._lib.BN_prime_checks_for_size(int(len(bhex_n) * 8)),
                                          backend._ffi.NULL, backend._ffi.NULL)
-    backend._lib.BN_clear_free(generated)
+    backend._lib.BN_set_word(generated, 0)
+    backend._lib.BN_free(generated)
     return result == 1

--- a/ipv8/configuration.py
+++ b/ipv8/configuration.py
@@ -110,15 +110,13 @@ default: dict[Any, Any] = {
             ],
             'bootstrappers': [DISPERSY_BOOTSTRAPPER.copy()],
             'initialize': {
-                'settings': {
-                    'min_circuits': 1,
-                    'max_circuits': 1,
-                    'max_joined_circuits': 100,
-                    'max_time': 10 * 60,
-                    'max_time_inactive': 20,
-                    'max_traffic': 250 * 1024 * 1024,
-                    'dht_lookup_interval': 30
-                }
+                'min_circuits': 1,
+                'max_circuits': 1,
+                'max_joined_circuits': 100,
+                'max_time': 10 * 60,
+                'max_time_inactive': 20,
+                'max_traffic': 250 * 1024 * 1024,
+                'dht_lookup_interval': 30
             },
             'on_start': [
                 ('build_tunnels', 1)

--- a/ipv8/messaging/anonymization/community.py
+++ b/ipv8/messaging/anonymization/community.py
@@ -103,7 +103,7 @@ class TunnelSettings(CommunitySettings):
     # to flow over the circuit (i.e. bandwidth payouts to intermediate nodes in a circuit).
     remove_tunnel_delay = 5
 
-    _peer_flags: Set[int]
+    _peer_flags: Set[int] = {PEER_FLAG_RELAY, PEER_FLAG_SPEED_TEST}
 
     _max_relay_early = 8
 
@@ -122,7 +122,7 @@ class TunnelSettings(CommunitySettings):
         Set the maximum number of relay_early cells that are allowed to pass a relay.
         """
         self._max_relay_early = value
-        if hasattr(self.endpoint, 'set_max_relay_early'):
+        if hasattr(self, 'endpoint') and hasattr(self.endpoint, 'set_max_relay_early'):
             self.endpoint.set_max_relay_early(value)
 
     @property
@@ -138,7 +138,7 @@ class TunnelSettings(CommunitySettings):
         Set the peer flags.
         """
         self._peer_flags = value
-        if hasattr(self.endpoint, 'set_peer_flags'):
+        if hasattr(self, 'endpoint') and hasattr(self.endpoint, 'set_peer_flags'):
             self.endpoint.set_peer_flags(value)
 
 
@@ -155,7 +155,6 @@ class TunnelCommunity(Community):
         """
         Create a new TunnelCommunity.
         """
-        settings.peer_flags = {PEER_FLAG_RELAY, PEER_FLAG_SPEED_TEST}
         self.settings = settings
         self.dht_provider = settings.dht_provider
 

--- a/ipv8/messaging/anonymization/community.py
+++ b/ipv8/messaging/anonymization/community.py
@@ -790,12 +790,12 @@ class TunnelCommunity(Community):
 
             self.logger.info("Got CREATED message forward as EXTENDED to origin.")
 
-            exit_socket = self.exit_sockets.pop(request.from_circuit_id, None)
-            if exit_socket is None:
+            if request.from_circuit_id not in self.exit_sockets:
                 self.logger.info("Created for unknown exit socket %s", request.from_circuit_id)
                 return
+            session_keys = self.exit_sockets[request.from_circuit_id].hop.keys
+            self.remove_exit_socket(request.from_circuit_id, remove_now=True)
 
-            session_keys = exit_socket.hop.keys
             bw_relay = RelayRoute(request.from_circuit_id, Hop(request.peer, session_keys), BACKWARD)
             fw_relay = RelayRoute(request.to_circuit_id, Hop(request.to_peer, session_keys), FORWARD)
 

--- a/ipv8/messaging/anonymization/crypto.py
+++ b/ipv8/messaging/anonymization/crypto.py
@@ -199,7 +199,6 @@ class PythonCryptoEndpoint(CryptoEndpoint, EndpointListener):
             return
 
         next_relay = self.relays[cell.circuit_id]
-        this_relay = self.relays[next_relay.circuit_id]
 
         if cell.relay_early and next_relay.relay_early_count >= self.max_relay_early:
             self.logger.warning('Dropping cell (too many relay_early cells)')
@@ -208,6 +207,7 @@ class PythonCryptoEndpoint(CryptoEndpoint, EndpointListener):
         try:
             if next_relay.rendezvous_relay:
                 self.decrypt_cell(cell, FORWARD, next_relay.hop)
+                this_relay = self.relays[next_relay.circuit_id]
                 self.encrypt_cell(cell, BACKWARD, this_relay.hop)
                 cell.relay_early = False
             else:

--- a/ipv8/test/messaging/anonymization/test_community.py
+++ b/ipv8/test/messaging/anonymization/test_community.py
@@ -11,6 +11,7 @@ from ....messaging.anonymization.tunnel import (
     CIRCUIT_STATE_EXTENDING,
     PEER_FLAG_EXIT_BT,
     PEER_FLAG_EXIT_IPV8,
+    PEER_FLAG_RELAY,
     PEER_FLAG_SPEED_TEST,
 )
 from ....messaging.interfaces.udp.endpoint import DomainAddress, UDPEndpoint
@@ -74,6 +75,8 @@ class TestTunnelCommunity(TestBase[TunnelCommunity]):
         tunnel_settings.min_circuits = 0
         tunnel_settings.max_circuits = 0
         tunnel_settings.remove_tunnel_delay = 0
+        # For some reason the exit flag set gets remembered across tests, so create a new set here
+        tunnel_settings.peer_flags = {PEER_FLAG_RELAY, PEER_FLAG_SPEED_TEST}
         ipv8 = MockIPv8("curve25519", TunnelCommunity, settings=tunnel_settings)
         # Then kill all automated circuit creation
         ipv8.overlay.cancel_all_pending_tasks()

--- a/ipv8/test/messaging/anonymization/test_hiddenservices.py
+++ b/ipv8/test/messaging/anonymization/test_hiddenservices.py
@@ -12,6 +12,7 @@ from ....messaging.anonymization.tunnel import (
     CIRCUIT_TYPE_DATA,
     CIRCUIT_TYPE_IP_SEEDER,
     PEER_FLAG_EXIT_BT,
+    PEER_FLAG_RELAY,
     PEER_FLAG_SPEED_TEST,
     PEER_SOURCE_DHT,
     IntroductionPoint,
@@ -106,6 +107,8 @@ class TestHiddenServices(TestBase[HiddenTunnelCommunity]):
         tunnel_settings.min_circuits = 0
         tunnel_settings.max_circuits = 0
         tunnel_settings.remove_tunnel_delay = 0
+        # For some reason the exit flag set gets remembered across tests, so create a new set here
+        tunnel_settings.peer_flags = {PEER_FLAG_RELAY, PEER_FLAG_SPEED_TEST}
         ipv8 = MockIPv8("curve25519", HiddenTunnelCommunity, settings=tunnel_settings)
         ipv8.overlay.ipv8 = ipv8
         ipv8.overlay.crypto_endpoint.setup_tunnels(ipv8.overlay, tunnel_settings)

--- a/ipv8/test/test_configuration.py
+++ b/ipv8/test/test_configuration.py
@@ -385,7 +385,7 @@ class TestConfiguration(TestBase):
                                                   [WalkerDefinition(Strategy.RandomWalk, 20, {'timeout': 3.0})],
                                                   [BootstrapperDefinition(Bootstrapper.DispersyBootstrapper,
                                                                           DISPERSY_BOOTSTRAPPER['init'])],
-                                                  {'settings': {
+                                                  {
                                                       'min_circuits': 1,
                                                       'max_circuits': 1,
                                                       'max_joined_circuits': 100,
@@ -393,7 +393,7 @@ class TestConfiguration(TestBase):
                                                       'max_time_inactive': 20,
                                                       'max_traffic': 250 * 1024 * 1024,
                                                       'dht_lookup_interval': 30
-                                                  }},
+                                                  },
                                                   [('build_tunnels', 1)]) \
                                      .add_overlay("DHTDiscoveryCommunity",
                                                   "anonymous id",

--- a/ipv8_service.py
+++ b/ipv8_service.py
@@ -136,8 +136,9 @@ else:
             for overlay in configuration['overlays']:
                 overlay_class = _COMMUNITIES.get(overlay['class'], (extra_communities or {}).get(overlay['class']))
                 my_peer = self.keys[overlay['key']]
-                settings = overlay_class.settings_class(my_peer=my_peer, endpoint=self.endpoint, network=self.network,
-                                                        **overlay['initialize'])
+                settings = overlay_class.settings_class(my_peer=my_peer, endpoint=self.endpoint, network=self.network)
+                for k, v in overlay['initialize'].items():
+                    setattr(settings, k, v)
                 overlay_instance = overlay_class(settings)
                 self.overlays.append(overlay_instance)
                 for walker in overlay['walkers']:

--- a/scripts/exitnode_ipv8_only_plugin.py
+++ b/scripts/exitnode_ipv8_only_plugin.py
@@ -35,6 +35,7 @@ except ImportError:
 
 from ipv8.configuration import get_default_configuration
 from ipv8.messaging.anonymization.tunnel import PEER_FLAG_EXIT_IPV8
+from ipv8.messaging.interfaces.dispatcher.endpoint import INTERFACES
 from ipv8.REST.rest_manager import RESTManager
 from ipv8.util import run_forever
 from ipv8_service import IPv8
@@ -75,6 +76,13 @@ class ExitnodeIPv8Service:
                 overlay['initialize']['settings']['max_circuits'] = 0
                 overlay['initialize']['settings']['max_joined_circuits'] = 1000
                 overlay['initialize']['settings']['peer_flags'] = {PEER_FLAG_EXIT_IPV8}
+
+        try:
+            from ipv8_rust_tunnels.endpoint import RustEndpoint as UDPEndpoint
+        except ImportError:
+            from ipv8.messaging.interfaces.udp.endpoint import UDPEndpoint
+
+        INTERFACES["UDPIPv4"] = UDPEndpoint
 
         print("Starting IPv8")  # noqa: T201
 

--- a/scripts/exitnode_ipv8_only_plugin.py
+++ b/scripts/exitnode_ipv8_only_plugin.py
@@ -72,10 +72,10 @@ class ExitnodeIPv8Service:
 
         for overlay in configuration['overlays']:
             if overlay['class'] == 'HiddenTunnelCommunity':
-                overlay['initialize']['settings']['min_circuits'] = 0
-                overlay['initialize']['settings']['max_circuits'] = 0
-                overlay['initialize']['settings']['max_joined_circuits'] = 1000
-                overlay['initialize']['settings']['peer_flags'] = {PEER_FLAG_EXIT_IPV8}
+                overlay['initialize']['min_circuits'] = 0
+                overlay['initialize']['max_circuits'] = 0
+                overlay['initialize']['max_joined_circuits'] = 1000
+                overlay['initialize']['peer_flags'] = {PEER_FLAG_EXIT_IPV8}
 
         try:
             from ipv8_rust_tunnels.endpoint import RustEndpoint as UDPEndpoint


### PR DESCRIPTION
This PR does the following:
* Enables `RustEndpoint` in the IPv8 exit node script. I haven't enabled it for all IPv8 nodes, as I don't think it makes sense since normal nodes will be making calls from within Python anyway (removing any chance of a performance improvement).
* Add the ability for the `TunnelCommunity` to deal with `DispatcherEndpoints`.
* Fixes a potential `KeyError` in `relays_cell` for rendezvous points.
* Fixes an issue with leftover asyncio tasks after `TunnelExitSocket` removal.

I also fixed some issues with the `CommunitySettings`:
* Fixes an issue with incorrect peer flags during the tunnel tests.
* Fixes an issue with properties in `CommunitySettings`.
* Fixes an issue with the  default tunnel settings getting stored in `overlay.settings.settings` instead of in `overlay.settings`.


