### PR TITLE
Remove Python 3.14 from supported versions

### DIFF
--- a/.github/workflows/pr-comment-validate.yml
+++ b/.github/workflows/pr-comment-validate.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]  # macos-latest not tested due to crashing.
-        version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,6 @@ setup(
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: 3.13",
-        "Programming Language :: Python :: 3.14",
         "Topic :: Scientific/Engineering",
         "Topic :: Software Development :: Libraries :: Python Modules",
         "Topic :: System :: Distributed Computing",


### PR DESCRIPTION
Found in #1323

This PR:

 - Removes Python 3.14 from the validation testing matrix and advertised versions.
 
This PR cannot be validated itself, I'll use #1323 for that.
