### PR TITLE
Shortened PR doc validation

### DIFF
--- a/doc/further-reading/advanced_identity.rst
+++ b/doc/further-reading/advanced_identity.rst
@@ -27,7 +27,7 @@ To enable anonymization of all traffic through the identity layer we need to loa
 This is done by editing the loaded overlays through ``configuration['overlays']``, as follows:
 
 .. literalinclude:: advanced_identity_1.py
-   :lines: 11-17
+   :lines: 10-16
    :dedent: 4
 
 Inclusion of the ``'HiddenTunnelCommunity'`` overlay automatically enables anonymization of identity traffic.
@@ -50,7 +50,7 @@ In the basic identity tutorial we started the REST API as follows:
 To set a REST API key, we will have to pass it to the ``RESTManager`` constructor, as follows (replacing ``"my secret key"`` with your key):
 
 .. literalinclude:: advanced_identity_1.py
-   :lines: 19-23
+   :lines: 18-22
    :dedent: 4
 
 All requests to the core will then have to use either:
@@ -74,7 +74,7 @@ In the basic identity tutorial we started the REST API as follows:
 To use a certificate file, we will have to pass it to the ``RESTManager`` constructor, as follows (replacing ``cert_file`` with the file path of your certificate file for the particular IPv8 instance):
 
 .. literalinclude:: advanced_identity_2.py
-   :lines: 26-32
+   :lines: 25-31
    :dedent: 4
 
 This can (and should) be combined with an API key.

--- a/doc/further-reading/advanced_identity_1.py
+++ b/doc/further-reading/advanced_identity_1.py
@@ -1,9 +1,8 @@
-from asyncio import run
+from asyncio import run, sleep
 from base64 import b64encode
 
 from ipv8.configuration import get_default_configuration
 from ipv8.REST.rest_manager import RESTManager
-from ipv8.util import run_forever
 from ipv8_service import IPv8
 
 
@@ -25,7 +24,7 @@ async def start_community() -> None:
         # Print the peer for reference
         print("Starting peer", b64encode(ipv8.keys["anonymous id"].mid))
 
-    await run_forever()
+    await sleep(1.0)  # We run a 1 second test for this example
 
 
 run(start_community())

--- a/doc/further-reading/advanced_identity_2.py
+++ b/doc/further-reading/advanced_identity_2.py
@@ -1,12 +1,11 @@
 import os
 import ssl
 import sys
-from asyncio import run
+from asyncio import run, sleep
 from base64 import b64encode
 
 from ipv8.configuration import get_default_configuration
 from ipv8.REST.rest_manager import RESTManager
-from ipv8.util import run_forever
 from ipv8_service import IPv8
 
 cert_file = os.path.join(os.path.dirname(sys.modules[IPv8.__module__].__file__),
@@ -33,7 +32,7 @@ async def start_community() -> None:
         # Print the peer for reference
         print("Starting peer", b64encode(ipv8.keys["anonymous id"].mid))
 
-    await run_forever()
+    await sleep(1.0)  # We run a 1 second test for this example
 
 
 run(start_community())

--- a/doc/validate_examples.py
+++ b/doc/validate_examples.py
@@ -87,9 +87,9 @@ for path in os.listdir("."):
                 t_stderr = threading.Thread(target=empty_reader, daemon=True, args=(reader_stderr, output_stderr))
                 t_stderr.start()
 
-                p.join(30.0)
+                p.join(5.0)
                 if p.is_alive():
-                    print(f"Killed {subfile} after 30 seconds!")
+                    print(f"Killed {subfile} after 5 seconds!")
                     p.kill()
 
                 captured_stdout = "".join(output_stdout)


### PR DESCRIPTION
This PR:

 - Updates `advanced_identity_1.py` and `advanced_identity_2.py` to stop after 1 second. This is not visible in the docs.
 - Updates `doc/validate_examples.py` to kill scripts after 5 seconds, instead of 30 seconds.
 
 Based on the previous PR: from `4m 31s` down to `1m 2s`.
