### PR TITLE
Fixed bootstrap with infinite max_peers

### DIFF
--- a/ipv8/community.py
+++ b/ipv8/community.py
@@ -221,7 +221,7 @@ class Community(EZPackOverlay):
         task = ensure_future(bootstrapper.initialize(self))
 
         addresses = await bootstrapper.get_addresses(self, 60.0)
-        for address in islice(addresses, self.max_peers):
+        for address in (addresses if self.max_peers > 0 else islice(addresses, self.max_peers)):
             self.walk_to(address)
 
         await task

--- a/ipv8/test/base.py
+++ b/ipv8/test/base.py
@@ -14,6 +14,7 @@ from functools import partial
 from typing import TYPE_CHECKING, Awaitable, Callable, Coroutine, Generic, Type, TypeVar, cast
 
 from ..lazy_community import PacketDecodingError, lazy_wrapper, lazy_wrapper_unsigned
+from ..messaging.interfaces.lan_addresses.interfaces import get_providers
 from ..messaging.serialization import PackError
 from ..overlay import Overlay
 from ..peer import Peer
@@ -255,6 +256,7 @@ class TestBase(TestCaseClass, Generic[OT]):
         """
         self.loop.set_debug(True)
         self.loop.set_exception_handler(self._cb_exception)
+        get_providers().clear()
         super().setUp()
         TestBase.__lockup_timestamp__ = time.time()
 


### PR DESCRIPTION
Fixes #1277
Fixes #1289

This PR:

 - Fixes `Community._bootstrap()` to allow infinite (-1) `max_peers`.
 - Fixes tests locking up on some machines due to LAN address resolution.

