### PR TITLE
WIP: Fixed coverage job failures

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -48,7 +48,9 @@ jobs:
         with:
           python-version: '3.12'
           cache: 'pip'
-      - run: python -m pip install -r requirements.txt
+      - run: |
+        cp /System/Volumes/Data/opt/homebrew/lib/libsodium.dylib libsodium.dylib 
+        python -m pip install -r requirements.txt
       - uses: ./.github/actions/coverage
         with:
           html_report_name: coverage-macos

--- a/create_test_coverage_report.py
+++ b/create_test_coverage_report.py
@@ -88,8 +88,11 @@ for filename in cov.get_data().measured_files():
         analysis = Analysis(cov.get_data(), file_reporter)
     elif Version(coverage.__version__) < Version("6"):
         analysis = Analysis(cov.get_data(), file_reporter, abs_file)
-    else:
+    elif Version(coverage.__version__) < Version("7.5"):
         analysis = Analysis(cov.get_data(), 0, file_reporter, abs_file)
+    else:
+        from coverage.results import analysis_from_file_reporter
+        analysis = analysis_from_file_reporter(cov.get_data(), 0, file_reporter, abs_file)
 
     # If the package name does not contain more than 2 parts, it's a top-level file.
     package_path = pathlib.Path(relative_filename(filename))


### PR DESCRIPTION
Fixes #1297

This PR:

 - Fixes the Mac coverage checker not finding libsodium.
 - Fixes the `create_test_coverage_report.py` script being incompatible with `coverage>=7.5.0`.

The script was locally verified to work with `coverage==7.5.3`.