### PR TITLE
Prepare for Python 3.10 update

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
+          python-version: '3.10'
           cache: 'pip'
       - run: python -m pip install -r requirements.txt
       - uses: ./.github/actions/coverage
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
+          python-version: '3.10'
           cache: 'pip'
       - uses: actions/cache/restore@v4
         id: restore_cache

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -5,11 +5,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Setup Python 3.9
+      - name: Setup Python 3.10
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: "3.10"
+      - run: python -m pip install -r requirements.txt
       - name: Install mypy
         run: pip install mypy
       - name: Run mypy
-        run: mypy -p ipv8
+        run: mypy --install-types --non-interactive

--- a/.github/workflows/pr-comment-validate.yml
+++ b/.github/workflows/pr-comment-validate.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]  # macos-latest not tested due to crashing.
-        version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        version: ["3.10", "3.11", "3.12", "3.13"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -113,10 +113,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: refs/pull/${{ github.event.issue.number }}/head
-      - name: Setup Python 3.9
+      - name: Setup Python 3.10
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: 3.10
       - name: Install dependencies
         run: |
           pip install --upgrade setuptools pip
@@ -137,10 +137,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: refs/pull/${{ github.event.issue.number }}/head
-      - name: Setup Python 3.9
+      - name: Setup Python 3.10
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: 3.10
       - name: Install dependencies
         run: |
           pip install --upgrade setuptools pip

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -5,10 +5,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Setup Python 3.9
+      - name: Setup Python 3.10
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: "3.10"
       - name: Install ruff
         run: pip install ruff
       - name: Get changed Python files

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -7,7 +7,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
+          python-version: '3.10'
           cache: 'pip'
       - run: python -m pip install -r requirements.txt
       - name: Run unit tests
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
+          python-version: '3.10'
           cache: 'pip'
       - uses: actions/cache/restore@v4
         id: restore_cache

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -52,8 +52,7 @@ lint.ignore = [
     "TRY002",
     "TRY300",
     "TRY301",
-    "TRY401",
-    "UP006",  # Backward compatibility, remove after Python >= 3.9
+    "TRY401"
 ]
 
 exclude = [
@@ -88,7 +87,7 @@ line-length = 120
 # Allow unused variables when underscore-prefixed.
 lint.dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 
-target-version = "py39"
+target-version = "py310"
 
 [lint.pylint]
 max-args = 6

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,11 +1,17 @@
 [mypy]
-ignore_missing_imports = True
+packages = ipv8
+python_version = 3.10
 
-[mypy-ipv8_service]
-follow_imports = skip
-
-[mypy-ipv8.attestation.wallet.irmaexact.enroll_script]
-ignore_errors = True
+[mypy-ipv8.attestation.wallet.primitives.cryptography_wrapper]
+ignore_errors = true
 
 [mypy-ipv8.test.*]
-ignore_errors = True
+ignore_errors = true
+
+# Modules without typing
+
+[mypy-libnacl.*]
+ignore_missing_imports = true
+
+[mypy-aiohttp_apispec.*]
+ignore_missing_imports = true


### PR DESCRIPTION
Prepares for #1345

This PR:

 - Updates GitHub Actions builders to Python 3.10, dropping Python 3.9.
 - Updates the `ruff` configuration to Python 3.10.
 - Updates the `mypy` configuration to Python 3.10 and makes the `mypy` configuration stricter (to catch more errors).

`mypy` is expected to fail, until #1345 is merged.