### PR TITLE
Fix run_all_tests for Mac

### DIFF
--- a/.github/workflows/pr-comment-validate.yml
+++ b/.github/workflows/pr-comment-validate.yml
@@ -72,7 +72,7 @@ jobs:
 
   set_failure_status:
     if: ${{failure() && github.event.issue.pull_request && startsWith(github.event.comment.body, 'validate') }}
-    needs: [set_pending_status, pr_commented]
+    needs: [set_pending_status, pr_commented, validate_attestation_tutorial, validate_identity_tutorial, validate_documentation]
     runs-on: ubuntu-latest
     steps:
       - name: Set commit failed status
@@ -89,7 +89,7 @@ jobs:
 
   set_success_status:
     if: ${{!failure() && github.event.issue.pull_request && startsWith(github.event.comment.body, 'validate') }}
-    needs: [set_pending_status, pr_commented]
+    needs: [set_pending_status, pr_commented, validate_attestation_tutorial, validate_identity_tutorial, validate_documentation]
     runs-on: ubuntu-latest
     steps:
       - name: Set commit success status

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -40,10 +40,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.8'
+          python-version: '3.12'
           cache: 'pip'
       - run: python -m pip install -r requirements.txt
       - name: Run unit tests
-        run: |
-          pip install pytest pytest-xdist
-          pytest -n auto ipv8
+        run: python run_all_tests.py -a

--- a/run_all_tests.py
+++ b/run_all_tests.py
@@ -295,7 +295,7 @@ def windows_missing_libsodium() -> bool:
     # Try to find it in the local directory. This is where we'll download it anyway.
     os.add_dll_directory(os.path.dirname(__file__) or os.path.abspath('.'))
     try:
-        import libnacl  # noqa: F401, F811
+        import libnacl  # noqa: F401
         return False
     except OSError:
         return True
@@ -331,7 +331,8 @@ if __name__ == "__main__":
     print(f"Launching in {process_count} processes ... awaiting results ... \033[s", end="", flush=True)  # noqa: T201
 
     with ProgrammerDistractor(not args.noanimation) as programmer_distractor:
-        with ProcessPoolExecutor(max_workers=process_count) as executor:
+        with ProcessPoolExecutor(max_workers=process_count,
+                                 mp_context=multiprocessing.get_context("spawn")) as executor:
             result = executor.map(task_test, test_class_names, chunksize=len(test_class_names) // process_count + 1)
             for process_output_handle in result:
                 failed, tests_run, time_taken, event_log, print_output = process_output_handle


### PR DESCRIPTION
This PR:

 - Updates the `unittests` workflow to use Python 3.12 for Mac.
 - Updates `run_all_tests` to explicitly pass a "spawn" context.
 - Updates the validation success states to link to `validate_attestation_tutorial, validate_identity_tutorial, validate_documentation`.

The `macos` check will fail on this PR. See https://github.com/qstokkink/py-ipv8/pull/2 for the shadow PR with the same commit.
