### PR TITLE
Fixed possibly unclosed sockets for LAN discovery

### DIFF
--- a/ipv8/messaging/interfaces/lan_addresses/any_os/testnet1.py
+++ b/ipv8/messaging/interfaces/lan_addresses/any_os/testnet1.py
@@ -14,22 +14,40 @@ class TestNet1(AddressProvider):
         """
         interface_specifications = []
 
+        s = None
         try:
             s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
             s.connect(("192.0.2.0", 80))
             local_ip = s.getsockname()[0]
             s.close()
+            s = None
             interface_specifications.append(local_ip)
         except OSError:
             self.on_exception()
+        finally:
+            if s is not None:
+                try:
+                    s.close()
+                    s = None
+                except OSError:
+                    self.on_exception()
 
+        s = None
         try:
             s = socket.socket(socket.AF_INET6, socket.SOCK_DGRAM)
             s.connect(("::ffff:0:192.0.2.0", 80))
             local_ip = s.getsockname()[0]
             s.close()
+            s = None
             interface_specifications.append(local_ip)
         except OSError:
             self.on_exception()
+        finally:
+            if s is not None:
+                try:
+                    s.close()
+                    s = None
+                except OSError:
+                    self.on_exception()
 
         return set(interface_specifications)

--- a/ipv8/messaging/interfaces/lan_addresses/unix/ioctl.py
+++ b/ipv8/messaging/interfaces/lan_addresses/unix/ioctl.py
@@ -7,7 +7,6 @@ if typing.TYPE_CHECKING:
         """
         Stub for the ioctl call's types.
         """
-        ...
 else:
     from fcntl import ioctl
 
@@ -31,6 +30,7 @@ class Ioctl(AddressProvider):
         """
         out_addresses = []
 
+        s = None
         try:
             s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
             for ifspec in socket.if_nameindex():
@@ -39,7 +39,16 @@ class Ioctl(AddressProvider):
                 family, = struct.unpack(FMT_FAMILY, ifreq[16:18])
                 if family == socket.AF_INET:
                     out_addresses.append(socket.inet_ntop(socket.AF_INET, ifreq[20:24]))
+            s.close()
+            s = None
         except OSError:
             self.on_exception()
+        finally:
+            if s is not None:
+                try:
+                    s.close()
+                    s = None
+                except OSError:
+                    self.on_exception()
 
         return set(out_addresses)


### PR DESCRIPTION
This PR:

 - Fixes resource warnings when sockets are left to garbage collection if an `OSError` occurs before closing.

This fix is slightly ugly because the `close()` of an unclosed socket can again error out, leading to a nested `try .. except`.