### PR TITLE
Fix missing file key in ConfigBuilder

### DIFF
--- a/ipv8/configuration.py
+++ b/ipv8/configuration.py
@@ -396,8 +396,7 @@ class ConfigBuilder:
             'alias': alias,
             'bin': key_bin_b64
         }
-        if file_path is not None:
-            key_config['file'] = file_path
+        key_config['file'] = file_path
         self.config['keys'].append(key_config)
         return self
 


### PR DESCRIPTION
This PR:

 - Fixes missing key `'file'` in `key_config` which would have led to a crash in another part