### PR TITLE
Fixed aiohttp compatibility

### DIFF
--- a/ipv8/test/REST/rest_base.py
+++ b/ipv8/test/REST/rest_base.py
@@ -103,6 +103,13 @@ class MockRequest(Request):
         """
         return self._transport
 
+    @property
+    def sockname(self) -> None:
+        """
+        Return an empty sockname.
+        """
+        return None
+
 
 async def response_to_bytes(response: Response) -> bytes:
     """


### PR DESCRIPTION
Fixes #1366

This PR:

 - Fixes `MockRequest` not implementing the `sockname` property, required by `aiohttp>=3.14.0`.
 
 This is only necessary for the unit tests. So, I don't think we need to do an emergency release for this.
