### PR TITLE
Fixed indentation in coverage.yml

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -49,8 +49,8 @@ jobs:
           python-version: '3.12'
           cache: 'pip'
       - run: |
-        cp /System/Volumes/Data/opt/homebrew/lib/libsodium.dylib libsodium.dylib 
-        python -m pip install -r requirements.txt
+          cp /System/Volumes/Data/opt/homebrew/lib/libsodium.dylib libsodium.dylib 
+          python -m pip install -r requirements.txt
       - uses: ./.github/actions/coverage
         with:
           html_report_name: coverage-macos


### PR DESCRIPTION
This PR:

 - Fixes wrong indentation in `coverage.yml`, introduced in #1299.

The jobs is currently failing with this error:

```
Annotations
    1 error

Invalid workflow file: 
    .github/workflows/coverage.yml#L52
    You have an error in your yaml syntax on line 52
```
