### PR TITLE
Removed pyOpenSSL and pyasn1 from dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,8 +17,6 @@ setup(
     install_requires=[
         "aiohttp",
         "aiohttp_apispec",
-        "pyOpenSSL",
-        "pyasn1",
         "marshmallow",
         "typing-extensions",
         "packaging",


### PR DESCRIPTION
This PR:

 - Removes  unnecessary dependencies from install_requires.
 