### PR TITLE
Removed TunnelEndpoint.loop

### DIFF
--- a/ipv8/REST/tunnel_endpoint.py
+++ b/ipv8/REST/tunnel_endpoint.py
@@ -52,7 +52,6 @@ class TunnelEndpoint(BaseEndpoint[IPv8]):
         """
         super().__init__()
         self.tunnels: TunnelCommunity | None = None
-        self.loop = asyncio.get_running_loop()
 
     def setup_routes(self) -> None:
         """


### PR DESCRIPTION
Fixes https://github.com/Tribler/py-ipv8/issues/1336.

As part of https://github.com/Tribler/py-ipv8/pull/1335 I accidentally committed `TunnelEndpoint.loop`. Getting the event loop is already happening in the Rust module