### PR TITLE
Automated Version Update

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -21,13 +21,13 @@
 # -- Project information -----------------------------------------------------
 
 project = 'IPv8'
-copyright = '2017-2023, Tribler'  # Do not change manually! Handled by github_increment_version.py
+copyright = '2017-2024, Tribler'  # Do not change manually! Handled by github_increment_version.py
 author = 'Tribler'
 
 # The short X.Y version
-version = '2.12'  # Do not change manually! Handled by github_increment_version.py
+version = '2.13'  # Do not change manually! Handled by github_increment_version.py
 # The full version, including alpha/beta/rc tags
-release = '2.12.0'  # Do not change manually! Handled by github_increment_version.py
+release = '2.13.0'  # Do not change manually! Handled by github_increment_version.py
 
 
 # -- General configuration ---------------------------------------------------

--- a/github_increment_version.py
+++ b/github_increment_version.py
@@ -131,7 +131,7 @@ def modify_setup(file_contents: str, setup_expression: ast.Expr) -> tuple[str, s
             old_version = cast(ast.Name, keyword.value).s
             version = Version(old_version)
 
-            new_vstring = str(version)
+            new_vstring = [version.major, version.minor, version.micro]
             old_version_tag = '.'.join(str(s) for s in new_vstring[:2])
             new_vstring[1] += 1
             new_version = '.'.join(str(s) for s in new_vstring)
@@ -327,16 +327,16 @@ def commit_messages_to_names(commit_msg_list: list[str]) -> list[str]:
     return sorted(out)
 
 
-pr = ipv8_repo.create_pull("Automated Version Update",
-                           "Suggested release message\n---\n"
+pr = ipv8_repo.create_pull(title="Automated Version Update",
+                           body="Suggested release message\n---\n"
                            f"Tag version: {new_version_tag}\n"
                            f"Release title: IPv8 v{new_version_tag}.{total_commits} release\nBody:\n"
                            f"Includes the first {total_commits} commits (+{commits_since_last} since v{old_version_tag}) for IPv8, containing:\n\n - "
                            + ("\n - ".join(commit_messages_to_names([c.commit.message.split('\n')[2]
                                                                      for c in comparison.commits
                                                                      if c.commit.message.startswith('Merge')]))),
-                           'master',
-                           '{}:{}'.format(username, 'automated_version_update'), True)
+                           base='master',
+                           head='{}:{}'.format(username, 'automated_version_update'), draft=True)
 
 pr_labels = next(label for label in ipv8_repo.get_labels() if label.name == "automatedpr")
 pr.add_to_labels(pr_labels)

--- a/ipv8/REST/rest_manager.py
+++ b/ipv8/REST/rest_manager.py
@@ -115,7 +115,7 @@ class RESTManager:
         aiohttp_apispec = AiohttpApiSpec(
             app=self.root_endpoint.app,
             title="IPv8 REST API documentation",
-            version="v2.12",  # Do not change manually! Handled by github_increment_version.py
+            version="v2.13",  # Do not change manually! Handled by github_increment_version.py
             url="/docs/swagger.json",
             swagger_path="/docs",
         )

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     description='The Python implementation of the IPV8 library',
     long_description=long_description,
     long_description_content_type='text/markdown',
-    version='2.12.0',  # Do not change manually! Handled by github_increment_version.py
+    version='2.13.0',  # Do not change manually! Handled by github_increment_version.py
     url='https://github.com/Tribler/py-ipv8',
     package_data={'': ['*.*']},
     packages=find_packages(),


### PR DESCRIPTION
Suggested release message
---
Tag version: 2.13
Release title: IPv8 v2.13.2111 release
Body:
Includes the first 2111 commits (+108 since v2.12) for IPv8, containing:

 - Added IPv6 support to TunnelCommunity
 - Added Python 3.12 support
 - Added automatic `libsodium.dll` downloader for Windows unit tests
 - Added cryptography-based fallback when NaCL import fails
 - Added direction argument to encrypt_str/decrypto_str
 - Added dummy workflow file for extended validation tests
 - Added support for Futures to the TaskManager
 - Added validation action status checks
 - Added pip dependencies cache in validate runs
 - Fixed DHT storage not getting cleaned up
 - Fixed cache leaks in Network
 - Fixed empty sha on validate action status setting
 - Fixed issue with serializing nested payloads that use raw
 - Fixed missing dependency: typing-extensions
 - Fixed mock IPv6 address generation
 - Fixed peer addresses not being updated
 - Fixed possibly unclosed sockets for LAN discovery
 - Fixed spelling and grammar instance in index.rst
 - Fixed the GitHub validate action
 - Fixed tracker service super args
 - Fixed tunnel endpoints
 - Fixed typing issues
 - Fixed validate job not installing dependencies
 - Fixed validation action errors
 - Fixed wrong hypen location in GitHub validate PR action
 - Removed `distutils_forwardport.py`
 - Removed overwrite dataclass construction
 - Removed separate prefix argument from setup_tunnels
 - Updated Endpoint.close to be optionally async
 - Updated IPv8 exit node script to use RustEndpoint
 - Updated TunnelCommunity cell logic
 - Updated aiohttp version
 - Updated best practices code to fit CommunitySettings
 - Updated hidden services to stop removing data circuits
 - Updated the project age
 - Updated validate action to run the unit tests