### PR TITLE
Updated default dll import path to be '.'

### DIFF
--- a/doc/basics/identity_tutorial_integration/main.py
+++ b/doc/basics/identity_tutorial_integration/main.py
@@ -1,5 +1,6 @@
 from asyncio import run
 from base64 import b64encode
+from time import sleep
 
 from ipv8.configuration import get_default_configuration
 from ipv8.REST.rest_manager import RESTManager
@@ -21,7 +22,15 @@ async def start_community() -> None:
         ipv8 = IPv8(configuration)
         await ipv8.start()
         rest_manager = RESTManager(ipv8)
-        await rest_manager.start(14410 + peer_id)
+
+        # We REALLY want this particular port, keep trying
+        keep_trying = True
+        while keep_trying:
+            try:
+                await rest_manager.start(14410 + peer_id)
+                keep_trying = False
+            except OSError:
+                sleep(1.0)  # noqa: ASYNC101
 
         # Print the peer for reference
         print("Starting peer", b64encode(ipv8.keys["anonymous id"].mid))

--- a/doc/deprecated/attestation_tutorial_integration/main.py
+++ b/doc/deprecated/attestation_tutorial_integration/main.py
@@ -2,6 +2,7 @@ from asyncio import run
 from base64 import b64encode
 from binascii import unhexlify
 from sys import argv
+from time import sleep
 
 from ipv8.attestation.identity.community import IdentityCommunity
 from ipv8.attestation.wallet.community import AttestationCommunity
@@ -109,7 +110,15 @@ async def start_communities() -> None:
         })
         await ipv8.start()
         rest_manager = RESTManager(ipv8)
-        await rest_manager.start(14410 + i)
+
+        # We REALLY want this particular port, keep trying
+        keep_trying = True
+        while keep_trying:
+            try:
+                await rest_manager.start(14410 + i)
+                keep_trying = False
+            except OSError:
+                sleep(1.0)  # noqa: ASYNC101
 
         # Print the peer for reference
         print("Starting peer", b64encode(ipv8.keys["anonymous id"].mid))

--- a/run_all_tests.py
+++ b/run_all_tests.py
@@ -260,12 +260,12 @@ def install_libsodium() -> None:
     # Ensure a libsodium.zip
     if not pathlib.Path("libsodium.zip").exists():
         import json
-        import urllib.request as request
+        from urllib import request
         response = request.urlopen("https://api.github.com/repos/jedisct1/libsodium/releases")
         release = json.loads(response.read())[0]
         response.close()
-        asset = [asset for asset in release['assets'] if asset['name'].endswith("-msvc.zip")][0]
-        pathlib.Path("libsodium.zip").write_bytes(request.urlopen(asset['browser_download_url']).read())
+        asset = next(asset for asset in release['assets'] if asset['name'].endswith("-msvc.zip"))
+        pathlib.Path("libsodium.zip").write_bytes(request.urlopen(asset['browser_download_url']).read())  # noqa: S310
 
     # Unpack just the libsodium.dll
     if not pathlib.Path("libsodium.dll").exists():
@@ -285,7 +285,7 @@ def windows_missing_libsodium() -> bool:
         return False
 
     # Try to find it in the local directory. This is where we'll download it anyway.
-    os.add_dll_directory(os.path.dirname(__file__) or os.path.abspath('.'))
+    os.add_dll_directory(os.path.abspath('.'))
     try:
         import libnacl  # noqa: F401
         return False


### PR DESCRIPTION
This PR:

 - Adds a retry to claim the REST ports of the identity validation scripts.
 - Updates the dll import path to be `.` instead of `__file__` for the unit tests.

This allows downstream projects, where `__file__` is not located in `.` to work.
