### PR TITLE
Automated Version Update

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -25,9 +25,9 @@ copyright = '2017-2024, Tribler'  # Do not change manually! Handled by github_in
 author = 'Tribler'
 
 # The short X.Y version
-version = '2.13'  # Do not change manually! Handled by github_increment_version.py
+version = '2.14'  # Do not change manually! Handled by github_increment_version.py
 # The full version, including alpha/beta/rc tags
-release = '2.13.0'  # Do not change manually! Handled by github_increment_version.py
+release = '2.14.0'  # Do not change manually! Handled by github_increment_version.py
 
 
 # -- General configuration ---------------------------------------------------

--- a/ipv8/REST/rest_manager.py
+++ b/ipv8/REST/rest_manager.py
@@ -115,7 +115,7 @@ class RESTManager:
         aiohttp_apispec = AiohttpApiSpec(
             app=self.root_endpoint.app,
             title="IPv8 REST API documentation",
-            version="v2.13",  # Do not change manually! Handled by github_increment_version.py
+            version="v2.14",  # Do not change manually! Handled by github_increment_version.py
             url="/docs/swagger.json",
             swagger_path="/docs",
         )

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     description='The Python implementation of the IPV8 library',
     long_description=long_description,
     long_description_content_type='text/markdown',
-    version='2.13.0',  # Do not change manually! Handled by github_increment_version.py
+    version='2.14.0',  # Do not change manually! Handled by github_increment_version.py
     url='https://github.com/Tribler/py-ipv8',
     package_data={'': ['*.*']},
     packages=find_packages(),


### PR DESCRIPTION
Title: Automated Version Update
Tag version: 2.14
Release title: IPv8 v2.14.2170 release
Body:
Includes the first 2170 commits (+59 since v2.13) for IPv8, containing:

 - Added methods for task retrieval to `TaskManager`
 - Added ruff/mypy/unittest workflows
 - Added serialization of lists of ints and booleans
 - Added validation tests to GitHub Actions
 - Added workflow for generating code coverage reports
 - Cache libsodium.dll from the main branch
 - Fixed GitHub increment version not pushing to correct remote
 - Fixed bootstrap with infinite max_peers
 - Fixed coverage job failures
 - Fixed increment version deleting its current branch
 - Fixed indentation in coverage.yml
 - Fixed missing file key in ConfigBuilder
 - Fixed pending task error in test_unload_while_contacting_node
 - Fixed relaying to exits
 - Fixed run_all_tests for Mac
 - Made github version increment script fully local
 - Moved commit status setting to separate secret
 - Removed IRMA identity format
 - Removed expired DNS entries from bootstrap list
 - Updated README.md workflow badge
 - Updated TunnelCommunity docs
 - Updated default dll import path to be '.'
 - Updated the Mock DHT provider to inherit from its intended superclass