### PR TITLE
Fixed relaying to exits

### DIFF
--- a/ipv8/messaging/anonymization/hidden_services.py
+++ b/ipv8/messaging/anonymization/hidden_services.py
@@ -471,12 +471,12 @@ class HiddenTunnelCommunity(TunnelCommunity):
         key = self.swarms[payload.info_hash].seeder_sk
         shared_secret, y, auth = self.crypto.generate_diffie_shared_secret(payload.key, key)
         rp.circuit.hs_session_keys = self.crypto.generate_session_keys(shared_secret)
-        self.circuits.get(rp.circuit.circuit_id)  # Needed for notifying the RustEndpoint
 
         rp_info = RendezvousInfo(rp.address, rp.circuit.hops[-1].public_key.key_to_bin(), rp.cookie)
         rp_info_bin = self.serializer.pack('payload', rp_info)
         rp_info_enc = self.crypto.encrypt_str(rp_info_bin, rp.circuit.hs_session_keys, FORWARD)
 
+        self.circuits.get(rp.circuit.circuit_id)  # Needed for notifying the RustEndpoint
         circuit = self.circuits[cast(int, circuit_id)]
         self.tunnel_data(circuit, source_address, CreatedE2EPayload(payload.identifier, y, auth, rp_info_enc))
 

--- a/run_all_tests.py
+++ b/run_all_tests.py
@@ -259,21 +259,13 @@ def install_libsodium() -> None:
     """
     # Ensure a libsodium.zip
     if not pathlib.Path("libsodium.zip").exists():
-        import re
-        from http.client import HTTPSConnection
-        connection = HTTPSConnection("download.libsodium.org")
-
-        connection.request("GET", "/libsodium/releases/", headers={})
-        web_response = connection.getresponse().read().decode()
-
-        # Extract the latest version
-        result = sorted(re.findall(r"libsodium-[0-9]*\.[0-9]*\.[0-9]*-stable-msvc.zip\"",
-                                    web_response))[-1][:-1]
-
-        connection.request("GET", f"/libsodium/releases/{result}", headers={})
-        pathlib.Path("libsodium.zip").write_bytes(connection.getresponse().read())
-
-        connection.close()
+        import json
+        import urllib.request as request
+        response = request.urlopen("https://api.github.com/repos/jedisct1/libsodium/releases")
+        release = json.loads(response.read())[0]
+        response.close()
+        asset = [asset for asset in release['assets'] if asset['name'].endswith("-msvc.zip")][0]
+        pathlib.Path("libsodium.zip").write_bytes(request.urlopen(asset['browser_download_url']).read())
 
     # Unpack just the libsodium.dll
     if not pathlib.Path("libsodium.dll").exists():


### PR DESCRIPTION
Currently, peers in the `TunnelCommunity` will suggest extending to peers that just have `PEER_FLAG_RELAY` set, and not `PEER_FLAG_EXIT_BT`. This is meant to remove some of the strain on the exit nodes.

However, the circuit creator will currently only try to extend to the suggested peers. This means that circuit creation can needlessly fail. For instance, it's currently not possible to create a 2-hop circuit in a network that consists only of exit nodes, even if the exit nodes all have `PEER_FLAG_RELAY` set.

This PR addresses this issue by letting the circuit creator extend to non-suggested exit nodes as well.