### PR TITLE
Automated version increment

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -21,13 +21,13 @@
 # -- Project information -----------------------------------------------------
 
 project = "IPv8"
-copyright = "2017-2024, Tribler"  # Do not change manually! Handled by github_increment_version.py
+copyright = "2017-2025, Tribler"  # Do not change manually! Handled by github_increment_version.py
 author = "Tribler"
 
 # The short X.Y version
-version = "3.0"  # Do not change manually! Handled by github_increment_version.py
+version = "3.1"  # Do not change manually! Handled by github_increment_version.py
 # The full version, including alpha/beta/rc tags
-release = "3.0.0"  # Do not change manually! Handled by github_increment_version.py
+release = "3.1.0"  # Do not change manually! Handled by github_increment_version.py
 
 
 # -- General configuration ---------------------------------------------------

--- a/ipv8/REST/rest_manager.py
+++ b/ipv8/REST/rest_manager.py
@@ -117,7 +117,7 @@ class RESTManager:
         aiohttp_apispec = AiohttpApiSpec(
             app=self.root_endpoint.app,
             title="IPv8 REST API documentation",
-            version="v3.0",  # Do not change manually! Handled by github_increment_version.py
+            version="v3.1",  # Do not change manually! Handled by github_increment_version.py
             url="/docs/swagger.json",
             swagger_path="/docs",
         )

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     description="The Python implementation of the IPV8 library",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    version="3.0.0",  # Do not change manually! Handled by github_increment_version.py
+    version="3.1.0",  # Do not change manually! Handled by github_increment_version.py
     url="https://github.com/Tribler/py-ipv8",
     package_data={"": ["*.*"]},
     packages=find_packages(),


### PR DESCRIPTION
Title: Automated Version Update
Tag version: 3.1
Release title: IPv8 v3.1.2226 release
Body:
Includes the first 2226 commits (+29 since v3.0) for IPv8, containing:

 - Fixed circuit creation
 - Fixed compatibility with marshmallow 4.0.0
 - Fixed error when adding peers to the routing table
 - Fixed memory leak in GetIfAddrs
 - Fixed uncaught getaddrinfo UnicodeError
 - Removed TunnelEndpoint.loop
 - Updated CommunityLauncher to be a Generic
 - Updated TunnelEndpoint to test circuits in Rust
 - Updated minimum Python version to 3.10
 - Updated validate job Python version to be 3.10 instead of 3.1
 - Updated workflow action version
 - Upgrade code base to Python 3.10