### PR TITLE
Added serialization of lists of ints and booleans

### DIFF
--- a/doc/reference/serialization.rst
+++ b/doc/reference/serialization.rst
@@ -114,7 +114,10 @@ A ``Serializer`` can be extended with additional data types by calling ``seriali
    "varlenI", "4 + ?", "str (length < 4294967295)"
    "doublevarlenH", "2 + ?", "str (length ? < 65356)"
    "payload", "2 + ?", "Serializable"
-
+   "payload-list", "?", "[Serializable]"
+   "arrayH-?", "2 + ? * 1", "[bool]"
+   "arrayH-q", "2 + ? * 8", "[int]"
+   "arrayH-d", "2 + ? * 8", "[float]"
 
 Some of these data types represent common usage of serializable classes:
 

--- a/ipv8/test/messaging/test_payload_dataclass.py
+++ b/ipv8/test/messaging/test_payload_dataclass.py
@@ -75,6 +75,21 @@ class NestedListType:
 
     a: List[NativeInt]  # Backward compatibility: Python >= 3.9 can use ``list[NativeInt]``
 
+@dataclass
+class ListIntType:
+    """
+    A single list of integers.
+    """
+
+    a: List[int]
+
+@dataclass
+class ListBoolType:
+    """
+    A single list of booleans.
+    """
+
+    a: List[bool]
 
 @ogdataclass
 class Unknown:
@@ -161,6 +176,8 @@ class Everything:
     d: EverythingItem
     e: List[EverythingItem]  # Backward compatibility: Python >= 3.9 can use ``list[EverythingItem]``
     f: str
+    g: List[int]
+    h: List[bool]
 
 
 class TestDataclassPayload(TestBase):
@@ -348,6 +365,26 @@ class TestDataclassPayload(TestBase):
         self.assertEqual(payload.a, NativeInt(42))
         self.assertEqual(deserialized.a, NativeInt(42))
 
+    def test_native_intlist_payload(self) -> None:
+        """
+        Check if a list of native types works correctly.
+        """
+        payload = ListIntType([1, 2])
+        deserialized = self._pack_and_unpack(ListIntType, payload)
+
+        self.assertListEqual(payload.a, [1, 2])
+        self.assertListEqual(deserialized.a, [1, 2])
+
+    def test_native_boollist_payload(self) -> None:
+        """
+        Check if a list of native types works correctly.
+        """
+        payload = ListBoolType([True, False])
+        deserialized = self._pack_and_unpack(ListBoolType, payload)
+
+        self.assertListEqual(payload.a, [True, False])
+        self.assertListEqual(deserialized.a, [True, False])
+
     def test_nestedlist_empty_payload(self) -> None:
         """
         Check if an empty list of nested payloads works correctly.
@@ -416,7 +453,9 @@ class TestDataclassPayload(TestBase):
                        b'1337',
                        EverythingItem(True),
                        [EverythingItem(False), EverythingItem(True)],
-                       "hi")
+                       "hi",
+                       [3, 4],
+                       [False, True])
 
         self.assertTrue(is_dataclass(a))
 
@@ -439,3 +478,9 @@ class TestDataclassPayload(TestBase):
 
         self.assertEqual(a.f, "hi")
         self.assertEqual(r.f, "hi")
+
+        self.assertEqual(a.g, [3, 4])
+        self.assertEqual(r.g, [3, 4])
+
+        self.assertEqual(a.h, [False, True])
+        self.assertEqual(r.h, [False, True])


### PR DESCRIPTION
Hi all,

In my own code, support for serialization of native `ints` and `bool` came in handy. This might also be beneficial to this project.

This PR:

 - Adds serialization of dataclasses with attributes that are lists of native `ints` and `bools`.
 - Updated the unit tests to test dataclasses with `List[int]` and `List[bool]`
 


