### PR TITLE
Automated Version Update

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -4,7 +4,6 @@ lint.unfixable = []
 
 lint.ignore = [
     "ANN003",
-    "ANN101",
     "ARG001",
     "ARG002",
     "ARG005",

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -25,9 +25,9 @@ copyright = '2017-2024, Tribler'  # Do not change manually! Handled by github_in
 author = 'Tribler'
 
 # The short X.Y version
-version = '2.14'  # Do not change manually! Handled by github_increment_version.py
+version = '3.0'  # Do not change manually! Handled by github_increment_version.py
 # The full version, including alpha/beta/rc tags
-release = '2.14.0'  # Do not change manually! Handled by github_increment_version.py
+release = '3.0.0'  # Do not change manually! Handled by github_increment_version.py
 
 
 # -- General configuration ---------------------------------------------------

--- a/ipv8/REST/rest_manager.py
+++ b/ipv8/REST/rest_manager.py
@@ -115,7 +115,7 @@ class RESTManager:
         aiohttp_apispec = AiohttpApiSpec(
             app=self.root_endpoint.app,
             title="IPv8 REST API documentation",
-            version="v2.14",  # Do not change manually! Handled by github_increment_version.py
+            version="v3.0",  # Do not change manually! Handled by github_increment_version.py
             url="/docs/swagger.json",
             swagger_path="/docs",
         )

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     description='The Python implementation of the IPV8 library',
     long_description=long_description,
     long_description_content_type='text/markdown',
-    version='2.14.0',  # Do not change manually! Handled by github_increment_version.py
+    version='3.0.0',  # Do not change manually! Handled by github_increment_version.py
     url='https://github.com/Tribler/py-ipv8',
     package_data={'': ['*.*']},
     packages=find_packages(),


### PR DESCRIPTION
Tag version: 3.0
Release title: IPv8 v3.0.2197 release
Body:
Includes the first 2197 commits (+27 since v2.14) for IPv8, containing:

 - Added ability to wait for cache arrival in RequestCache
 - Added documentation for the DHT(Discovery)Community
 - Added peer address freeze
 - Added taskmanager register shutdown task
 - Fixed community bootstrap
 - Updated REST tests to use Mocks
 - Updated dataclass payloads to use a base class
 - Updated minimum Python version to 3.9
