### PR TITLE
Automated minor version increment

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -27,7 +27,7 @@ author = "Tribler"
 # The short X.Y version
 version = "3.2"  # Do not change manually! Handled by github_increment_version.py
 # The full version, including alpha/beta/rc tags
-release = "3.2.0"  # Do not change manually! Handled by github_increment_version.py
+release = "3.2.1"  # Do not change manually! Handled by github_increment_version.py
 
 
 # -- General configuration ---------------------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     description="The Python implementation of the IPV8 library",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    version="3.2.0",  # Do not change manually! Handled by github_increment_version.py
+    version="3.2.1",  # Do not change manually! Handled by github_increment_version.py
     url="https://github.com/Tribler/py-ipv8",
     package_data={"": ["*.*"]},
     packages=find_packages(),


### PR DESCRIPTION
Tag version: 3.2.1
Release title: IPv8 v3.2.2247 release
Body:
Includes the first 2247 commits (+4 since v3.2) for IPv8, containing:

 - Removed pyOpenSSL and pyasn1 from dependencies 
 - Updated rust module

