### PR TITLE
Moved commit status setting to separate secret

### DIFF
--- a/.github/workflows/pr-comment-validate.yml
+++ b/.github/workflows/pr-comment-validate.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Set commit pending status
         uses: guibranco/github-status-action-v2@v1.1.13
         with:
-          authToken: ${{secrets.GITHUB_TOKEN}}
+          authToken: ${{secrets.COMMIT_STATUS_TOKEN}}
           context: 'Cross-env Validation'
           description: 'Pending..'
           state: 'pending'
@@ -80,7 +80,7 @@ jobs:
           actual_pull_head: ${{needs.set_pending_status.outputs.actual_pull_head}}
         uses: guibranco/github-status-action-v2@v1.1.13
         with:
-          authToken: ${{secrets.GITHUB_TOKEN}}
+          authToken: ${{secrets.COMMIT_STATUS_TOKEN}}
           context: 'Cross-env Validation'
           description: 'Failed!'
           state: 'failure'
@@ -97,7 +97,7 @@ jobs:
           actual_pull_head: ${{needs.set_pending_status.outputs.actual_pull_head}}
         uses: guibranco/github-status-action-v2@v1.1.13
         with:
-          authToken: ${{secrets.GITHUB_TOKEN}}
+          authToken: ${{secrets.COMMIT_STATUS_TOKEN}}
           context: 'Cross-env Validation'
           description: 'Success!'
           state: 'success'


### PR DESCRIPTION
This PR:

 - Updates the commit status setting to a separate GitHub secret.

