### PR TITLE
Cache libsodium.dll from the main branch

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches:
       - master
+  schedule:
+    - cron: "10 6 * * 1,3,5" # Mon, Wed, Fri @ 6:10 UTC
   workflow_dispatch:
 jobs:
   linux:
@@ -35,7 +37,6 @@ jobs:
         with:
           html_report_name: coverage-windows
       - uses: actions/cache/save@v4
-        if: steps.restore_cache.outputs.cache-hit != 'true'
         with:
           path: libsodium.dll
           key: cache_libsodium_dll

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -28,11 +28,6 @@ jobs:
       - run: python -m pip install -r requirements.txt
       - name: Run unit tests
         run: python run_all_tests.py -a
-      - uses: actions/cache/save@v4
-        if: steps.restore_cache.outputs.cache-hit != 'true'
-        with:
-          path: libsodium.dll
-          key: cache_libsodium_dll
   macos:
     runs-on: macos-latest
     timeout-minutes: 2

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -39,4 +39,6 @@ jobs:
           cache: 'pip'
       - run: python -m pip install -r requirements.txt
       - name: Run unit tests
-        run: python run_all_tests.py -a
+        run: |
+          cp /System/Volumes/Data/opt/homebrew/lib/libsodium.dylib libsodium.dylib
+          python run_all_tests.py -a


### PR DESCRIPTION
Fixes #1294

This PR:

 - Fixes the Mac unit tests not finding `libsodium.dylib`.
 - Updates the coverage job to be periodic (with the intent of refreshing a cache).
 - Removes cache storage from the unittest job (this was doing very little).
