### PR TITLE
Fixed uncaught getaddrinfo UnicodeError

### DIFF
--- a/ipv8/messaging/interfaces/lan_addresses/any_os/getaddrinfo.py
+++ b/ipv8/messaging/interfaces/lan_addresses/any_os/getaddrinfo.py
@@ -12,22 +12,26 @@ class SocketGetAddrInfo(AddressProvider):
     def get_addresses(self) -> set:
         """
         Attempt to use ``getaddrinfo()`` to retrieve addresses.
+
+        Ref. ``UnicodeError``: https://github.com/python/cpython/issues/77139.
+
+        :returns: The set of probable local interfaces.
         """
         interface_specifications = []
 
         try:
             interface_specifications.extend(socket.getaddrinfo(socket.getfqdn(), 0))
-        except OSError:
+        except (OSError, UnicodeError):
             self.on_exception()
 
         try:
             interface_specifications.extend(socket.getaddrinfo(socket.gethostname(), None))
-        except OSError:
+        except (OSError, UnicodeError):
             self.on_exception()
 
         try:
             interface_specifications.extend(socket.getaddrinfo(None, 0))
-        except OSError:
+        except (OSError, UnicodeError):
             self.on_exception()
 
-        return {i[4][0] for i in interface_specifications if cast(str, i[4][0]).find(".") != -1}
+        return {i[4][0] for i in interface_specifications if cast("str", i[4][0]).find(".") != -1}


### PR DESCRIPTION
Related to upstream https://github.com/Tribler/tribler/issues/8686

This PR:

 - Fixes an uncaught `UnicodeError` being thrown when `socket.getaddrinfo()` is invoked. This is an unsolved bug in CPython.

It seems like we've developed some unfortunate `mypy` errors, since the last PR. Given the number of errors, I think that's best left to a separate PR.
