### PR TITLE
Automated Version Update

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -21,13 +21,13 @@
 # -- Project information -----------------------------------------------------
 
 project = "IPv8"
-copyright = "2017-2025, Tribler"  # Do not change manually! Handled by github_increment_version.py
+copyright = "2017-2026, Tribler"  # Do not change manually! Handled by github_increment_version.py
 author = "Tribler"
 
 # The short X.Y version
-version = "3.1"  # Do not change manually! Handled by github_increment_version.py
+version = "3.2"  # Do not change manually! Handled by github_increment_version.py
 # The full version, including alpha/beta/rc tags
-release = "3.1.0"  # Do not change manually! Handled by github_increment_version.py
+release = "3.2.0"  # Do not change manually! Handled by github_increment_version.py
 
 
 # -- General configuration ---------------------------------------------------

--- a/ipv8/REST/rest_manager.py
+++ b/ipv8/REST/rest_manager.py
@@ -117,7 +117,7 @@ class RESTManager:
         aiohttp_apispec = AiohttpApiSpec(
             app=self.root_endpoint.app,
             title="IPv8 REST API documentation",
-            version="v3.1",  # Do not change manually! Handled by github_increment_version.py
+            version="v3.2",  # Do not change manually! Handled by github_increment_version.py
             url="/docs/swagger.json",
             swagger_path="/docs",
         )

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     description="The Python implementation of the IPV8 library",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    version="3.1.0",  # Do not change manually! Handled by github_increment_version.py
+    version="3.2.0",  # Do not change manually! Handled by github_increment_version.py
     url="https://github.com/Tribler/py-ipv8",
     package_data={"": ["*.*"]},
     packages=find_packages(),


### PR DESCRIPTION
Tag version: 3.2
Release title: IPv8 v3.2.2243 release
Body:
Includes the first 2243 commits (+17 since v3.1) for IPv8, containing:

 - Added deprecrated curves to prevent upstream removal
 - Added possible exits to extend candidates
 - Fixed Community.guess_address() to only return valid addresses
 - Fixed TestHiddenServices setting bad peer flags
 - Fixed for extending to the wrong candidate
 - Updated message identifier specification for dataclass
 - Updated UDPv6Endpoint to only allow IPv4
